### PR TITLE
Introduce packet builder functions for devices

### DIFF
--- a/ledfx/devices/adalight.py
+++ b/ledfx/devices/adalight.py
@@ -1,33 +1,24 @@
 import logging
 from enum import Enum
+from struct import pack
 
 import numpy as np
 import serial
 import serial.tools.list_ports
 import voluptuous as vol
 
-from ledfx.devices import Device
+from ledfx.devices import Device, packets
 
 _LOGGER = logging.getLogger(__name__)
 
-
-class ColorOrder(Enum):
-    RGB = 1
-    RBG = 2
-    GRB = 3
-    BRG = 4
-    GBR = 5
-    BGR = 6
-
-
-COLOR_ORDERS = {
-    "RGB": ColorOrder.RGB,
-    "RBG": ColorOrder.RBG,
-    "GRB": ColorOrder.GRB,
-    "BRG": ColorOrder.BRG,
-    "GBR": ColorOrder.GBR,
-    "BGR": ColorOrder.BGR,
-}
+COLOR_ORDERS = [
+    "RGB",
+    "RBG",
+    "GRB",
+    "BRG",
+    "GBR",
+    "BGR",
+]
 
 
 class AvailableCOMPorts:
@@ -64,7 +55,7 @@ class AdalightDevice(Device):
                 ): vol.All(vol.Coerce(int), vol.Range(min=1)),
                 vol.Required(
                     "color_order", description="Color order", default="RGB"
-                ): vol.In(list(COLOR_ORDERS.keys())),
+                ): vol.In(list(COLOR_ORDERS)),
             }
         )
 
@@ -73,27 +64,7 @@ class AdalightDevice(Device):
         self.serial = None
         self.baudrate = self._config["baudrate"]
         self.com_port = self._config["com_port"]
-        self.color_order = COLOR_ORDERS[self._config["color_order"]]
-
-        # adalight header
-        # Byte   Value
-        # 0     'A' (0x41)
-        # 1     'd' (0x64)
-        # 2     'a' (0x61)
-        # 3     pixel count, high byte
-        # 4     pixel count, low byte
-        # 5     Checksum (high byte XOR low byte XOR 0x55)
-
-        buffer_size = 6 + self.pixel_count * 3
-        self.buffer = bytearray(buffer_size)
-
-        self.buffer[0] = ord("A")
-        self.buffer[1] = ord("d")
-        self.buffer[2] = ord("a")
-        pixel_count_in_bytes = (self.pixel_count).to_bytes(2, byteorder="big")
-        self.buffer[3] = pixel_count_in_bytes[0]
-        self.buffer[4] = pixel_count_in_bytes[1]
-        self.buffer[5] = self.buffer[3] ^ self.buffer[4] ^ 0x55
+        self.color_order = self._config["color_order"]
 
     def activate(self):
         try:
@@ -117,41 +88,11 @@ class AdalightDevice(Device):
             self.serial.close()
 
     def flush(self, data):
-
-        byteData = data.astype(np.dtype("B"))
-
-        i = 3
-        for rgb in byteData:
-            i += 3
-            rgb_bytes = rgb.tobytes()
-            self.buffer[i], self.buffer[i + 1], self.buffer[i + 2] = (
-                rgb_bytes[0],
-                rgb_bytes[1],
-                rgb_bytes[2],
-            )
-
-            if self.color_order == ColorOrder.RGB:
-                continue
-            elif self.color_order == ColorOrder.GRB:
-                self.swap(self.buffer, i, i + 1)
-            elif self.color_order == ColorOrder.BGR:
-                self.swap(self.buffer, i, i + 2)
-            elif self.color_order == ColorOrder.RBG:
-                self.swap(self.buffer, i + 1, i + 2)
-            elif self.color_order == ColorOrder.BRG:
-                self.swap(self.buffer, i, i + 1)
-                self.swap(self.buffer, i + 1, i + 2)
-            elif self.color_order == ColorOrder.GBR:
-                self.swap(self.buffer, i, i + 1)
-                self.swap(self.buffer, i, i + 2)
         try:
-            self.serial.write(self.buffer)
+            self.serial.write(packets.build_adalight_packet(data, self.color_order))
 
         except serial.SerialException:
             _LOGGER.critical(
                 "Serial Connection Interrupted. Please check connections and ensure your device is functioning correctly."
             )
             self.deactivate()
