### PR TITLE
Issue 233 divide by zero on transitions

### DIFF
--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -267,17 +267,22 @@ class Virtual:
             _LOGGER.warning(error)
             raise ValueError(error)
 
-        self.transition_frame_total = (
-            self.refresh_rate * self._config["transition_time"]
-        )
-        self.transition_frame_counter = 0
+        if (
+            self._config["transition_mode"] != "None"
+            and self._config["transition_time"] > 0
+        ):
+            self.transition_frame_total = (
+                    self.refresh_rate * self._config["transition_time"]
+            )
+            self.transition_frame_counter = 0
 
-        if self._active_effect is None:
-            self._transition_effect = DummyEffect(self.pixel_count)
-
+            if self._active_effect is None:
+                self._transition_effect = DummyEffect(self.pixel_count)
+            else:
+                self.clear_transition_effect()
+                self._transition_effect = self._active_effect
         else:
             self.clear_transition_effect()
-            self._transition_effect = self._active_effect
 
         self._active_effect = effect
         self._active_effect.activate(self)
@@ -395,8 +400,6 @@ class Virtual:
             self._transition_effect is not None
             and self._transition_effect.is_active
             and hasattr(self._transition_effect, "pixels")
-            and self._config["transition_mode"] != "None"
-            and self._config["transition_time"] > 0
         ):
             # Get and process transition effect frame
             self._transition_effect.render()


### PR DESCRIPTION
Should address https://github.com/LedFx/LedFx/issues/233

Two issues

Transitions are created for a transition with zero time, but the mechanism to clear transitions is protected from zero transition time in the config

Don't create a transition when it should be immeadiate

Secondly don't test the config during transition processing, only at transition creation

Otherwise, transitions can be left orphened as the config can change async from the active transition