### PR TITLE
New gradient option to increase gradient roll speed based on magnitude of beats

### DIFF
--- a/ledfx/effects/bands.py
+++ b/ledfx/effects/bands.py
@@ -38,11 +38,12 @@ class BandsAudioEffect(AudioReactiveEffect, GradientEffect):
         self.r = np.zeros(pixel_count)
 
     def config_updated(self, config):
-        self.bkg_color = np.array((0,0,0), dtype=float)
+        self.bkg_color = np.array((0, 0, 0), dtype=float)
 
     def audio_data_updated(self, data):
         # Grab the filtered melbank
         self.r = self.melbank(filtered=True, size=self.pixel_count)
+        super().gradient_magnitude_beat_power(data)
 
     def render(self):
         out = np.tile(self.r, (3, 1)).T

--- a/ledfx/effects/bands_matrix.py
+++ b/ledfx/effects/bands_matrix.py
@@ -39,12 +39,13 @@ class BandsMatrixAudioEffect(AudioReactiveEffect, GradientEffect):
 
     def config_updated(self, config):
         # Create the filters used for the effect
-        self.bkg_color = np.array((0,0,0), dtype=float)
+        self.bkg_color = np.array((0, 0, 0), dtype=float)
         self.flip_gradient = config["flip_gradient"]
 
     def audio_data_updated(self, data):
         # Grab the filtered melbank
         self.r = self.melbank(filtered=True, size=self.pixel_count)
+        super().gradient_magnitude_beat_power(data)
 
     def render(self):
         out = np.tile(self.r, (3, 1)).T

--- a/ledfx/effects/bar.py
+++ b/ledfx/effects/bar.py
@@ -55,6 +55,7 @@ class BarAudioEffect(AudioReactiveEffect, GradientEffect):
                 # 8 colours, 4 beats to a bar
                 self.color_idx += self._config["color_step"]
                 self.color_idx = self.color_idx % 1  # loop back to zero
+        super().gradient_magnitude_beat_power(data)
 
     def render(self):
         if self._config["ease_method"] == "ease_in_out":

--- a/ledfx/effects/blocks.py
+++ b/ledfx/effects/blocks.py
@@ -26,6 +26,7 @@ class BlocksAudioEffect(AudioReactiveEffect, GradientEffect):
     def audio_data_updated(self, data):
         # Grab the filtered melbank
         self.r = self.melbank(filtered=True, size=self.pixel_count)
+        super().gradient_magnitude_beat_power(data)
 
     def render(self):
         out = np.tile(self.r, (3, 1))

--- a/ledfx/effects/equalizer.py
+++ b/ledfx/effects/equalizer.py
@@ -43,6 +43,7 @@ class EQAudioEffect(AudioReactiveEffect, GradientEffect):
         # Grab the filtered melbank
         self.r = self.melbank(filtered=True, size=self.pixel_count)
         np.clip(self.r, 0, 1, out=self.r)
+        super().gradient_magnitude_beat_power(data)
 
     def render(self):
         r_split = np.array_split(self.r, self._config["gradient_repeat"])

--- a/ledfx/effects/magnitude.py
+++ b/ledfx/effects/magnitude.py
@@ -35,6 +35,7 @@ class MagnitudeAudioEffect(AudioReactiveEffect, GradientEffect):
 
     def audio_data_updated(self, data):
         self.magnitude = getattr(data, self.power_func)()
+        super().gradient_magnitude_beat_power(data)
 
     def render(self):
         # Grab the filtered and interpolated melbank data

--- a/ledfx/effects/multiBar.py
+++ b/ledfx/effects/multiBar.py
@@ -55,6 +55,7 @@ class MultiBarAudioEffect(AudioReactiveEffect, GradientEffect):
             # 8 colours, 4 beats to a bar
             self.color_idx += self._config["color_step"]
             self.color_idx = self.color_idx % 1  # loop back to zero
+        super().gradient_magnitude_beat_power(data)
 
     def render(self):
         # Run linear beat oscillator through easing method

--- a/ledfx/effects/pitchSpectrum.py
+++ b/ledfx/effects/pitchSpectrum.py
@@ -45,7 +45,7 @@ class PitchSpectrumAudioEffect(AudioReactiveEffect, GradientEffect):
         midi_value = data.pitch()
         if midi_value is None:
             midi_value = 0
