### PR TITLE
Openrgb device

### DIFF
--- a/ledfx/devices/openrgb.py
+++ b/ledfx/devices/openrgb.py
@@ -1,0 +1,93 @@
+import logging
+import socket
+
+import numpy as np
+import voluptuous as vol
+
+from ledfx.devices import NetworkedDevice, packets
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class OpenRGB(NetworkedDevice):
+    """OpenRGB protocol device support"""
+
+    @staticmethod
+    @property
+    def CONFIG_SCHEMA():
+        return vol.Schema(
+            {
+                vol.Required(
+                    "name", description="Friendly name for the device"
+                ): str,
+                vol.Required(
+                    "openrgb_name",
+                    description="Exact name of openRGB device (within openRGB).",
+                ): str,
+                vol.Required(
+                    "pixel_count",
+                    description="Number of individual pixels",
+                    default=1,
+                ): vol.All(int, vol.Range(min=1)),
+                vol.Required(
+                    "port",
+                    description="Port for the UDP device",
+                    default=6742,
+                ): vol.All(int, vol.Range(min=1, max=65535)),
+            }
+        )
+
+    def __init__(self, ledfx, config):
+        super().__init__(ledfx, config)
+        self.ip_address = self._config["ip_address"]
+        self.port = self._config["port"]
+        self.openrgb_device_name = self._config["openrgb_name"]
+
+    def activate(self):
+        try:
+            from openrgb import OpenRGBClient
+
+            self.openrgb_device = OpenRGBClient(
+                self.ip_address, self.port, "LedFx", 2  # protocol_version
+            ).get_devices_by_name(f"{self.openrgb_device_name}")[0]
+            # check for eedevice
+            device_supports_direct = False
+            for mode in self.openrgb_device.modes:
+                if mode.name.lower() == "direct":
+                    device_supports_direct = True
+            if not device_supports_direct:
+                raise ValueError()
+        except ImportError:
+            _LOGGER.critical("Unable to load openrgb library")
+            self.deactivate()
+        except IndexError:
+            _LOGGER.critical(
+                f"Couldn't find openRGB device named: {self.openrgb_device_name}"
+            )
+            self.deactivate()
+        except ValueError:
+            _LOGGER.critical(
+                f"{self.openrgb_device_name} doesn't support direct mode, and isn't suitable for streamed effects from LedFx"
+            )
+            self.deactivate()
+        else:
+            super().activate()
+
+    def deactivate(self):
+        super().deactivate()
+
+    def flush(self, data):
+        """Flush LED data to the strip"""
+        try:
+            OpenRGB.send_out(
+                self.openrgb_device.comms.sock,
+                data,
+                self.openrgb_device.id,
+            )
+        except AttributeError:
+            self.activate()
+
+    @staticmethod
+    def send_out(sock: socket.socket, data: np.ndarray, device_id: int):
+        packet = packets.build_openrgb_packet(data, device_id)
+        sock.send(packet)

--- a/ledfx/devices/packets.py
+++ b/ledfx/devices/packets.py
@@ -1,19 +1,20 @@
+import struct
+
 import numpy as np
-
-"""
-Generic WARLS packet encoding
-Max LEDs: 255
-
-Header: [1, timeout]
-Byte 	Description
-2 + n*4 	LED Index
-3 + n*4 	Red Value
-4 + n*4 	Green Value
-5 + n*4 	Blue Value
-"""
 
 
 def build_warls_packet(data: np.ndarray, timeout: int, last_frame: np.array):
+    """
+    Generic WARLS packet encoding
+    Max LEDs: 255
+
+    Header: [1, timeout]
+    Byte 	Description
+    2 + n*4 	LED Index
+    3 + n*4 	Red Value
+    4 + n*4 	Green Value
+    5 + n*4 	Blue Value
+    """
     packet = bytearray([1, (timeout or 1)])
 
     byteData = data.astype(np.dtype("B"))
@@ -39,20 +40,18 @@ def build_warls_packet(data: np.ndarray, timeout: int, last_frame: np.array):
     return packet
 
 
-"""
-Generic DRGB packet encoding
-Max LEDs: 490
-
-Header: [2, timeout]
-Byte 	Description
-2 + n*3 	Red Value
-3 + n*3 	Green Value
-4 + n*3 	Blue Value
-
-"""
-
-
 def build_drgb_packet(data: np.ndarray, timeout: int):
+    """
+    Generic DRGB packet encoding
+    Max LEDs: 490
+
+    Header: [2, timeout]
+    Byte 	Description
+    2 + n*3 	Red Value
+    3 + n*3 	Green Value
+    4 + n*3 	Blue Value
+
+    """
     packet = bytearray([2, (timeout or 1)])
 
     byteData = data.astype(np.dtype("B"))
@@ -60,20 +59,18 @@ def build_drgb_packet(data: np.ndarray, timeout: int):
     return packet
 
 
-"""
-Generic DRGBW packet encoding
-Max LEDs: 367
-
-Header: [3, timeout]
-Byte 	Description
-2 + n*3 	Red Value
-3 + n*3 	Green Value
-4 + n*3 	Blue Value
-5 + n*4 	White Value
-"""
-
-
 def build_drgbw_packet(data: np.ndarray, timeout: int):
