### PR TITLE
Fix gradient roll

### DIFF
--- a/ledfx/effects/gradient.py
+++ b/ledfx/effects/gradient.py
@@ -138,7 +138,7 @@ class GradientEffect(Effect):
             self._gradient_curve = np.roll(
                 self._gradient_curve,
                 int(pixels_to_roll),
-                axis=0,
+                axis=1,
             )
 
     def get_gradient_color(self, point):


### PR DESCRIPTION
Shifting axis=0 makes it look more like a strobe, axis=1 produces expected result