### PR TITLE
Fix remaining concurrent data access crash

### DIFF
--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -410,7 +410,7 @@ class Virtual:
             and hasattr(self._transition_effect, "pixels")
         ):
             # Get and process transition effect frame
-            self._transition_effect.render()
+            self._transition_effect._render()
             transition_frame = self._transition_effect.get_pixels()
             # np.clip(transition_frame, 0, 255, transition_frame)
             transition_frame[frame > 255] = 255


### PR DESCRIPTION
Fix remaining bare render call to wrapper _render that enforces data mutex

Transition renders were not protected in the last fix

Much smaller window of opportunity, but managed to trigger it.