### PR TITLE
3.11 proposed changes for sleep time against perf_counter

### DIFF
--- a/ledfx/__main__.py
+++ b/ledfx/__main__.py
@@ -384,6 +384,8 @@ def main():
 def entry_point(icon=None):
     # have to re-parse args here :/ no way to pass them through pysicon's setup
     args = parse_args()
+    # remove prior to merge
+    _LOGGER.warning(f"sys.version:{sys.version}")
 
     exit_code = 4
     while exit_code == 4:

--- a/ledfx/effects/rainbow.py
+++ b/ledfx/effects/rainbow.py
@@ -2,7 +2,9 @@ import voluptuous as vol
 
 from ledfx.effects import fill_rainbow
 from ledfx.effects.temporal import TemporalEffect
+import logging
 
+_LOGGER = logging.getLogger(__name__)
 
 class RainbowEffect(TemporalEffect):
 
@@ -22,6 +24,8 @@ class RainbowEffect(TemporalEffect):
     _hue = 0.1
 
     def effect_loop(self):
+        _LOGGER.warning("IN RAINBOW")
+
         hue_delta = self._config["frequency"] / self.pixel_count
         self.pixels = fill_rainbow(self.pixels, self._hue, hue_delta)
 

--- a/ledfx/effects/temporal.py
+++ b/ledfx/effects/temporal.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import timeit
 
 # from ledfx.effects.audio import AudioReactiveEffect
 from threading import Thread
@@ -11,8 +12,8 @@ from ledfx.effects import Effect
 _LOGGER = logging.getLogger(__name__)
 
 # use 10 frames per second as default rate at 1x multiplier
-# windows will cap at 64Hz max for now, others at 100Hz with speed slider ot 10
-# rework when we go to 3.11
+# max effective cap is 100 fps due to speed slider multiplier
+
 DEFAULT_RATE = 1.0 / 10.0
 
 
@@ -32,7 +33,8 @@ class TemporalEffect(Effect):
     )
 
     def thread_function(self):
-
+        # this is temp debug to be removed before merge
+        _LOGGER.warning(f"spawning: {self.name}")
         while self._thread_active:
             startTime = time.time()
 
@@ -52,6 +54,9 @@ class TemporalEffect(Effect):
             if timeToSleep < 0.001:
                 timeToSleep = 0.001
             time.sleep(timeToSleep)