-
-    def swap(self, array, pos1, pos2):
-        array[pos1], array[pos2] = array[pos2], array[pos1]

--- a/ledfx/devices/packets.py
+++ b/ledfx/devices/packets.py
@@ -1,0 +1,130 @@
+import numpy as np
+
+"""
+Generic WARLS packet encoding
+Max LEDs: 255
+
+Header: [1, timeout]
+Byte 	Description
+2 + n*4 	LED Index
+3 + n*4 	Red Value
+4 + n*4 	Green Value
+5 + n*4 	Blue Value
+"""
+def build_warls_packet(data: np.ndarray, timeout: int, last_frame: np.array):
+    packet = bytearray([1, (timeout or 1)])
+
+    byteData = data.astype(np.dtype("B"))
+
+    if last_frame is None or data.shape != last_frame.shape:
+        last_frame = np.full(data.shape ,np.nan)
+    '''
+    for i in range(len(byteData)): # loop through byteData
+        if not np.array_equal(last_bytes[i], byteData[i]): # if index has changed from last sent frame
+            packet.extend(bytes([i]))   # add index as first byte
+            packet.extend(byteData[i].flatten().tobytes())
+    ''' # do above in numpy
+    # get indexes of pixels that have changed
+    idx=np.flatnonzero(np.any(last_frame!=data, axis=1))
+    # make a new output array
+    out=np.zeros((len(idx), 4), dtype="B")
+    # first byte of each pixel is the index
+    out[:,0] = idx
+    # final three bytes are the pixel values
+    out[:,1:] = byteData[idx]
+    # convert out to bytes to send
+    packet.extend(out.flatten().tobytes())
+    return packet
+
+"""
+Generic DRGB packet encoding
+Max LEDs: 490
+
+Header: [2, timeout]
+Byte 	Description
+2 + n*3 	Red Value
+3 + n*3 	Green Value
+4 + n*3 	Blue Value
+
+"""
+def build_drgb_packet(data: np.ndarray, timeout: int):
+    packet = bytearray([2, (timeout or 1)])
+
+    byteData = data.astype(np.dtype("B"))
+    packet.extend(byteData.flatten().tobytes())
+    return packet
+
+'''
+Generic DRGBW packet encoding
+Max LEDs: 367
+
+Header: [3, timeout]
+Byte 	Description
+2 + n*3 	Red Value
+3 + n*3 	Green Value
+4 + n*3 	Blue Value
+5 + n*4 	White Value
+'''
+def build_drgbw_packet(data: np.ndarray, timeout: int):
+    packet = bytearray([3, (timeout or 1)])
+
+    byteData = data.astype(np.dtype("B"))
+    out = np.zeros((len(byteData), 4), dtype="B")
+    out[:,:3] = byteData
+    # 4th column is unusued white channel -> 0
+    packet.extend(out.flatten().tobytes())
+
+
+    # for i in range(len(byteData)):
+    #     packet.extend(byteData[i].flatten().tobytes())
+    #     packet.extend(bytes(0)) 
+    return packet
+
+
+"""
+Generic DNRGB packet encoding
+Max LEDs: 489 / packet
+
+Header: [4, timeout, start index high byte, start index low byte]
+Byte 	Description
+4 + n*3 	Red Value
+5 + n*3 	Green Value
+6 + n*3 	Blue Value
+"""
+def build_dnrgb_packet(data: np.ndarray, timeout: int, led_start_index: np.uint16):
+    packet = bytearray([4, (timeout or 1), (led_start_index >> 8),(led_start_index & 0x00ff)]) # high byte, then low byte
+
+    byteData = data.astype(np.dtype("B"))
+    packet.extend(byteData.flatten().tobytes())
+    return packet
+
+"""
+Generic Adalight serial packet encoding
+
+Header: [A, d, a, pixel count high byte, pixel count low byte, pixel count checksum]
+Byte 	Description
+4 + n*3 	Red Value
+5 + n*3 	Green Value
+6 + n*3 	Blue Value
+"""
+def build_adalight_packet(data: np.ndarray, color_order: str):
+    pixel_length = len(data)
+    packet = bytearray([ord("A"), ord("d"), ord("a"), (pixel_length >> 8),(pixel_length & 0x00ff)]) # high byte, then low byte
+    packet.extend([packet[3] ^ packet[4] ^ 0x55]) # checksum
+
+    byteData = data.astype(np.dtype("B"))
+    # if color_order == "RGB": pass
+    if color_order == "GRB":
+        byteData[:, [1, 0]] = byteData[:, [0, 1]] # swap columns
+    elif color_order == "BGR":
+        byteData[:, [2, 0]] = byteData[:, [0, 2]]
+    elif color_order == "RBG":
+        byteData[:, [2, 1]] = byteData[:, [1, 2]]
+    elif color_order == "BRG":
+        byteData[:, [2, 0]] = byteData[:, [0, 2]]
+        byteData[:, [2, 1]] = byteData[:, [1, 2]]
+    elif color_order == "GBR":
+        byteData[:, [2, 0]] = byteData[:, [0, 2]]
+        byteData[:, [1, 0]] = byteData[:, [0, 1]]
+    packet.extend(byteData.flatten().tobytes())
+    return packet

