### PR TITLE
Base UDPDevice and SerialDevice classes

### DIFF
--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -45,11 +45,11 @@ class Device(BaseRegistry):
                 vol.Required(
                     "name", description="Friendly name for the device"
                 ): str,
-                vol.Required(
-                    "pixel_count",
-                    description="Number of individual pixels",
-                    default=1,
-                ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+                # vol.Required(
+                #     "pixel_count",
+                #     description="Number of individual pixels",
+                #     default=1,
+                # ): vol.All(vol.Coerce(int), vol.Range(min=1)),
                 vol.Optional(
                     "icon_name",
                     description="https://material-ui.com/components/material-icons/",

--- a/ledfx/devices/adalight.py
+++ b/ledfx/devices/adalight.py
@@ -1,13 +1,9 @@
 import logging
-from enum import Enum
-from struct import pack
 
-import numpy as np
 import serial
-import serial.tools.list_ports
 import voluptuous as vol
 
-from ledfx.devices import Device, packets
+from ledfx.devices import SerialDevice, packets
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,16 +17,7 @@ COLOR_ORDERS = [
 ]
 
 
-class AvailableCOMPorts:
-    ports = serial.tools.list_ports.comports()
-
-    available_ports = []
-
-    for p in ports:
-        available_ports.append(p.device)
-
-
-class AdalightDevice(Device):
+class AdalightDevice(SerialDevice):
     """Adalight device support"""
 
     @staticmethod
@@ -39,21 +26,6 @@ class AdalightDevice(Device):
         return vol.Schema(
             {
                 vol.Required(
-                    "name", description="Friendly name for the device"
-                ): str,
-                vol.Required(
-                    "com_port",
-                    description="COM port for Adalight compatible device",
-                ): vol.In(list(AvailableCOMPorts.available_ports)),
-                vol.Required(
-                    "baudrate", description="baudrate", default=500000
-                ): vol.All(vol.Coerce(int), vol.Range(min=115200)),
-                vol.Required(
-                    "pixel_count",
-                    description="Number of individual pixels",
-                    default=1,
-                ): vol.All(vol.Coerce(int), vol.Range(min=1)),
-                vol.Required(
                     "color_order", description="Color order", default="RGB"
                 ): vol.In(list(COLOR_ORDERS)),
             }
@@ -61,31 +33,8 @@ class AdalightDevice(Device):
 
     def __init__(self, ledfx, config):
         super().__init__(ledfx, config)
-        self.serial = None
-        self.baudrate = self._config["baudrate"]
-        self.com_port = self._config["com_port"]
+        self._device_type = "Adalight"
         self.color_order = self._config["color_order"]
-
-    def activate(self):
-        try:
-            if self.serial and self.serial.isOpen:
-                return
-
-            self.serial = serial.Serial(self.com_port, self.baudrate)
-            if self.serial.isOpen:
-                super().activate()
-
-        except serial.SerialException:
-            _LOGGER.critical(
-                "Serial Error: Please ensure your device is connected, functioning and the correct COM port is selected."
-            )
-            # Todo: Trigger the UI to refresh after the clear effect call. Currently it still shows as active.
-            self.deactivate()
-
-    def deactivate(self):
-        super().deactivate()
-        if self.serial:
-            self.serial.close()
 
     def flush(self, data):
         try:

--- a/ledfx/devices/adalight.py
+++ b/ledfx/devices/adalight.py
@@ -26,6 +26,11 @@ class AdalightDevice(SerialDevice):
         return vol.Schema(
             {
                 vol.Required(
+                    "pixel_count",
+                    description="Number of individual pixels",
+                    default=1,
+                ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+                vol.Required(
                     "color_order", description="Color order", default="RGB"
                 ): vol.In(list(COLOR_ORDERS)),
             }

--- a/ledfx/devices/ddp.py
+++ b/ledfx/devices/ddp.py
@@ -35,6 +35,11 @@ class DDPDevice(UDPDevice):
     CONFIG_SCHEMA = vol.Schema(
         {
             vol.Required(
+                "pixel_count",
+                description="Number of individual pixels",
+                default=1,
+            ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            vol.Required(
                 "port",
                 description="Port for the UDP device",
                 default=4048,

--- a/ledfx/devices/ddp.py
+++ b/ledfx/devices/ddp.py
@@ -1,19 +1,18 @@
 import logging
-import socket
 import struct
 
 import numpy as np
 import voluptuous as vol
 
-from ledfx.devices import NetworkedDevice
+from ledfx.devices import UDPDevice
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class DDPDevice(NetworkedDevice):
+class DDPDevice(UDPDevice):
     """DDP device support"""
 
-    PORT = 4048
+    # PORT = 4048
     HEADER_LEN = 0x0A
     # DDP_ID_VIRTUAL     = 1
     # DDP_ID_CONFIG      = 250
@@ -36,41 +35,29 @@ class DDPDevice(NetworkedDevice):
     CONFIG_SCHEMA = vol.Schema(
         {
             vol.Required(
-                "name", description="Friendly name for the device"
-            ): str,
-            vol.Required(
-                "pixel_count",
-                description="Number of individual pixels",
-                default=1,
-            ): int,
+                "port",
+                description="Port for the UDP device",
+                default=4048,
+            ): vol.All(vol.Coerce(int), vol.Range(min=1, max=65535)),
         }
     )
 
     def __init__(self, ledfx, config):
-        self.frame_count = 0
         super().__init__(ledfx, config)
-
-    def activate(self):
-        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        _LOGGER.info(f"DDP sender for {self.config['name']} started.")
-        super().activate()
-
-    def deactivate(self):
-        _LOGGER.info(f"DDP sender for {self.config['name']} stopped.")
-        super().deactivate()
-        self._sock = None
+        self._device_type = "DDP"
+        self.frame_count = 0
 
     def flush(self, data):
         self.frame_count += 1
         try:
             DDPDevice.send_out(
-                self._sock, self.destination, data, self.frame_count
+                self._sock, self.destination, self._config["port"], data, self.frame_count
             )
         except AttributeError:
             self.activate()
 
     @staticmethod
-    def send_out(sock, dest, data, frame_count):
+    def send_out(sock, dest, port, data, frame_count):
         sequence = frame_count % 15 + 1
         byteData = data.astype(np.uint8).flatten().tobytes()
         packets, remainder = divmod(len(byteData), DDPDevice.MAX_DATALEN)
@@ -92,6 +79,7 @@ class DDPDevice(NetworkedDevice):
         DDPDevice.send_packet(
             sock,
             dest,
+            port,
             sequence,
             packets,
             remainder,
@@ -101,7 +89,7 @@ class DDPDevice(NetworkedDevice):
 
     @staticmethod
     def send_packet(
-        sock, dest, sequence, packet_count, data_len, data, push=False
+        sock, dest, port, sequence, packet_count, data_len, data, push=False
     ):
         udpData = bytearray()
         header = struct.pack(
@@ -119,5 +107,5 @@ class DDPDevice(NetworkedDevice):
 
         sock.sendto(
             bytes(udpData),
-            (dest, DDPDevice.PORT),
+            (dest, port),
         )

--- a/ledfx/devices/e131.py
+++ b/ledfx/devices/e131.py
@@ -14,6 +14,11 @@ class E131Device(NetworkedDevice):
 
     CONFIG_SCHEMA = vol.Schema(
         {
+            vol.Required(
+                "pixel_count",
+                description="Number of individual pixels",
+                default=1,
+            ): vol.All(vol.Coerce(int), vol.Range(min=1)),
             vol.Optional(
                 "universe",
                 description="DMX universe for the device",

--- a/ledfx/devices/e131.py
+++ b/ledfx/devices/e131.py
@@ -14,14 +14,6 @@ class E131Device(NetworkedDevice):
 
     CONFIG_SCHEMA = vol.Schema(
         {
-            vol.Required(
-                "name", description="Friendly name for the device"
-            ): str,
-            vol.Required(
-                "pixel_count",
-                description="Number of individual pixels",
-                default=1,
-            ): vol.All(vol.Coerce(int), vol.Range(min=1)),
             vol.Optional(
                 "universe",
                 description="DMX universe for the device",

--- a/ledfx/devices/open_pixel_control.py
+++ b/ledfx/devices/open_pixel_control.py
@@ -15,6 +15,11 @@ class OpenPixelControl(NetworkedDevice):
     CONFIG_SCHEMA = vol.Schema(
         {
             vol.Required(
+                "pixel_count",
+                description="Number of individual pixels",
+                default=1,
+            ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            vol.Required(
                 "channel",
                 description="Channel to send pixel data",
                 default=0,

--- a/ledfx/devices/open_pixel_control.py
+++ b/ledfx/devices/open_pixel_control.py
@@ -15,14 +15,6 @@ class OpenPixelControl(NetworkedDevice):
     CONFIG_SCHEMA = vol.Schema(
         {
             vol.Required(
-                "name", description="Friendly name for the device"
-            ): str,
-            vol.Required(
-                "pixel_count",
-                description="Number of individual pixels",
-                default=1,
-            ): vol.All(vol.Coerce(int), vol.Range(min=1)),
-            vol.Required(
                 "channel",
                 description="Channel to send pixel data",
                 default=0,

--- a/ledfx/devices/rpi_ws281x.py
+++ b/ledfx/devices/rpi_ws281x.py
@@ -37,6 +37,11 @@ class RPI_WS281X(Device):
         return vol.Schema(
             {
                 vol.Required(
+                    "pixel_count",
+                    description="Number of individual pixels",
+                    default=1,
+                ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+                vol.Required(
                     "gpio_pin",
                     description="Raspberry Pi GPIO pin your LEDs are connected to",
                 ): vol.In(list([21, 31])),

--- a/ledfx/devices/rpi_ws281x.py
+++ b/ledfx/devices/rpi_ws281x.py
@@ -37,17 +37,9 @@ class RPI_WS281X(Device):
         return vol.Schema(
             {
                 vol.Required(
-                    "name", description="Friendly name for the device"
-                ): str,
-                vol.Required(
                     "gpio_pin",
                     description="Raspberry Pi GPIO pin your LEDs are connected to",
                 ): vol.In(list([21, 31])),
-                vol.Required(
-                    "pixel_count",
-                    description="Number of individual pixels",
-                    default=1,
-                ): vol.All(vol.Coerce(int), vol.Range(min=1)),
                 vol.Required(
                     "color_order", description="Color order", default="RGB"
                 ): vol.In(list(COLOR_ORDERS.keys())),

--- a/ledfx/devices/udp.py
+++ b/ledfx/devices/udp.py
@@ -21,6 +21,11 @@ class UDPRealtimeDevice(UDPDevice):
     CONFIG_SCHEMA = vol.Schema(
         {
             vol.Required(
+                "pixel_count",
+                description="Number of individual pixels",
+                default=1,
+            ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            vol.Required(
                 "port",
                 description="Port for the UDP device",
                 default=21324,

--- a/ledfx/devices/wled.py
+++ b/ledfx/devices/wled.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from ledfx.devices import NetworkedDevice
 from ledfx.devices.ddp import DDPDevice
 from ledfx.devices.e131 import E131Device
-from ledfx.devices.udp import UDPDevice
+from ledfx.devices.udp import UDPRealtimeDevice
 from ledfx.utils import WLED
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ class WLEDDevice(NetworkedDevice):
     )
 
     SYNC_MODES = {
-        "UDP": UDPDevice,
+        "UDP": UDPRealtimeDevice,
         "DDP": DDPDevice,
         "E131": E131Device,
     }

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -634,6 +634,14 @@ class BaseRegistry(ABC):
         del cls._registry[name]
         return cls
 
+    # currently this permanently overwrites Device.CONFIG_SCHEMA instead of just for a wrapper device
+    # @classmethod
+    # def designate_wrapper_device(self, cls):
+    #     """Designate Wrapper device to ignore pixel_count in schema"""
+    #     # replace base Device classes schema with Wrapper devices schema
+    #     setattr(inspect.getmro(cls)[2], self._schema_attr, getattr_explicit(inspect.getmro(cls)[0], self._schema_attr, None))
+    #     return cls
+
     @classmethod
     def schema(self, extended=True, extra=vol.ALLOW_EXTRA):
         """Returns the extended schema of the class"""


### PR DESCRIPTION
Create base `UDPDevice` and `SerialDevice` that devices (like the WLED UDP Realtime, DDP, and Adalight) can inherent from. This should remove the amount of work/boilerplate that is required to add support for new devices.
(eg. if someone has a new serial device they want to add, they can inherent `SerialDevices` and all they need to write is `def flush()`

I have also moved the `name` and `pixel_count` schema attributes to the base `Device` class, since it should be a completely shared attribute.

I plan to create a base `TCPDevice` class as a foundation for TCP devices Soon™