### PR TITLE
new restapi endpoint for tools / force_color

### DIFF
--- a/ledfx/api/virtual_tools.py
+++ b/ledfx/api/virtual_tools.py
@@ -1,0 +1,89 @@
+import logging
+from json import JSONDecodeError
+
+from aiohttp import web
+
+from ledfx.api import RestEndpoint
+from ledfx.color import parse_color, validate_color
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VirtualToolsEndpoint(RestEndpoint):
+
+    ENDPOINT_PATH = "/api/virtuals/{virtual_id}/tools"
+
+    async def get(self, virtual_id) -> web.Response:
+        """
+        Get presets for active effect of a virtual
+        """
+        virtual = self._ledfx.virtuals.get(virtual_id)
+        if virtual is None:
+            response = {
+                "status": "failed",
+                "reason": f"Virtual with ID {virtual_id} not found",
+            }
+            return web.json_response(data=response, status=404)
+
+        response = {
+            "status": "success",
+            "virtual": virtual_id,
+            "Data": "Nothing to see, Move along",
+        }
+
+        return web.json_response(data=response, status=200)
+
+    async def put(self, virtual_id, request) -> web.Response:
+        """Extensible tools support"""
+        tools = ["force_color"]
+
+        virtual = self._ledfx.virtuals.get(virtual_id)
+        if virtual is None:
+            response = {
+                "status": "failed",
+                "reason": f"Virtual with ID {virtual_id} not found",
+            }
+            return web.json_response(data=response, status=404)
+
+        try:
+            data = await request.json()
+        except JSONDecodeError:
+            response = {
+                "status": "failed",
+                "reason": "JSON Decoding failed",
+            }
+            return web.json_response(data=response, status=400)
+
+        tool = data.get("tool")
+
+        if tool is None:
+            response = {
+                "status": "failed",
+                "reason": 'Required attribute "tool" was not provided',
+            }
+            return web.json_response(data=response, status=400)
+
+        if tool not in ["force_color"]:
+            response = {
+                "status": "failed",
+                "reason": f'Category {tool} is not in {tools}',
+            }
+            return web.json_response(data=response, status=400)
+
+        if tool == "force_color":
+            _LOGGER.info(f'We have made it to the force color code!!!!')
+            color = data.get("color")
+            if color is None:
+                response = {
+                    "status": "failed",
+                    "reason": 'Required attribute for force_color, color was not provided',
+                }
+                return web.json_response(data=response, status=400)
+
+            virtual.force_frame(parse_color(validate_color(color)))
+
+        effect_response = {}
+        effect_response["tool"] = tool
+
+        response = {"status": "success", "tool": tool}
+        return web.json_response(data=response, status=200)

--- a/ledfx/api/virtual_tools.py
+++ b/ledfx/api/virtual_tools.py
@@ -8,6 +8,7 @@ from ledfx.color import parse_color, validate_color
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class VirtualToolsEndpoint(RestEndpoint):
     """api for all virtual manipulations"""
 
@@ -72,4 +73,3 @@ class VirtualToolsEndpoint(RestEndpoint):
 
         response = {"status": "success", "tool": tool}
         return web.json_response(data=response, status=200)
-

--- a/ledfx/api/virtual_tools.py
+++ b/ledfx/api/virtual_tools.py
@@ -71,7 +71,6 @@ class VirtualToolsEndpoint(RestEndpoint):
             return web.json_response(data=response, status=400)
 
         if tool == "force_color":
-            _LOGGER.info(f'We have made it to the force color code!!!!')
             color = data.get("color")
             if color is None:
                 response = {

--- a/ledfx/api/virtuals_tools.py
+++ b/ledfx/api/virtuals_tools.py
@@ -67,7 +67,7 @@ class VirtualsToolsEndpoint(RestEndpoint):
         if tool not in ["force_color"]:
             response = {
                 "status": "failed",
-                "reason": f'Category {tool} is not in {tools}',
+                "reason": f"Category {tool} is not in {tools}",
             }
             return web.json_response(data=response, status=400)
 
@@ -76,7 +76,7 @@ class VirtualsToolsEndpoint(RestEndpoint):
             if color is None:
                 response = {
                     "status": "failed",
-                    "reason": 'Required attribute for force_color, color was not provided',
+                    "reason": "Required attribute for force_color, color was not provided",
                 }
                 return web.json_response(data=response, status=400)
 

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -357,6 +357,19 @@ class Virtual:
 
             self._active = False
 
+    def force_frame(self, color):
+        """
+        Force all pixels in device to color
+        Use for pre-clearing in calibration scenarios
+        """
+        _LOGGER.info(f'name: {self.name} active: {self._active} pixel_count: {self.pixel_count}')
+        self.assembled_frame = np.full((self.pixel_count, 3), color)
+        _LOGGER.info(f'frame length: {len(self.assembled_frame)}')
+        self.flush(self.assembled_frame)
+        self._ledfx.events.fire_event(
+            VirtualUpdateEvent(self.id, self.assembled_frame)
+        )
+
     @property
     def active_effect(self):
         return self._active_effect

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -362,9 +362,7 @@ class Virtual:
         Force all pixels in device to color
         Use for pre-clearing in calibration scenarios
         """
-        _LOGGER.info(f'name: {self.name} active: {self._active} pixel_count: {self.pixel_count}')
         self.assembled_frame = np.full((self.pixel_count, 3), color)
-        _LOGGER.info(f'frame length: {len(self.assembled_frame)}')
         self.flush(self.assembled_frame)
         self._ledfx.events.fire_event(
             VirtualUpdateEvent(self.id, self.assembled_frame)


### PR DESCRIPTION
http://localhost:8888/api/virtuals_tools
http://localhost:8888/api/virtuals_tools/MY_DEVICE_ID

with a body of 

{
    "tool": "force_color",
    "color": "black"
}

Will stuff the buffer space for that device with the requested color, even if device is not active

for the bare call without a device id specified, all real devices will be color stuffed, so it is easy to blank all devices in one call

Any running effects will overwrite, but this can be used to stuff with "black" so that following changes to segments are distinct

Consider automating black back fill for all all impacted physical devices when a virtual segments configuration is changed