### PR TITLE
Prevent default action of device add/edit form

### DIFF
--- a/frontend/src/components/DeviceConfigDialog/index.jsx
+++ b/frontend/src/components/DeviceConfigDialog/index.jsx
@@ -82,10 +82,11 @@ class DeviceConfigDialog extends React.Component {
         this.props.onClose();
     };
 
-    handleSubmit = () => {
+    handleSubmit = e => {
         const { initial, onAddDevice, onUpdateDevice } = this.props;
         const { deviceType, model: config } = this.state;
 
+        e.preventDefault();
         if (initial.id) {
             onUpdateDevice(initial.id, deviceType, config);
         } else {


### PR DESCRIPTION
Fixes issue where editing or adding a device would silently fail in Firefox.