### PR TITLE
Updated old dependencies causing the backend crash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # https://wiki.python.org/moin/WindowsCompilers
 
 
-    aiohttp~=3.7.4.post0
+    aiohttp~=3.8.3
     aiohttp_cors~=0.7.0
     aubio>=0.4.9
     cython~=0.29.21
@@ -25,4 +25,4 @@
     tcp-latency~=0.0.10
     voluptuous~=0.12.1
     yappi~=1.3.3
-    zeroconf==0.30.0
+    zeroconf==0.39.4


### PR DESCRIPTION
Older zeroconf version caused crashes on computers with newer ethernet drivers