### PR TITLE
option to not send unchanged frames

### DIFF
--- a/ledfx/devices/udp.py
+++ b/ledfx/devices/udp.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 import numpy as np
 import voluptuous as vol
@@ -40,6 +41,11 @@ class UDPRealtimeDevice(UDPDevice):
                 description="Seconds to wait after the last received packet to yield device control",
                 default=1,
             ): vol.All(vol.Coerce(int), vol.Range(min=1, max=255)),
+            vol.Optional(
+                "minimise_traffic",
+                description="Won't send updates if nothing has changed on the LED device",
+                default=True,
+            ): bool,
         }
     )
 
@@ -47,63 +53,51 @@ class UDPRealtimeDevice(UDPDevice):
         super().__init__(ledfx, config)
         self._device_type = "UDP Realtime"
         self.last_frame = None
+        self.last_frame_sent_time = 0
 
     def flush(self, data):
         try:
-            UDPRealtimeDevice.send_out(
-                self._sock,
-                self.destination,
-                self._config["port"],
-                data,
-                self.last_frame,
-                self._config.get("udp_packet_type"),
-                self._config.get("timeout"),
-            )
+            self.choose_and_send_packet(data, self._config["timeout"],)
             self.last_frame = np.copy(data)
         except AttributeError:
             self.activate()
 
-    @staticmethod
-    def send_out(
-        sock,
-        dest,
-        port,
+    def choose_and_send_packet(
+        self,
         data,
-        last_frame,
-        udp_packet_type,
-        timeout=1,
+        timeout,
     ):
         frame_size = len(data)
 
-        if udp_packet_type == "DRGB" and frame_size <= 490:
+        if self._config["udp_packet_type"] == "DRGB" and frame_size <= 490:
             udpData = packets.build_drgb_packet(data, timeout)
-            sock.sendto(bytes(udpData),(dest, port))
+            self.transmit_packet(udpData, np.array_equal(data, self.last_frame))
 
-        elif udp_packet_type == "WARLS" and frame_size <= 255:
-            udpData = packets.build_warls_packet(data, timeout, last_frame)
-            sock.sendto(bytes(udpData),(dest, port))
+        elif self._config["udp_packet_type"] == "WARLS" and frame_size <= 255:
+            udpData = packets.build_warls_packet(data, timeout, self.last_frame)
+            self.transmit_packet(udpData, np.array_equal(data, self.last_frame))
 
-        elif udp_packet_type == "DRGBW" and frame_size <= 367:
+        elif self._config["udp_packet_type"] == "DRGBW" and frame_size <= 367:
             udpData = packets.build_drgbw_packet(data, timeout)
-            sock.sendto(bytes(udpData),(dest, port))
+            self.transmit_packet(udpData, np.array_equal(data, self.last_frame))
 
-        elif udp_packet_type == "DNRGB":
+        elif self._config["udp_packet_type"] == "DNRGB":
             number_of_packets = int(np.ceil(frame_size / 489))
             for i in range(number_of_packets):
                 start_index = i * 489
                 end_index = start_index + 489
                 udpData = packets.build_dnrgb_packet(data[start_index:end_index], timeout, start_index)
-                sock.sendto(bytes(udpData),(dest, port))
+                self.transmit_packet(udpData, np.array_equal(data[start_index:end_index], self.last_frame[start_index:end_index]))
 
-        elif udp_packet_type == "adaptive_smallest" and frame_size <= 255:
-            if last_frame is not None:
+        elif self._config["udp_packet_type"] == "adaptive_smallest" and frame_size <= 255:
+            if self.last_frame is not None:
                 # compare potential size of WARLS packet to DRGB packet
-                if np.count_nonzero(np.any(data!=last_frame, axis=1)) * 4 < len(data) * 3:
-                    udpData = packets.build_warls_packet(data, timeout, last_frame)
-                    sock.sendto(bytes(udpData),(dest, port))
+                if np.count_nonzero(np.any(data!=self.last_frame, axis=1)) * 4 < len(data) * 3:
+                    udpData = packets.build_warls_packet(data, timeout, self.last_frame)
+                    self.transmit_packet(udpData, np.array_equal(data, self.last_frame))
                     return
             udpData = packets.build_drgb_packet(data, timeout)
-            sock.sendto(bytes(udpData),(dest, port))
+            self.transmit_packet(udpData, np.array_equal(data, self.last_frame))
 
         else:
             _LOGGER.warning(
@@ -111,13 +105,23 @@ class UDPRealtimeDevice(UDPDevice):
             )
             if frame_size <= 490: # DRGB
                 udpData = packets.build_drgb_packet(data, timeout)
-                sock.sendto(bytes(udpData),(dest, port))
+                self.transmit_packet(udpData, np.array_equal(data, self.last_frame))
             else:   #DNRGB
                 number_of_packets = int(np.ceil(frame_size / 489))
                 for i in range(number_of_packets):
                     start_index = i * 489
                     end_index = start_index + 489
                     udpData = packets.build_dnrgb_packet(data[start_index:end_index], timeout, start_index)
-                    sock.sendto(bytes(udpData),(dest, port))
+                    self.transmit_packet(udpData, np.array_equal(data[start_index:end_index], self.last_frame[start_index:end_index]))
 
 
+    def transmit_packet(self, packet, frame_is_equal_to_last: bool):
+        timestamp = time.time()
+        if self._config["minimise_traffic"] and frame_is_equal_to_last:
+            half_of_timeout = (((self._config["timeout"] * self._config["refresh_rate"]) - 1) // 2) / self._config["refresh_rate"]
+            if (timestamp > self.last_frame_sent_time + half_of_timeout):
+                self._sock.sendto(bytes(packet),(self.destination, self._config["port"]))
+                self.last_frame_sent_time = timestamp
+        else:
+            self._sock.sendto(bytes(packet),(self.destination, self._config["port"]))
+            self.last_frame_sent_time = timestamp


### PR DESCRIPTION
#### Part 2 of my drive to minimise unnecessary wifi traffic:

new `udp.py` config option: `minimise_traffic`
When selected, `UDPRealtimeDevices` will not send an update if a frame hasn't changed since last frame.
(it still sends a frame regardless of change every timeout/2 seconds to keep WLED connection/control active)