### PR TITLE
Cludgy attack on the changing sleep resolution

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -16,6 +16,7 @@ from ledfx.effects import Effect
 from ledfx.effects.math import ExpFilter
 from ledfx.effects.melbank import FFT_SIZE, MIC_RATE, Melbanks
 from ledfx.events import AudioDeviceChangeEvent, Event
+from ledfx.utils import does_sleep_lie
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -289,6 +290,8 @@ class AudioInputSource:
         except sd.PortAudioError as e:
             _LOGGER.error(f"{e}, Reverting to default input device")
             open_audio_stream(default_device)
+
+        does_sleep_lie()
 
     def deactivate(self):
         if self._stream:

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -29,6 +29,7 @@ _LOGGER = logging.getLogger(__name__)
 
 sleep_lies = True
 
+
 def does_sleep_lie():
     global sleep_lies
     monotonic_res = time.get_clock_info("monotonic").resolution
@@ -87,6 +88,7 @@ def fps_to_sleep_interval(fps):
         min_clock = 0.001
     _LOGGER.warning(f"MIN clock is {min_clock}")
     return max(min_clock, monotonic_res * (monotonic_ticks - 1))
+
 
 def install_package(package):
     _LOGGER.debug(f"Installed package: {package}")

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -6,6 +6,7 @@ from functools import cached_property
 import numpy as np
 import voluptuous as vol
 import zeroconf
+import timeit
 
 from ledfx.effects import DummyEffect
 from ledfx.effects.math import interpolate_pixels
@@ -353,7 +354,14 @@ class Virtual:
         return self._active_effect
 
     def thread_function(self):
+        self.passed = 0.0
+        self.sleep_time = 0.0
+        self.postsleep = 0.0
+        self.presleep = 0.0
+
         while True:
+            self.start = timeit.default_timer()
+            _LOGGER.warning(f"presleep {self.presleep:.04f} postsleep:{self.postsleep:.04f} sleep for: {self.sleep_time:.04f} passed: {self.passed}")
             if not self._active:
                 break
             if (
@@ -377,7 +385,14 @@ class Virtual:
                         VirtualUpdateEvent(self.id, self.assembled_frame)
                     )
 
-            time.sleep(fps_to_sleep_interval(self.refresh_rate))
+            self.passed = timeit.default_timer() - self.start
+            self.sleep_time = fps_to_sleep_interval(self.refresh_rate)
+            self.presleep = timeit.default_timer()-self.start
+            time.sleep(self.sleep_time)
+            self.postsleep = timeit.default_timer()-self.start
+
+
+
 
     def assemble_frame(self):
         """

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -1,12 +1,12 @@
 import logging
 import threading
 import time
+import timeit
 from functools import cached_property
 
 import numpy as np
 import voluptuous as vol
 import zeroconf
-import timeit
 
 from ledfx.effects import DummyEffect
 from ledfx.effects.math import interpolate_pixels
@@ -361,7 +361,9 @@ class Virtual:
 
         while True:
             self.start = timeit.default_timer()
-            _LOGGER.warning(f"presleep {self.presleep:.04f} postsleep:{self.postsleep:.04f} sleep for: {self.sleep_time:.04f} passed: {self.passed}")
+            _LOGGER.warning(
+                f"presleep {self.presleep:.04f} postsleep:{self.postsleep:.04f} sleep for: {self.sleep_time:.04f} passed: {self.passed}"
+            )
             if not self._active:
                 break
             if (
@@ -387,12 +389,9 @@ class Virtual:
 
             self.passed = timeit.default_timer() - self.start
             self.sleep_time = fps_to_sleep_interval(self.refresh_rate)
-            self.presleep = timeit.default_timer()-self.start
+            self.presleep = timeit.default_timer() - self.start
             time.sleep(self.sleep_time)
-            self.postsleep = timeit.default_timer()-self.start
-
-
-
+            self.postsleep = timeit.default_timer() - self.start
 
     def assemble_frame(self):
         """


### PR DESCRIPTION
Modfiy the min sleep time to frame time for unexpected high resolution sleep cases

All debug left in for now under -vv warning level

Foul global, needs rework as singlton or other

An example of what could be done