--- a/ledfx/devices/udp.py
+++ b/ledfx/devices/udp.py
@@ -4,10 +4,17 @@ import socket
 import numpy as np
 import voluptuous as vol
 
-from ledfx.devices import NetworkedDevice
+from ledfx.devices import NetworkedDevice, packets
 
 _LOGGER = logging.getLogger(__name__)
 
+SUPPORTED_PACKETS = [
+    "DRGB",
+    "WARLS",
+    "DRGBW",
+    "DNRGB",
+    "adaptive_smallest"
+]
 
 class UDPDevice(NetworkedDevice):
     """Generic UDP device support"""
@@ -27,19 +34,16 @@ class UDPDevice(NetworkedDevice):
                 description="Number of individual pixels",
                 default=1,
             ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            vol.Required(
+                "udp_packet_type",
+                description="RGB packet encoding",
+                default="DRGB",
+            ): vol.In(list(SUPPORTED_PACKETS)),
             vol.Optional(
-                "include_indexes",
-                description="Include the index for every LED",
-                default=False,
-            ): bool,
-            vol.Optional(
-                "data_prefix",
-                description="Data to be prepended in hex format. Use 0201 for WLED devices",
-            ): str,
-            vol.Optional(
-                "data_postfix",
-                description="Data to be appended in hex format",
-            ): str,
+                "timeout",
+                description="Seconds to wait after the last received packet to yield device control",
+                default=1,
+            ): vol.All(vol.Coerce(int), vol.Range(min=1, max=255)),
         }
     )
 
@@ -53,6 +57,8 @@ class UDPDevice(NetworkedDevice):
         _LOGGER.info(f"UDP sender for {self.config['name']} stopped.")
         self._sock = None
 
+    last_frame = None
+
     def flush(self, data):
         try:
             UDPDevice.send_out(
@@ -60,10 +66,11 @@ class UDPDevice(NetworkedDevice):
                 self.destination,
                 self._config["port"],
                 data,
-                self._config.get("data_prefix"),
-                self._config.get("data_postfix"),
-                self._config["include_indexes"],
+                self.last_frame,
+                self._config.get("udp_packet_type"),
+                self._config.get("timeout"),
             )
+            self.last_frame = np.copy(data)
         except AttributeError:
             self.activate()
 
@@ -73,39 +80,55 @@ class UDPDevice(NetworkedDevice):
         dest,
         port,
         data,
-        prefix=None,
-        postfix=None,
-        include_indexes=False,
+        last_frame,
+        udp_packet_type,
+        timeout=1,
     ):
-        udpData = bytearray()
-        byteData = data.astype(np.dtype("B"))
+        frame_size = len(data)
 
-        # Append the prefix if provided
-        if prefix:
-            try:
-                udpData.extend(bytes.fromhex(prefix))
+        if udp_packet_type == "DRGB" and frame_size <= 490:
+            udpData = packets.build_drgb_packet(data, timeout)
+            sock.sendto(bytes(udpData),(dest, port))
 
-            except ValueError:
-                _LOGGER.warning(f"Cannot convert prefix {prefix} to hex value")
+        elif udp_packet_type == "WARLS" and frame_size <= 255:
+            udpData = packets.build_warls_packet(data, timeout, last_frame)
+            sock.sendto(bytes(udpData),(dest, port))
 
