### PR TITLE
Fix crazy frame rates on switching to some audio sources

### DIFF
--- a/ledfx/effects/temporal.py
+++ b/ledfx/effects/temporal.py
@@ -9,7 +9,11 @@ import voluptuous as vol
 from ledfx.effects import Effect
 
 _LOGGER = logging.getLogger(__name__)
-DEFAULT_RATE = 1.0 / 300.0
+
+# use 10 frames per second as default rate at 1x multiplier
+# windows will cap at 64Hz max for now, others at 100Hz with speed slider ot 10
+# rework when we go to 3.11
+DEFAULT_RATE = 1.0 / 10.0
 
 
 @Effect.no_registration
@@ -45,8 +49,9 @@ class TemporalEffect(Effect):
             timeToSleep = (sleepInterval / self._config["speed"]) - (
                 time.time() - startTime
             )
-            if timeToSleep > 0:
-                time.sleep(timeToSleep)
+            if timeToSleep < 0.001:
+                timeToSleep = 0.001
+            time.sleep(timeToSleep)
 
     def effect_loop(self):
         """

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -6,6 +6,7 @@ from functools import cached_property
 import numpy as np
 import voluptuous as vol
 import zeroconf
+import timeit
 
 from ledfx.effects import DummyEffect
 from ledfx.effects.math import interpolate_pixels
@@ -356,6 +357,7 @@ class Virtual:
         while True:
             if not self._active:
                 break
+            start_time = timeit.default_timer()
             if (
                 self._active_effect
                 and self._active_effect.is_active
@@ -378,6 +380,12 @@ class Virtual:
                     )
 
             time.sleep(fps_to_sleep_interval(self.refresh_rate))
+            pass_time = timeit.default_timer() - start_time
+            min_time = time.get_clock_info("monotonic").resolution
+            # use an aggressive check for did we sleep against implied min
+            # for all otherwise working behaviours this will be passive
+            if pass_time < ( min_time / 2 ):
+                time.sleep(min_time - pass_time)
 
     def assemble_frame(self):
         """

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -1,12 +1,12 @@
 import logging
 import threading
 import time
+import timeit
 from functools import cached_property
 
 import numpy as np
 import voluptuous as vol
 import zeroconf
-import timeit
 
 from ledfx.effects import DummyEffect
 from ledfx.effects.math import interpolate_pixels
@@ -384,7 +384,7 @@ class Virtual:
             min_time = time.get_clock_info("monotonic").resolution
             # use an aggressive check for did we sleep against implied min
             # for all otherwise working behaviours this will be passive
-            if pass_time < ( min_time / 2 ):
+            if pass_time < (min_time / 2):
                 time.sleep(min_time - pass_time)
 
     def assemble_frame(self):


### PR DESCRIPTION
Add an extra sleep trap on reactive threading loop when sleep is higher resolution than expected

Due to some audio sources under the covers changing the behaviour of sleep, the monotonic resolution is not the actual sleep resolution

Trap when we don't sleep enough compared to the implied minimum resolution by a gross margin, and then impose an extra sleep to make up to ~monotonic resolution single quantum

In scenarios where there is a high resolution monotonic, then frame sleeps will be multiples of monotonic resolution so code will remain passive