### PR TITLE
Fix double threads on temporal

### DIFF
--- a/ledfx/effects/fade.py
+++ b/ledfx/effects/fade.py
@@ -27,6 +27,9 @@ class FadeEffect(TemporalEffect, GradientEffect):
         self.idx = 0
         self.forward = True
 
+    def on_activate(self, pixel_count):
+        pass
+
     def effect_loop(self):
         self.idx += 0.0015
         if self.idx > 1:

--- a/ledfx/effects/gradient.py
+++ b/ledfx/effects/gradient.py
@@ -169,6 +169,9 @@ class TemporalGradientEffect(TemporalEffect, GradientEffect, ModulateEffect):
     NAME = "Gradient"
     CATEGORY = "Non-Reactive"
 
+    def on_activate(self, pixel_count):
+        pass
+
     def effect_loop(self):
         # TODO: Could add some cool effects like twinkle or sin modulation
         # of the gradient.

--- a/ledfx/effects/rainbow.py
+++ b/ledfx/effects/rainbow.py
@@ -21,6 +21,9 @@ class RainbowEffect(TemporalEffect):
 
     _hue = 0.1
 
+    def on_activate(self, pixel_count):
+        pass
+
     def effect_loop(self):
         hue_delta = self._config["frequency"] / self.pixel_count
         self.pixels = fill_rainbow(self.pixels, self._hue, hue_delta)

--- a/ledfx/effects/singleColor.py
+++ b/ledfx/effects/singleColor.py
@@ -22,6 +22,9 @@ class SingleColorEffect(TemporalEffect, ModulateEffect):
     def config_updated(self, config):
         self.color = np.array(parse_color(self._config["color"]), dtype=float)
 
+    def on_activate(self, pixel_count):
+        pass
+
     def effect_loop(self):
         color_array = np.tile(self.color, (self.pixel_count, 1))
         self.pixels = self.modulate(color_array)


### PR DESCRIPTION
Temporal behavior mutated when audio reactive was refactored ~2 years ago.

This is the cleanest fix without digging deeper.

add empty on_activation() to each temporal inherited class, as the temporal class registers the thread, and with no on_activation() method in the child, base class method walking for on_activation() will call into temporal parent class again and double register the effect, leading to two threads running for each temporal.

This thread creation is the equivalent of the audio registration for reactive, the behavior there is sane. For audio reactives the audio buffer incoming is the equivalent.

This is a side effect of rework in effect __init__.py that implemented base class walking.