### PR TITLE
Fix a crash when strobe_width out of range

### DIFF
--- a/ledfx/effects/melt_and_sparkle.py
+++ b/ledfx/effects/melt_and_sparkle.py
@@ -51,8 +51,8 @@ class HuxleyMelt(AudioReactiveEffect, HSVEffect):
             vol.Optional(
                 "strobe_width",
                 description="Percussive strobe width, in pixels",
-                default=10,
-            ): vol.All(vol.Coerce(int), vol.Range(min=0, max=1000)),
+                default=0.01,
+            ): vol.All(vol.Coerce(float), vol.Range(min=0, max=1)),
             vol.Optional(
                 "strobe_decay_rate",
                 description="Percussive strobe decay rate. Higher -> decays faster.",
@@ -189,8 +189,9 @@ class HuxleyMelt(AudioReactiveEffect, HSVEffect):
         # Update strobe overlay array.
         if not self.onsets_queue.empty():
             self.onsets_queue.get()
-            strobe_width = min(self.strobe_width, self.pixel_count)
-            position = np.random.randint(self.pixel_count - strobe_width)
+            strobe_width = int(self.strobe_width * self.pixel_count)
+            # Can't use the random function if the strobe width takes up the entire strip, so return 0
+            position = 0 if not (self.pixel_count - strobe_width) else np.random.randint(self.pixel_count - strobe_width)
             self.strobe_overlay[position : position + strobe_width] = 1.0
 
         # Adjust saturation by the strength of the overlay mask

--- a/ledfx/effects/melt_and_sparkle.py
+++ b/ledfx/effects/melt_and_sparkle.py
@@ -191,7 +191,11 @@ class HuxleyMelt(AudioReactiveEffect, HSVEffect):
             self.onsets_queue.get()
             strobe_width = int(self.strobe_width * self.pixel_count)
             # Can't use the random function if the strobe width takes up the entire strip, so return 0
-            position = 0 if not (self.pixel_count - strobe_width) else np.random.randint(self.pixel_count - strobe_width)
+            position = (
+                0
+                if not (self.pixel_count - strobe_width)
+                else np.random.randint(self.pixel_count - strobe_width)
+            )
             self.strobe_overlay[position : position + strobe_width] = 1.0
 
         # Adjust saturation by the strength of the overlay mask


### PR DESCRIPTION
Fixes an issue where setting the strobe width too high in the melt and sparkle effect caused a crash. Changed strobe width to use a float, and gave it a low default value to hopefully be at 1 pixel when starting out. Modified how position is calculated to avoid a crash if the strobe effect is set to 100%.

Closes #252