### PR TITLE
Fix gradient roll HSV crash, + new helper function + cleanup

### DIFF
--- a/ledfx/effects/blade_power_plus.py
+++ b/ledfx/effects/blade_power_plus.py
@@ -81,7 +81,7 @@ class BladePowerPlus(AudioReactiveEffect, HSVEffect, GradientEffect):
         rgb_gradient = self.apply_gradient(1)
         self.hsv = self.rgb_to_hsv(rgb_gradient)
 
-        if self.config["solid_color"] is True:
+        if self._config["solid_color"] is True:
             hsv_color = self.rgb_to_hsv(
                 np.array(COLORS[self._config["color"]])
             )
@@ -95,7 +95,7 @@ class BladePowerPlus(AudioReactiveEffect, HSVEffect, GradientEffect):
     def audio_data_updated(self, data):
         # Get filtered bar power
         self.bar = (
-            getattr(data, self.power_func)() * self.config["multiplier"] * 2
+            getattr(data, self.power_func)() * self._config["multiplier"] * 2
         )
 
     def render_hsv(self):
@@ -109,6 +109,6 @@ class BladePowerPlus(AudioReactiveEffect, HSVEffect, GradientEffect):
         # Construct hsv array
         self.out[:, 0] = self.hsv[:, 0]
         self.out[:, 1] = self.hsv[:, 1]
-        self.out[:bar_idx, 2] = self.config["brightness"]
+        self.out[:bar_idx, 2] = self._config["brightness"]
 
         self.hsv_array = self.out

--- a/ledfx/effects/hsv_effect.py
+++ b/ledfx/effects/hsv_effect.py
@@ -346,8 +346,8 @@ class HSVEffect(Effect):
             pixels_to_roll = np.floor(self._hsv_roll_counter)
             self._hsv_roll_counter -= pixels_to_roll
 
-            if "invert_roll" in self.config:
-                if self.config["invert_roll"]:
+            if "invert_roll" in self._config:
+                if self._config["invert_roll"]:
                     pixels_to_roll *= -1
 
             self.hsv = np.roll(


### PR DESCRIPTION
Now that `gradient_roll` accepts floats, fix a crash when setting it to a float on a hsv effect, and also create a hsv-effect wide helper function to nicely implement the improved rolling on all hsv effects.
Also means the blade power plus can be slightly cleaned up. (no more needing to divide numbers by 5, since setting gradient roll to 0.2 has the same effect as previously setting gradient roll to 1 on blade power plus)