### PR TITLE
Aggressive frame flush crash on multiple device startup

### DIFF
--- a/ledfx/devices/wled.py
+++ b/ledfx/devices/wled.py
@@ -44,7 +44,9 @@ class WLEDDevice(NetworkedDevice):
         super().__init__(ledfx, config)
         self.subdevice = None
 
-        self.DEVICE_CONFIGS = {
+        # moved DEVICE_CONFIGS class var to device_configs instance var as it is manipulated in seperate instances
+        # see https://github.com/LedFx/LedFx/pull/237
+        self.device_configs = {
             "UDP": {
                 "name": None,
                 "ip_address": None,
@@ -81,7 +83,7 @@ class WLEDDevice(NetworkedDevice):
             self.subdevice.deactivate()
 
         device = self.SYNC_MODES[self._config["sync_mode"]]
-        config = self.DEVICE_CONFIGS[self._config["sync_mode"]]
+        config = self.device_configs[self._config["sync_mode"]]
         config["name"] = self._config["name"]
         config["ip_address"] = self._config["ip_address"]
         config["pixel_count"] = self._config["pixel_count"]

--- a/ledfx/devices/wled.py
+++ b/ledfx/devices/wled.py
@@ -18,7 +18,6 @@ class WLEDDevice(NetworkedDevice):
     This class fetches its config (px count, etc) from the WLED device
     at launch, and lets the user choose a sync mode to use.
     """
-
     CONFIG_SCHEMA = vol.Schema(
         {
             vol.Optional(
@@ -40,35 +39,35 @@ class WLEDDevice(NetworkedDevice):
         "E131": E131Device,
     }
 
-    DEVICE_CONFIGS = {
-        "UDP": {
-            "name": None,
-            "ip_address": None,
-            "pixel_count": None,
-            "port": 21324,
-            "udp_packet_type": "DNRGB",
-            "timeout": 1,
-            "minimise_traffic": True,
-        },
-        "DDP": {
-            "name": None,
-            "ip_address": None,
-            "pixel_count": None,
-        },
-        "E131": {
-            "name": None,
-            "ip_address": None,
-            "pixel_count": None,
-            "universe": 1,
-            "universe_size": 510,
-            "channel_offset": 0,
-            "packet_priority": 100,
-        },
-    }
-
     def __init__(self, ledfx, config):
         super().__init__(ledfx, config)
         self.subdevice = None
+
+        self.DEVICE_CONFIGS = {
+            "UDP": {
+                "name": None,
+                "ip_address": None,
+                "pixel_count": None,
+                "port": 21324,
+                "udp_packet_type": "DNRGB",
+                "timeout": 1,
+                "minimise_traffic": True,
+            },
+            "DDP": {
+                "name": None,
+                "ip_address": None,
+                "pixel_count": None,
+            },
+            "E131": {
+                "name": None,
+                "ip_address": None,
+                "pixel_count": None,
+                "universe": 1,
+                "universe_size": 510,
+                "channel_offset": 0,
+                "packet_priority": 100,
+            },
+        }
 
     def config_updated(self, config):
         if not isinstance(

--- a/ledfx/devices/wled.py
+++ b/ledfx/devices/wled.py
@@ -18,7 +18,7 @@ class WLEDDevice(NetworkedDevice):
     This class fetches its config (px count, etc) from the WLED device
     at launch, and lets the user choose a sync mode to use.
     """
-    
+
     CONFIG_SCHEMA = vol.Schema(
         {
             vol.Optional(

--- a/ledfx/devices/wled.py
+++ b/ledfx/devices/wled.py
@@ -18,6 +18,7 @@ class WLEDDevice(NetworkedDevice):
     This class fetches its config (px count, etc) from the WLED device
     at launch, and lets the user choose a sync mode to use.
     """
+    
     CONFIG_SCHEMA = vol.Schema(
         {
             vol.Optional(


### PR DESCRIPTION
Seeing crashes on startup with multiple WLED controllers, now running 4 x athom and 1 x pixel stick

Stack trace below, which is a trap to check that the pixel render frame is the same size as the subdevice

https://github.com/LedFx/LedFx/blob/main/ledfx/devices/e131.py#L122
`
        if data.size != self._config["channel_count"]:`

However, could reproduce what looked like one device using the config of another.

This was actually due to code in setup_subdevice which is a reference, not a copy to the class level single instance variable DEVICE_CONFIGS

https://github.com/LedFx/LedFx/blob/main/ledfx/devices/wled.py#L43

as later code makes changes to the content of config,

https://github.com/LedFx/LedFx/blob/main/ledfx/devices/wled.py#L84
`
config = self.DEVICE_CONFIGS[self._config["sync_mode"]]`

 its a shared structure across all instances of the class, and therefore each registered device can damage others. I don't know how this worked at all once I was running devices with different frame sizes.

The simplest fix is to move DEVICE_CONFIGS into the __init__ method, so it is a seperate variable every time. Otherwise a deepcopy could be used. Will leave that to review comments.

Other two structures at class level are effectively constants. Maybe it was the original coders intent that DEVICE_CONFIGS be a constant as well, but handling by reference causes the problem. Not sure if we should change the naming to device_configs as it is not a constant now.

```
Exception in thread Thread-6 (thread_function):
Traceback (most recent call last):
  File "C:\Users\atod\AppData\Local\Programs\Python\Python310\lib\threading.py", line 1009, in _bootstrap_inner
[INFO    ] ledfx.config                   : Saving configuration file to C:\Users\atod\AppData\Roaming.ledfx
    self.run()
  File "C:\Users\atod\AppData\Local\Programs\Python\Python310\lib\threading.py", line 946, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\atod\PycharmProjects\LedFxbrf\ledfx\virtuals.py", line 374, in thread_function
    self.flush()
  File "C:\Users\atod\PycharmProjects\LedFxbrf\ledfx\virtuals.py", line 531, in flush
    device.update_pixels(self.id, data)
  File "C:\Users\atod\PycharmProjects\LedFxbrf\ledfx\devices__init__.py", line 143, in update_pixels
    self.flush(frame)
  File "C:\Users\atod\PycharmProjects\LedFxbrf\ledfx\devices\wled.py", line 106, in flush
    self.subdevice.flush(data)
  File "C:\Users\atod\PycharmProjects\LedFxbrf\ledfx\devices\e131.py", line 123, in flush
    raise Exception(
Exception: Invalid buffer size. 1536 != 1518
```