### PR TITLE
New integration variables

### DIFF
--- a/ledfx/api/integrations.py
+++ b/ledfx/api/integrations.py
@@ -28,7 +28,7 @@ class IntegrationsEndpoint(RestEndpoint):
                 "type": integration.type,
                 "active": integration.active,
                 "published": integration.published,
-                "status": integration.status,
+                "status": integration.status.to_json(),
                 "data": integration.data,
                 "config": integration.config,
             }

--- a/ledfx/api/integrations.py
+++ b/ledfx/api/integrations.py
@@ -24,8 +24,10 @@ class IntegrationsEndpoint(RestEndpoint):
         for integration in self._ledfx.integrations.values():
             response["integrations"][integration.id] = {
                 "id": integration.id,
+                "name": integration.name,
                 "type": integration.type,
                 "active": integration.active,
+                "published": integration.published,
                 "status": integration.status,
                 "data": integration.data,
                 "config": integration.config,

--- a/ledfx/api/integrations.py
+++ b/ledfx/api/integrations.py
@@ -156,12 +156,14 @@ class IntegrationsEndpoint(RestEndpoint):
             return web.json_response(data=response, status=400)
 
         integration_config = data.get("config")
-        if integration_config is None:
-            response = {
-                "status": "failed",
-                "reason": 'Required attribute "config" was not provided',
-            }
-            return web.json_response(data=response, status=400)
+        integration_config["name"] = integration_config.get("name") or integration.get('name')
+        integration_config["description"] = integration_config.get("description") or integration.get("description")
+        # if integration_config is None:
+        #     response = {
+        #         "status": "failed",
+        #         "reason": 'Required attribute "config" was not provided',
+        #     }
+            # return web.json_response(data=response, status=400)
 
         integration_type = data.get("type")
         if integration_type is None:

--- a/ledfx/api/integrations.py
+++ b/ledfx/api/integrations.py
@@ -156,14 +156,18 @@ class IntegrationsEndpoint(RestEndpoint):
             return web.json_response(data=response, status=400)
 
         integration_config = data.get("config")
-        integration_config["name"] = integration_config.get("name") or integration.get('name')
-        integration_config["description"] = integration_config.get("description") or integration.get("description")
+        integration_config["name"] = integration_config.get(
+            "name"
+        ) or integration.get("name")
+        integration_config["description"] = integration_config.get(
+            "description"
+        ) or integration.get("description")
         # if integration_config is None:
         #     response = {
         #         "status": "failed",
         #         "reason": 'Required attribute "config" was not provided',
         #     }
-            # return web.json_response(data=response, status=400)
+        # return web.json_response(data=response, status=400)
 
         integration_type = data.get("type")
         if integration_type is None:

--- a/ledfx/integrations/__init__.py
+++ b/ledfx/integrations/__init__.py
@@ -20,11 +20,22 @@ class Status(IntEnum):
     DISCONNECTING = 2
     CONNECTING = 3
 
+    def to_json(self):
+        values = {
+            0: "disconnected",
+            1: "connected",
+            2: "disconnecting",
+            3: "connecting"
+        }
+        return values[self.value]
+
 
 @BaseRegistry.no_registration
 class Integration(BaseRegistry):
     def __init__(self, ledfx, config, active, data):
         self._ledfx = ledfx
+        self.name = "Unnamed Integration"
+        self.description = ""
         self._config = config
         self._active = active
         self.published = False
@@ -89,11 +100,11 @@ class Integration(BaseRegistry):
 
     @property
     def name(self):
-        return self._config["name"]
+        return self.name
 
     @property
     def description(self):
-        return self._config["description"]
+        return self.description
 
     @property
     def status(self):

--- a/ledfx/integrations/__init__.py
+++ b/ledfx/integrations/__init__.py
@@ -27,6 +27,7 @@ class Integration(BaseRegistry):
         self._ledfx = ledfx
         self._config = config
         self._active = active
+        self.published = False
         self._data = data
         self._status = Status.DISCONNECTED
 
@@ -105,7 +106,10 @@ class Integration(BaseRegistry):
     @property
     def data(self):
         return self._data
-
+    
+    @property
+    def published(self):
+        return self._published
 
 class Integrations(RegistryLoader):
     """Thin wrapper around the integration registry that manages integrations"""

--- a/ledfx/integrations/__init__.py
+++ b/ledfx/integrations/__init__.py
@@ -100,11 +100,11 @@ class Integration(BaseRegistry):
 
     @property
     def name(self):
-        return self.name
+        return self._name
 
     @property
     def description(self):
-        return self.description
+        return self._description
 
     @property
     def status(self):

--- a/ledfx/integrations/__init__.py
+++ b/ledfx/integrations/__init__.py
@@ -34,11 +34,11 @@ class Status(IntEnum):
 class Integration(BaseRegistry):
     def __init__(self, ledfx, config, active, data):
         self._ledfx = ledfx
-        self.name = "Unnamed Integration"
-        self.description = ""
+        self._name = "Unnamed Integration"
+        self._description = ""
         self._config = config
         self._active = active
-        self.published = False
+        self._published = False
         self._data = data
         self._status = Status.DISCONNECTED
 

--- a/ledfx/integrations/__init__.py
+++ b/ledfx/integrations/__init__.py
@@ -22,10 +22,10 @@ class Status(IntEnum):
 
     def to_json(self):
         values = {
-            0: "disconnected",
-            1: "connected",
-            2: "disconnecting",
-            3: "connecting",
+            0: "Disconnected",
+            1: "Connected",
+            2: "Disconnecting",
+            3: "Connecting",
         }
         return values[self.value]
 

--- a/ledfx/integrations/__init__.py
+++ b/ledfx/integrations/__init__.py
@@ -25,7 +25,7 @@ class Status(IntEnum):
             0: "disconnected",
             1: "connected",
             2: "disconnecting",
-            3: "connecting"
+            3: "connecting",
         }
         return values[self.value]
 
