### PR TITLE
Remove dependence on time.sleep for effect updates

### DIFF
--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -28,7 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def calc_available_fps():
-    monotonic_res = time.get_clock_info("monotonic").resolution
+    monotonic_res = time.get_clock_info("perf_counter").resolution
 
     if monotonic_res < 0.001:
         mult = int(0.001 / monotonic_res)
@@ -49,17 +49,6 @@ def calc_available_fps():
 
 
 AVAILABLE_FPS = calc_available_fps()
-
-
-@lru_cache(maxsize=32)
-def fps_to_sleep_interval(fps):
-    monotonic_res = time.get_clock_info("monotonic").resolution
-    monotonic_ticks = next(
-        (t for f, t in AVAILABLE_FPS.items() if f >= fps),
-        list(AVAILABLE_FPS.values())[-1],
-    )
-    return max(0.001, monotonic_res * (monotonic_ticks - 1))
-
 
 def install_package(package):
     _LOGGER.debug(f"Installed package: {package}")

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -50,6 +50,7 @@ def calc_available_fps():
 
 AVAILABLE_FPS = calc_available_fps()
 
+
 def install_package(package):
     _LOGGER.debug(f"Installed package: {package}")
     env = os.environ.copy()

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -31,6 +31,7 @@ from ledfx.transitions import Transitions
 _LOGGER = logging.getLogger(__name__)
 NANOSECONDS = 1000000000
 
+
 class Virtual:
 
     CONFIG_SCHEMA = vol.Schema(
@@ -356,7 +357,9 @@ class Virtual:
         while True:
             if not self._active:
                 break
-            can_update = time.monotonic_ns() >= last_updated + (1 / self.refresh_rate * NANOSECONDS)
+            can_update = time.monotonic_ns() >= last_updated + (
+                1 / self.refresh_rate * NANOSECONDS
+            )
             if (
                 self._active_effect
                 and self._active_effect.is_active


### PR DESCRIPTION
This fixes an issue where unreliable behavior of time.sleep() causes the refresh rate of effects to misbehave when a Direct Sound audio device is in use. Removing time.sleep() and instead using time.monotonic_ns() to calculate whether or not to update should solve the problem regardless of the device in use.