### PR TITLE
Python version sleep management for effects

### DIFF
--- a/ledfx/effects/temporal.py
+++ b/ledfx/effects/temporal.py
@@ -11,7 +11,8 @@ from ledfx.effects import Effect
 _LOGGER = logging.getLogger(__name__)
 
 # use 10 frames per second as default rate at 1x multiplier
-# windows pre 3.11 will cap at 64Hz max for now, others at 100Hz with speed slider ot 10
+# windows pre 3.11 will cap at 64Hz max for now,
+# other OS at 100Hz with speed slider ot 10
 DEFAULT_RATE = 1.0 / 10.0
 
 

--- a/ledfx/effects/temporal.py
+++ b/ledfx/effects/temporal.py
@@ -11,8 +11,7 @@ from ledfx.effects import Effect
 _LOGGER = logging.getLogger(__name__)
 
 # use 10 frames per second as default rate at 1x multiplier
-# windows will cap at 64Hz max for now, others at 100Hz with speed slider ot 10
-# rework when we go to 3.11
+# windows pre 3.11 will cap at 64Hz max for now, others at 100Hz with speed slider ot 10
 DEFAULT_RATE = 1.0 / 10.0
 
 

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -40,7 +40,7 @@ _LOGGER = logging.getLogger(__name__)
 # At 3.11 onwards use the high res perf_counter everywhere as monotonic still
 # reports 15ms on a windows OS, but the sleep implementation is perf based
 
-if sys.version_info[0] >= 3 and sys.version_info[1] >= 11:
+if (sys.version_info[0] == 3 and sys.version_info[1] >= 11) or sys.version_info[0] >= 4:
     clock_source = "perf_counter"
 else:
     clock_source = "monotonic"

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -40,7 +40,9 @@ _LOGGER = logging.getLogger(__name__)
 # At 3.11 onwards use the high res perf_counter everywhere as monotonic still
 # reports 15ms on a windows OS, but the sleep implementation is perf based
 
-if (sys.version_info[0] == 3 and sys.version_info[1] >= 11) or sys.version_info[0] >= 4:
+if (
+    sys.version_info[0] == 3 and sys.version_info[1] >= 11
+) or sys.version_info[0] >= 4:
     clock_source = "perf_counter"
 else:
     clock_source = "monotonic"

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -124,7 +124,9 @@ class Virtual:
     _active_effect = None
     _transition_effect = None
 
-    if (sys.version_info[0] == 3 and sys.version_info[1] >= 11) or sys.version_info[0] >= 4:
+    if (
+        sys.version_info[0] == 3 and sys.version_info[1] >= 11
+    ) or sys.version_info[0] >= 4:
         _min_time = time.get_clock_info("perf_counter").resolution
     else:
         _min_time = time.get_clock_info("monotonic").resolution

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -124,7 +124,7 @@ class Virtual:
     _active_effect = None
     _transition_effect = None
 
-    if sys.version_info[0] >= 3 and sys.version_info[1] >= 11:
+    if (sys.version_info[0] == 3 and sys.version_info[1] >= 11) or sys.version_info[0] >= 4:
         _min_time = time.get_clock_info("perf_counter").resolution
     else:
         _min_time = time.get_clock_info("monotonic").resolution


### PR DESCRIPTION
Rework monotonic / performance counter code to be adaptive to the python version in runtime

Improve protection code for < 3.11 and windows switching sleep clock resolution under the covers

This code will now just take best advantage of the OS / Python version it happens to be on