-        note_color = RGB(0,0,0)
+        note_color = RGB(0, 0, 0)
         if not self.avg_midi:
             self.avg_midi = midi_value
 
@@ -55,6 +55,7 @@ class PitchSpectrumAudioEffect(AudioReactiveEffect, GradientEffect):
                 self.avg_midi * (1.0 - self._config["responsiveness"])
                 + midi_value * self._config["responsiveness"]
             )
+        super().gradient_magnitude_beat_power(data)
 
         # Grab the note color based on where it falls in the midi range
         if self.avg_midi >= MIN_MIDI:
@@ -71,7 +72,7 @@ class PitchSpectrumAudioEffect(AudioReactiveEffect, GradientEffect):
             #
             new_color = mix_colors(self.pixels[index], note_color, y[index])
             new_color = mix_colors(
-                new_color, RGB(0,0,0), self._config["fade_rate"]
+                new_color, RGB(0, 0, 0), self._config["fade_rate"]
             )
             new_pixels[index] = new_color
 

--- a/ledfx/effects/power.py
+++ b/ledfx/effects/power.py
@@ -41,7 +41,7 @@ class PowerAudioEffect(AudioReactiveEffect, GradientEffect):
         self._bass_filter = self.create_filter(
             alpha_decay=0.1, alpha_rise=0.99
         )
-        self.sparks_color = np.array((0,0,0), dtype=float)
+        self.sparks_color = np.array((0, 0, 0), dtype=float)
 
     def audio_data_updated(self, data):
         # Get onset data
@@ -60,6 +60,7 @@ class PowerAudioEffect(AudioReactiveEffect, GradientEffect):
         # Map it to the length of the strip and apply it
         bass_idx = int(bass * self.pixel_count)
         self.out[:bass_idx] = color
+        super().gradient_magnitude_beat_power(data)
 
     def render(self):
         if self._config["sparks"]:

--- a/ledfx/effects/real_strobe.py
+++ b/ledfx/effects/real_strobe.py
@@ -4,7 +4,7 @@ import time
 import numpy as np
 import voluptuous as vol
 
-from ledfx.color import parse_color, validate_color, GRADIENTS
+from ledfx.color import GRADIENTS, parse_color, validate_color
 from ledfx.effects.audio import AudioReactiveEffect
 from ledfx.effects.gradient import GradientEffect
 from ledfx.utils import empty_queue
@@ -140,3 +140,4 @@ class Strobe(AudioReactiveEffect, GradientEffect):
         ):
             self.onsets_queue.put(True)
             self.last_strobe_time = currentTime
+        super().gradient_magnitude_beat_power(data)

--- a/ledfx/effects/strobe.py
+++ b/ledfx/effects/strobe.py
@@ -1,7 +1,7 @@
 import numpy as np
 import voluptuous as vol
 
-from ledfx.color import parse_color, validate_color, GRADIENTS
+from ledfx.color import GRADIENTS, parse_color, validate_color
 from ledfx.effects.audio import AudioReactiveEffect
 from ledfx.effects.gradient import GradientEffect
 
@@ -75,6 +75,7 @@ class Strobe(AudioReactiveEffect, GradientEffect):
         self.brightness = (
             ((-o % (1 / self.freq)) * self.freq) ** self.strobe_decay
         ) * (1 - o) ** self.beat_decay
+        super().gradient_magnitude_beat_power(data)
 
     def render(self):
         self.output[:] = (

--- a/ledfx/effects/wavelength.py
+++ b/ledfx/effects/wavelength.py
@@ -28,6 +28,7 @@ class WavelengthAudioEffect(AudioReactiveEffect, GradientEffect):
     def audio_data_updated(self, data):
         # Grab the filtered melbank
         self.r = self.melbank(filtered=True, size=self.pixel_count)
+        super().gradient_magnitude_beat_power(data)
 
     def render(self):
         # Apply the melbank data to the gradient curve and update the pixels


### PR DESCRIPTION
Simple idea I've had in my head after seeing Melt
Currently adds the beat speed option to fade effect as well, though that's not an audio effect, so that needs fixing

Had to re-add COLORS to gradient.py because precommit was yelling at me