### PR TITLE
Allow smaller gradient roll steps

### DIFF
--- a/ledfx/effects/gradient.py
+++ b/ledfx/effects/gradient.py
@@ -30,7 +30,7 @@ class GradientEffect(Effect):
                 "gradient_roll",
                 description="Amount to shift the gradient",
                 default=0,
-            ): vol.All(vol.Coerce(int), vol.Range(min=0, max=10)),
+            ): vol.All(vol.Coerce(float), vol.Range(min=0, max=10)),
             vol.Optional(
                 "gradient_repeat",
                 description="Repeat the gradient into segments",


### PR DESCRIPTION
Gradient Roll has always been too fast for me (minimum of 1 pixel per frame, so 60 pixels a second?!)
This PR uses a float to allow eg.
0.1 Gradient Roll = 1 pixel rolled every 10 frames