### PR TITLE
Convert sACN data from numpy array to python list

### DIFF
--- a/ledfx/devices/e131.py
+++ b/ledfx/devices/e131.py
@@ -184,7 +184,9 @@ class E131Device(Device):
             dmx_data = np.array(self._sacn[universe].dmx_data)
             dmx_data[dmx_start:dmx_end] = data[input_start:input_end]
 
-            self._sacn[universe].dmx_data = dmx_data.clip(0, 255)
+            # Because the sACN library checks for data to be of int type, we have to
+            # convert the numpy array into a python list of ints using tolist()
+            self._sacn[universe].dmx_data = dmx_data.clip(0, 255).tolist()
             # output = dmx_data.clip(0, 255)
 
         # This is ugly - weird race condition where loading on startup from a device with a short ID results in the sACN thread trying to send data to NoneType.


### PR DESCRIPTION
Converting sent sACN data from numpy "np.int64" array to python list to support newer versions of the sACN library, since it now requires all data sent to be of the normal python "int" type