+
+            # this is temp debug to be removed before merge
+            _LOGGER.warning(f"Temporal frame time:{(time.time() - startTime):.04f}")
 
     def effect_loop(self):
         """

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -380,11 +380,13 @@ class Virtual:
                     )
 
             pass_time = timeit.default_timer() - start_time
-            time.sleep(fps_to_sleep_interval(self.refresh_rate) - pass_time)
+            sleep_time = fps_to_sleep_interval(self.refresh_rate) - pass_time
+            if sleep_time > 0:
+                time.sleep(sleep_time)
 
             # following is temp debug and will be removed prior to commit
             wake_time = timeit.default_timer() - start_time
-            _LOGGER.warning(f"pass:{pass_time:.04f} frame:{fps_to_sleep_interval(self.refresh_rate):.04f} wake:{wake_time:.04f}")
+            _LOGGER.warning(f"pass:{pass_time:.04f} frame:{fps_to_sleep_interval(self.refresh_rate):.04f} sleep:{sleep_time:.04f} wake:{wake_time:.04f}")
             # end temp debug
 
     def assemble_frame(self):

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -386,7 +386,9 @@ class Virtual:
 
             # following is temp debug and will be removed prior to commit
             wake_time = timeit.default_timer() - start_time
-            _LOGGER.warning(f"pass:{pass_time:.04f} frame:{fps_to_sleep_interval(self.refresh_rate):.04f} sleep:{sleep_time:.04f} wake:{wake_time:.04f}")
+            _LOGGER.warning(
+                f"pass:{pass_time:.04f} frame:{fps_to_sleep_interval(self.refresh_rate):.04f} sleep:{sleep_time:.04f} wake:{wake_time:.04f}"
+            )
             # end temp debug
 
     def assemble_frame(self):

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -379,13 +379,13 @@ class Virtual:
                         VirtualUpdateEvent(self.id, self.assembled_frame)
                     )
 
-            time.sleep(fps_to_sleep_interval(self.refresh_rate))
             pass_time = timeit.default_timer() - start_time
-            min_time = time.get_clock_info("monotonic").resolution
-            # use an aggressive check for did we sleep against implied min
-            # for all otherwise working behaviours this will be passive
-            if pass_time < (min_time / 2):
-                time.sleep(min_time - pass_time)
+            time.sleep(fps_to_sleep_interval(self.refresh_rate) - pass_time)
+
+            # following is temp debug and will be removed prior to commit
+            wake_time = timeit.default_timer() - start_time
+            _LOGGER.warning(f"pass:{pass_time:.04f} frame:{fps_to_sleep_interval(self.refresh_rate):.04f} wake:{wake_time:.04f}")
+            # end temp debug
 
     def assemble_frame(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@
     certifi~=2020.12.5
     mido>=1.2.10
     multidict~=5.0.0
-    numpy~=1.20.2
+    numpy~=1.23.5
     openrgb-python~=0.2.10
     paho-mqtt~=1.5.1
     psutil>=5.8.0
@@ -26,5 +26,5 @@
     sounddevice~=0.4.2
     tcp-latency~=0.0.10
     voluptuous~=0.12.1
-    yappi~=1.3.3
+    yappi~=1.4.0
     zeroconf==0.30.0


### PR DESCRIPTION
Will be forced to DRAFT until 3.11 is a thing

Fix for https://github.com/LedFx/LedFx/issues/257

all references to monotonic in codebase moved to perf_counter Still investigating double calls to temporal effects, may be normal, or may be issue. May effect reactive as well. TBC

Aggressive debug will be removed before moving out of draft

runtime checked with temp sanity debug in __main__.py, to be removed
[WARNING ] __main__                       : sys.version:3.11.0 (main, Oct 24 2022, 18:26:48) [MSC v.1933 64 bit (AMD64)]

Following is observation with final fix in place, showing why we can't do this in 3.10

Bad 3.10 bad behaviour, note double 3.10 wake time of approx 2x 0.015625

[WARNING ] ledfx.virtuals                 : pass:0.0008 frame:0.0150 wake:0.0307
[WARNING ] ledfx.virtuals                 : pass:0.0008 frame:0.0150 wake:0.0309
[WARNING ] ledfx.virtuals                 : pass:0.0016 frame:0.0150 wake:0.0297
[WARNING ] ledfx.virtuals                 : pass:0.0017 frame:0.0150 wake:0.0306

Good 3.10 good behaviour with wake time a 1 to 2 milliseconds after requested

[WARNING ] ledfx.virtuals                 : pass:0.0019 frame:0.0150 wake:0.0168
[WARNING ] ledfx.virtuals                 : pass:0.0011 frame:0.0150 wake:0.0158
[WARNING ] ledfx.virtuals                 : pass:0.0009 frame:0.0150 wake:0.0160
[WARNING ] ledfx.virtuals                 : pass:0.0009 frame:0.0150 wake:0.0167

Even better 3.11 behaviour with wake time 0.1 ms after requested! Same for all audio sources With dependancy on monotonic time source for sleep removed in 3.11

[WARNING ] ledfx.virtuals                 : pass:0.0008 frame:0.0150 wake:0.0156
[WARNING ] ledfx.virtuals                 : pass:0.0007 frame:0.0150 wake:0.0156
[WARNING ] ledfx.virtuals                 : pass:0.0009 frame:0.0150 wake:0.0156
[WARNING ] ledfx.virtuals                 : pass:0.0008 frame:0.0150 wake:0.0156

recommend temporals be moved to animation based on time passed rather than call rate in future efforts