### PR TITLE
Harden config load for mutated device

### DIFF
--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -749,9 +749,18 @@ class Virtuals:
                 ledfx=self._ledfx,
             )
             if "segments" in virtual:
-                self._ledfx.virtuals.get(virtual["id"]).update_segments(
-                    virtual["segments"]
-                )
+                try:
+                    self._ledfx.virtuals.get(virtual["id"]).update_segments(
+                        virtual["segments"]
+                    )
+                except vol.MultipleInvalid:
+                    _LOGGER.warning(
+                        "Virtual Segment Changed. Not restoring segment"
+                    )
+                    continue
+                except RuntimeError:
+                    pass
+
             if "effect" in virtual:
                 try:
                     effect = self._ledfx.effects.create(


### PR DESCRIPTION
If physicals such as led count has changed on a virtual config, then skip it rather than excepting

Application will still launch and good configs will run, bad configs will refuse to launch effects with an existing front end warning. Delete device and rediscover to fix the config
Segments in span / copy virtuals will also get cleared if larger than physical device Prior behaviour was to just crash out, so you would have to hand repair your config if you reduced number of leds on a device This could be more graceful and auto repair, but its an 80 / 20 I would live with "delete the bad device via the UX"

[ERROR   ] ledfx.virtuals                 : Invalid segment pixels: (0, 49). Device 'WLED5' valid pixels between (0, -1)
[WARNING ] ledfx.virtuals                 : Virtual Segment Changed. Not restoring segment