### PR TITLE
Add OpenRGB devices by ID

### DIFF
--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -530,13 +530,13 @@ class Devices(RegistryLoader):
                             _LOGGER.info(msg)
                             raise ValueError(msg)
                     elif device_type == "openrgb":
-                        # check the OpenRGB id for OpenRGB device, it might still be okay at a shared ip_address
+                        # check the OpenRGB ID for OpenRGB device, it might still be okay at a shared ip_address
                         # eg. for multi OpenRGB devices
                         if (
                             device_config["openrgb_id"]
                             == existing_device.config["openrgb_id"]
                         ):
-                            msg = f"Ignoring {device_ip}: Shares IP and openrgb name with existing device {existing_device.name}"
+                            msg = f"Ignoring {device_ip}: Shares IP and OpenRGB ID with existing device {existing_device.name}"
                             _LOGGER.info(msg)
                             raise ValueError(msg)
                     else:

--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -530,11 +530,11 @@ class Devices(RegistryLoader):
                             _LOGGER.info(msg)
                             raise ValueError(msg)
                     elif device_type == "openrgb":
-                        # check the openrgb name for OpenRGB device, it might still be okay at a shared ip_address
+                        # check the OpenRGB id for OpenRGB device, it might still be okay at a shared ip_address
                         # eg. for multi OpenRGB devices
                         if (
-                            device_config["openrgb_name"]
-                            == existing_device.config["openrgb_name"]
+                            device_config["openrgb_id"]
+                            == existing_device.config["openrgb_id"]
                         ):
                             msg = f"Ignoring {device_ip}: Shares IP and openrgb name with existing device {existing_device.name}"
                             _LOGGER.info(msg)

--- a/ledfx/devices/openrgb.py
+++ b/ledfx/devices/openrgb.py
@@ -23,7 +23,7 @@ class OpenRGB(NetworkedDevice):
                 ): str,
                 vol.Required(
                     "openrgb_id",
-                    description="ID of openRGB device (within openRGB).",
+                    description="ID of OpenRGB device (within OpenRGB).",
                     default=0,
                 ): vol.All(int, vol.Range(min=0)),
                 vol.Required(
@@ -76,7 +76,7 @@ class OpenRGB(NetworkedDevice):
             self.deactivate()
         except IndexError:
             _LOGGER.critical(
-                f"Couldn't find openRGB device ID: {self.openrgb_device_id}"
+                f"Couldn't find OpenRGB device ID: {self.openrgb_device_id}"
             )
             self._online = False
             self.deactivate()


### PR DESCRIPTION
Fix issue about having multiple devices with same name like RAM stick 
ref https://discord.com/channels/469985374052286474/785654321055531078/944763746503499828

Device ID is list of the devices in OpenRGB interface 
![Screenshot 2022-02-21 110854](https://user-images.githubusercontent.com/47688491/154871172-8d68f422-233f-42bb-a813-6d34b67cc8a1.png)

or it can be get from openrgb-python module

```py
import openrgb
from openrgb import OpenRGBClient

client = OpenRGBClient('localhost', 6742)

print(client)

print(client.devices)
```