@@ -117,10 +117,11 @@ class Integration(BaseRegistry):
     @property
     def data(self):
         return self._data
-    
+
     @property
     def published(self):
         return self._published
+
 
 class Integrations(RegistryLoader):
     """Thin wrapper around the integration registry that manages integrations"""

--- a/ledfx/integrations/spotify.py
+++ b/ledfx/integrations/spotify.py
@@ -13,10 +13,13 @@ class Spotify(Integration):
 
     def __init__(self, ledfx, config, active, data):
         super().__init__(ledfx, config, active, data)
+        self._ledfx = ledfx
+        self._config = config
         self._name = self.NAME
         self._description = self.DESCRIPTION
         self._published = True
         self._data = {}
+        self._config['name'] = self._name
 
         self.restore_from_data(self._ledfx.config["scenes"])
 

--- a/ledfx/integrations/spotify.py
+++ b/ledfx/integrations/spotify.py
@@ -1,4 +1,5 @@
 import logging
+
 from ledfx.integrations import Integration
 
 _LOGGER = logging.getLogger(__name__)

--- a/ledfx/integrations/spotify.py
+++ b/ledfx/integrations/spotify.py
@@ -49,11 +49,11 @@ class Spotify(Integration):
     @property
     def name(self):
         return self._name
-    
+
     @property
     def description(self):
         return self._description
-    
+
     @property
     def published(self):
         return self._published

--- a/ledfx/integrations/spotify.py
+++ b/ledfx/integrations/spotify.py
@@ -7,10 +7,13 @@ _LOGGER = logging.getLogger(__name__)
 class Spotify(Integration):
     """Spotify Integration"""
 
+    NAME = "Spotify"
+    DESCRIPTION = "Activate scenes with Spotify Connect [BETA]. Requires Spotify Premium."
+
     def __init__(self, ledfx, config, active, data):
         super().__init__(ledfx, config, active, data)
-        self._name = "Spotify"
-        self._description = "Activate scenes with Spotify Connect [BETA]. Requires Spotify Premium."
+        self._name = self.NAME
+        self._description = self.DESCRIPTION
         self._published = True
         self._data = {}
 

--- a/ledfx/integrations/spotify.py
+++ b/ledfx/integrations/spotify.py
@@ -9,9 +9,9 @@ class Spotify(Integration):
 
     def __init__(self, ledfx, config, active, data):
         super().__init__(ledfx, config, active, data)
-        self.name = "Spotify"
-        self.description = "Activate scenes with Spotify Connect [BETA]. Requires Spotify Premium."
-        self.published = True
+        self._name = "Spotify"
+        self._description = "Activate scenes with Spotify Connect [BETA]. Requires Spotify Premium."
+        self._published = True
         self._data = {}
 
         self.restore_from_data(self._ledfx.config["scenes"])

--- a/ledfx/integrations/spotify.py
+++ b/ledfx/integrations/spotify.py
@@ -19,7 +19,7 @@ class Spotify(Integration):
         self._description = self.DESCRIPTION
         self._published = True
         self._data = {}
-        self._config['name'] = self._name
+        self._config["name"] = self._name
 
         self.restore_from_data(self._ledfx.config["scenes"])
 

--- a/ledfx/integrations/spotify.py
+++ b/ledfx/integrations/spotify.py
@@ -45,3 +45,15 @@ class Spotify(Integration):
 
     async def disconnect(self, msg=None):
         await super().disconnect()
+
+    @property
+    def name(self):
+        return self._name
+    
+    @property
+    def description(self):
+        return self._description
+    
+    @property
+    def published(self):
+        return self._published

--- a/ledfx/integrations/spotify.py
+++ b/ledfx/integrations/spotify.py
@@ -1,21 +1,5 @@
-# from ledfx.utils import RegistryLoader, async_fire_and_forget, async_fire_and_return, async_callback
-# from ledfx.events import Event
-# import importlib
-# import pkgutil
 import logging
-
-# import aiohttp
-# import asyncio
-import voluptuous as vol
-
 from ledfx.integrations import Integration
-
-# import numpy as np
-
-
-# import time
-# import os
-# import re
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,30 +7,11 @@ _LOGGER = logging.getLogger(__name__)
 class Spotify(Integration):
     """Spotify Integration"""
 
-    NAME = "Spotify"
-    DESCRIPTION = "Activate scenes with Spotify Connect [BETA]. Requires Spotify Premium."
-
-    CONFIG_SCHEMA = vol.Schema(
-        {
-            vol.Required(
-                "name",
-                description="Name of this integration instance and associated settings",
-                default="Spotify",
-            ): str,
-            vol.Required(
-                "description",
-                description="Description of this integration",
-                default="Activate scenes with Spotify",
-            ): str,
-        }
-    )
-
     def __init__(self, ledfx, config, active, data):
-
         super().__init__(ledfx, config, active, data)
-
-        self._ledfx = ledfx
-        self._config = config
+        self.name = "Spotify"
+        self.description = "Activate scenes with Spotify Connect [BETA]. Requires Spotify Premium."
+        self.published = True
         self._data = {}
 
         self.restore_from_data(self._ledfx.config["scenes"])


### PR DESCRIPTION
Making name and description available in the endpoint and removing from config (probably doesn't need to be user configurable). Added a published property to enable/disable integrations that may not be complete yet. Updated spotify plugin to remove name/description from config. Fix jason serializable error with new status enum.