-        # Append all of the pixel data
-        if include_indexes:
-            for i in range(len(byteData)):
-                udpData.extend(bytes([i]))
-                udpData.extend(byteData[i].flatten().tobytes())
+        elif udp_packet_type == "DRGBW" and frame_size <= 367:
+            udpData = packets.build_drgbw_packet(data, timeout)
+            sock.sendto(bytes(udpData),(dest, port))
+
+        elif udp_packet_type == "DNRGB":
+            number_of_packets = int(np.ceil(frame_size / 489))
+            for i in range(number_of_packets):
+                start_index = i * 489
+                end_index = start_index + 489
+                udpData = packets.build_dnrgb_packet(data[start_index:end_index], timeout, start_index)
+                sock.sendto(bytes(udpData),(dest, port))
+
+        elif udp_packet_type == "adaptive_smallest" and frame_size <= 255:
+            if last_frame is not None:
+                # compare potential size of WARLS packet to DRGB packet
+                if np.count_nonzero(np.any(data!=last_frame, axis=1)) * 4 < len(data) * 3:
+                    udpData = packets.build_warls_packet(data, timeout, last_frame)
+                    sock.sendto(bytes(udpData),(dest, port))
+                    return
+            udpData = packets.build_drgb_packet(data, timeout)
+            sock.sendto(bytes(udpData),(dest, port))
+
         else:
-            udpData.extend(byteData.flatten().tobytes())
+            _LOGGER.warning(
+                "UDP packet is configured incorrectly (check the pixel count vs the max size): https://kno.wled.ge/interfaces/udp-realtime/"
+            )
+            if frame_size <= 490: # DRGB
+                udpData = packets.build_drgb_packet(data, timeout)
+                sock.sendto(bytes(udpData),(dest, port))
+            else:   #DNRGB
+                number_of_packets = int(np.ceil(frame_size / 489))
+                for i in range(number_of_packets):
+                    start_index = i * 489
+                    end_index = start_index + 489
+                    udpData = packets.build_dnrgb_packet(data[start_index:end_index], timeout, start_index)
+                    sock.sendto(bytes(udpData),(dest, port))
 
-        # Append the postfix if provided
-        if postfix:
-            try:
-                udpData.extend(bytes.fromhex(postfix))
-            except ValueError:
-                _LOGGER.warning(
-                    f"Cannot convert postfix {postfix} to hex value"
-                )
 
-        sock.sendto(
-            bytes(udpData),
-            (dest, port),
-        )

--- a/ledfx/devices/wled.py
+++ b/ledfx/devices/wled.py
@@ -79,9 +79,6 @@ class WLEDDevice(NetworkedDevice):
         config["ip_address"] = self._config["ip_address"]
         config["pixel_count"] = self._config["pixel_count"]
 
-        if self._config["sync_mode"] == "UDP":
-            config["data_prefix"] = "02%02X" % self._config["timeout"]
-
         self.subdevice = device(self._ledfx, config)
         self.subdevice._destination = self._destination
 

--- a/ledfx/devices/wled.py
+++ b/ledfx/devices/wled.py
@@ -25,7 +25,7 @@ class WLEDDevice(NetworkedDevice):
                 "timeout",
                 description="Time between LedFx effect off and WLED effect activate",
                 default=1,
-            ): vol.All(vol.Coerce(int), vol.Range(0, 10)),
+            ): vol.All(vol.Coerce(int), vol.Range(0, 255)),
         }
     )
 
@@ -41,8 +41,7 @@ class WLEDDevice(NetworkedDevice):
             "ip_address": None,
             "pixel_count": None,
             "port": 21324,
-            "include_indexes": False,
-            "data_prefix": None,
+            "udp_packet_type": "DNRGB"
         },
         "DDP": {
             "name": None,


### PR DESCRIPTION
 `devices/packets.py` contains builder functions for WARLS, DRGB, DRGBW, DNRGB and Adalight (will add e1.31 and DDP soon™) 
UDP packets info here: https://kno.wled.ge/interfaces/udp-realtime/

All packet building should be faster because they've been converted to vectorised functions instead of the current for loops (thanks not_matt for your numpy help)
This also changes the UDP and WLED device schema, so I think new configs will be required?

This is also fixes the issue that you can't use more than 490 pixels using WLED UDP, as WLED UDP now defaults to DNRGB (which supports multi-packet updates)

Lastly, I have built `adaptive_smallest`, a udp option for strips smaller than 255 to calculate if a WARLS or DRGB packet will be smaller, per frame update, to reduce WIFI traffic. (though, there is still more logic to be built around WARLS, as atm it will happily send an empty packet. Logic needs to be added to not send empty packets unless it hasn't sent a packet for a time approaching the `timeout`)