### PR TITLE
Add empty _render method to prevent crash on effect deactivate.

### DIFF
--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -24,6 +24,9 @@ class DummyEffect:
     def __init__(self, pixel_count):
         self.pixels = np.zeros((pixel_count, 3))
 
+    def _render(self):
+        pass
+
     def render(self):
         pass
 


### PR DESCRIPTION
Caused by rework to defend data from concurrent manipulation when _render was introduced