### PR TITLE
235 audio render crash

### DIFF
--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -1,5 +1,6 @@
 import colorsys
 import logging
+import threading
 
 # from ledfx.effects.audio import FREQUENCY_RANGES
 from functools import lru_cache
@@ -235,6 +236,7 @@ class Effect(BaseRegistry):
         self._ledfx = ledfx
         self._config = {}
         self.update_config(config)
+        self.lock = threading.Lock()
 
     def __del__(self):
         if self._active:
@@ -307,6 +309,11 @@ class Effect(BaseRegistry):
         should just be referenced in the effect's loop directly
         """
         pass
+
+    def _render(self):
+        self.lock.acquire()
+        self.render()
+        self.lock.release()
 
     def render(self):
         """

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -758,7 +758,9 @@ class AudioReactiveEffect(Effect):
     def _audio_data_updated(self):
         self.melbank.cache_clear()
         if self.is_active:
+            self.lock.acquire()
             self.audio_data_updated(self.audio)
+            self.lock.release()
 
     def audio_data_updated(self, data):
         """

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -267,17 +267,22 @@ class Virtual:
             _LOGGER.warning(error)
             raise ValueError(error)
 
-        self.transition_frame_total = (
-            self.refresh_rate * self._config["transition_time"]
-        )
-        self.transition_frame_counter = 0
+        if (
+            self._config["transition_mode"] != "None"
+            and self._config["transition_time"] > 0
+        ):
+            self.transition_frame_total = (
+                    self.refresh_rate * self._config["transition_time"]
+            )
+            self.transition_frame_counter = 0
 
-        if self._active_effect is None:
-            self._transition_effect = DummyEffect(self.pixel_count)
-
+            if self._active_effect is None:
+                self._transition_effect = DummyEffect(self.pixel_count)
+            else:
+                self.clear_transition_effect()
+                self._transition_effect = self._active_effect
         else:
             self.clear_transition_effect()
-            self._transition_effect = self._active_effect
 
         self._active_effect = effect
         self._active_effect.activate(self)
@@ -395,8 +400,6 @@ class Virtual:
             self._transition_effect is not None
             and self._transition_effect.is_active
             and hasattr(self._transition_effect, "pixels")
-            and self._config["transition_mode"] != "None"
-            and self._config["transition_time"] > 0
         ):
             # Get and process transition effect frame
             self._transition_effect.render()

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -384,7 +384,7 @@ class Virtual:
         Assembles the frame to be flushed.
         """
         # Get and process active effect frame
-        self._active_effect.render()
+        self._active_effect._render()
         frame = self._active_effect.get_pixels()
         if frame is None:
             return


### PR DESCRIPTION
See https://github.com/LedFx/LedFx/issues/235

rain effect has concurrent access risk of the render data from two seperate threads  Calls into numpy np.flatnonzero(self.drop_frames) does an integrity check on the data and will panic if the data is changed between enter and exit 

`Traceback
Exception in thread Thread-3 (thread_function):
Traceback (most recent call last):
File "C:\Users\atod\AppData\Local\Programs\Python\Python310\lib\threading.py", line 1009, in _bootstrap_inner
self.run()
File "C:\Users\atod\AppData\Local\Programs\Python\Python310\lib\threading.py", line 946, in run
self._target(*self._args, **self._kwargs)
File "C:\Users\atod\PycharmProjects\LedFxbrf\ledfx\virtuals.py", line 367, in thread_function
self.assembled_frame = self.assemble_frame()
File "C:\Users\atod\PycharmProjects\LedFxbrf\ledfx\virtuals.py", line 387, in assemble_frame
self._active_effect.render()
File "C:\Users\atod\PycharmProjects\LedFxbrf\ledfx\effects\rain.py", line 104, in render
drop_indices = np.flatnonzero(self.drop_frames)
File "<array_function internals>", line 180, in flatnonzero
File "C:\Users\atod\PycharmProjects\LedFxbrf\venv\lib\site-packages\numpy\core\numeric.py", line 669, in flatnonzero
return np.nonzero(np.ravel(a))[0]
File "<array_function internals>", line 180, in nonzero
File "C:\Users\atod\PycharmProjects\LedFxbrf\venv\lib\site-packages\numpy\core\fromnumeric.py", line 1958, in nonzero
return _wrapfunc(a, 'nonzero')
File "C:\Users\atod\PycharmProjects\LedFxbrf\venv\lib\site-packages\numpy\core\fromnumeric.py", line 57, in _wrapfunc
return bound(*args, **kwds)
RuntimeError: number of non-zero array elements changed during function execution.`

Such concurrency can cause other unexpected side effects, even if not trapped by numpy  

Therefore the two paths should run an threading lock, this is substantiated in the base class of effect(...)  Then calls into the child implementations of render and audio_data_update use the lock to protect code execution that may update or use the render data structs, understanding that this may not be specific to the rain effect  

It is worth noting that a pre existing naming convention of _audio_data_updated calls into audio_data_updated, I would expect the _ to be the internal private function, but in this case it is the publicly called. I have followed this pre existing naming convention for wrapping render with _render, where it did not otherwise have wrapping code 

This fix in various versions has run for hours without failure, prior MTBF was ~15 min for rain, sometime much quicker, as it is purely chance.

It should be noted this branch carries the fixes for transitions which have not yet been merged, was not sure how to easily exclude those from this second pull request