### PR TITLE
Allow zeroconf dependency >= 0.30.0 since it fixed the windows bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@
     requests>=2.24.0
     pyyaml>=5.3.1
     aubio>=0.4.9
-    zeroconf<=0.28.8
+    zeroconf<=0.28.8||>=0.30.0
     cython==0.29.21
     pyupdater>=4.0.0
     sentry-sdk==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ INSTALL_REQUIRES = [
     "aubio>=0.4.9",
     # Zeroconf Bug introduced in 0.29
     # https://github.com/jstasiak/python-zeroconf/issues/337
-    "zeroconf<=0.28.8",
+    "zeroconf<=0.28.8||>=0.30.0",
     'pywin32>=300; platform_system == "Windows"',
     "cython>=0.29.21",
     "pyupdater>=4.0.0",


### PR DESCRIPTION
Allows to build ledfx on newer systems