### PR TITLE
Last effect unsubscribe does not stop audio

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -33,6 +33,7 @@ class AudioInputSource:
     _processed_audio_sample = None
     _volume = -90
     _volume_filter = ExpFilter(-90, alpha_decay=0.99, alpha_rise=0.99)
+    _subscriber_threshold = 0
 
     @staticmethod
     def device_index_validator(val):
@@ -301,7 +302,7 @@ class AudioInputSource:
         """Registers a callback with the input source"""
         self._callbacks.append(callback)
 
-        if len(self._callbacks) == 1:
+        if len(self._callbacks) > 0 and not self._is_activated:
             self.activate()
 
     def unsubscribe(self, callback):
@@ -309,7 +310,7 @@ class AudioInputSource:
         if callback in self._callbacks:
             self._callbacks.remove(callback)
 
-        if len(self._callbacks) == 0:
+        if len(self._callbacks) <= self._subscriber_threshold:
             self.deactivate()
 
     def get_device_index_by_name(self, device_name: str):
@@ -454,6 +455,9 @@ class AudioAnalysisSource(AudioInputSource):
         self.subscribe(self.bar_oscillator)
         self.subscribe(self.volume_beat_now)
         self.subscribe(self.freq_power)
+
+        # ensure any new analysis callbacks are above this line
+        self._subscriber_threshold = len(self._callbacks)
 
     def initialise_analysis(self):
         # melbanks

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -749,9 +749,18 @@ class Virtuals:
                 ledfx=self._ledfx,
             )
             if "segments" in virtual:
-                self._ledfx.virtuals.get(virtual["id"]).update_segments(
-                    virtual["segments"]
-                )
+                try:
+                    self._ledfx.virtuals.get(virtual["id"]).update_segments(
+                        virtual["segments"]
+                    )
+                except vol.MultipleInvalid:
+                    _LOGGER.warning(
+                        "Virtual Segment Changed. Not restoring segment"
+                    )
+                    continue
+                except RuntimeError:
+                    pass
+
             if "effect" in virtual:
                 try:
                     effect = self._ledfx.effects.create(


### PR DESCRIPTION
Looking at the way that the class audioInputSource behaves, it looks like on adding an effect for the first time, we get 6 audioAnalysis callbacks added into self._callbacks AND a callback for the effect itself AudioReactiveEffect
Therefore when an effect is shut down, it only kills its own AudioReactiveEffect callback and count never gets below six
This check for should I shut down audio will therefore never fire

https://github.com/LedFx/LedFx/blob/main/ledfx/effects/audio.py#L312