+    """
+    Generic DRGBW packet encoding
+    Max LEDs: 367
+
+    Header: [3, timeout]
+    Byte 	Description
+    2 + n*3 	Red Value
+    3 + n*3 	Green Value
+    4 + n*3 	Blue Value
+    5 + n*4 	White Value
+    """
     packet = bytearray([3, (timeout or 1)])
 
     byteData = data.astype(np.dtype("B"))
@@ -88,21 +85,19 @@ def build_drgbw_packet(data: np.ndarray, timeout: int):
     return packet
 
 
-"""
-Generic DNRGB packet encoding
-Max LEDs: 489 / packet
-
-Header: [4, timeout, start index high byte, start index low byte]
-Byte 	Description
-4 + n*3 	Red Value
-5 + n*3 	Green Value
-6 + n*3 	Blue Value
-"""
-
-
 def build_dnrgb_packet(
     data: np.ndarray, timeout: int, led_start_index: np.uint16
 ):
+    """
+    Generic DNRGB packet encoding
+    Max LEDs: 489 / packet
+
+    Header: [4, timeout, start index high byte, start index low byte]
+    Byte 	Description
+    4 + n*3 	Red Value
+    5 + n*3 	Green Value
+    6 + n*3 	Blue Value
+    """
     packet = bytearray(
         [4, (timeout or 1), (led_start_index >> 8), (led_start_index & 0x00FF)]
     )  # high byte, then low byte
@@ -112,18 +107,16 @@ def build_dnrgb_packet(
     return packet
 
 
-"""
-Generic Adalight serial packet encoding
-
-Header: [A, d, a, pixel count high byte, pixel count low byte, pixel count checksum]
-Byte 	Description
-4 + n*3 	Red Value
-5 + n*3 	Green Value
-6 + n*3 	Blue Value
-"""
-
-
 def build_adalight_packet(data: np.ndarray, color_order: str):
+    """
+    Generic Adalight serial packet encoding
+
+    Header: [A, d, a, pixel count high byte, pixel count low byte, pixel count checksum]
+    Byte 	Description
+    4 + n*3 	Red Value
+    5 + n*3 	Green Value
+    6 + n*3 	Blue Value
+    """
     pixel_length = len(data)
     packet = bytearray(
         [
@@ -151,4 +144,42 @@ def build_adalight_packet(data: np.ndarray, color_order: str):
         byteData[:, [2, 0]] = byteData[:, [0, 2]]
         byteData[:, [1, 0]] = byteData[:, [0, 1]]
     packet.extend(byteData.flatten().tobytes())
+    return packet
+
+
+def build_openrgb_packet(
+    data: np.ndarray,
+    device_id: int,
+):
+    """
+    openRGB packet encoding
+
+    Header: [O,R,G,B, openrgb device_id, RGBCONTROLLER_UPDATELEDS command (1050), total packet bytes length, length of payload, number of pixels]
+    Byte 	Description
+    23 + n*4 	Red Value
+    24 + n*4 	Green Value
+    25 + n*4 	Blue Value
+    26 + n*4 	White Value
+    """
+    frame_size = len(data)
+
+    # header
+    packet = bytearray(
+        # fmt: off
+        struct.pack(
+            "ccccIIIIH",
+            b"O", b"R", b"G", b"B",
+            device_id,
+            1050,  # RGBCONTROLLER_UPDATELEDS packet
+            struct.calcsize(f"IH{3*frame_size}b{frame_size}x"),   # total packet length
+            (frame_size * 4 + 2),  # body length
+            frame_size,  # number of pixels
+        )
+        # fmt: on
+    )
+
+    # body
+    out = np.zeros((frame_size, 4), dtype="B")
+    out[:, 0:3] = data.astype(np.dtype("B"))
+    packet.extend(out.flatten().tobytes())
     return packet

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@
     mido>=1.2.10
     multidict~=5.0.0
     numpy~=1.20.2
+    openrgb-python~=0.2.10
     paho-mqtt~=1.5.1
     psutil>=5.8.0
     pyserial~=3.5

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ INSTALL_REQUIRES = [
     "certifi>=2020.12.5",
     "mido>=1.2.10",
     "multidict~=5.0.0",
+    "openrgb-python~=0.2.10",
     "paho-mqtt>=1.5.1",
     "psutil>=5.8.0",
     "pyserial>=3.5",


### PR DESCRIPTION
I don't have any RGB peripherals so only tested using below config into `WLED`:
```json
    "LEDStripDevices": {
        "devices": [
            {
                "port": "/dev/ttyUSB0",
                "baud": 115200,
                "num_leds": 21,
                "protocol": "adalight"
            }
        ]
    }
```
Code checks to confirm the selected device supports 'direct' mode, which is suitable for high fps streaming.
Code uses `openrgb-python` from pypi, but uses my own implementation to build the RGB packet.

PR means LedFx now supports:
https://gitlab.com/CalcProgrammer1/OpenRGB/-/wikis/Supported-Devices