### PR TITLE
Fix crash on enable of c cycler in Energy effect

### DIFF
--- a/ledfx/api/config.py
+++ b/ledfx/api/config.py
@@ -196,7 +196,9 @@ class ConfigEndpoint(RestEndpoint):
                     self._ledfx.config["melbanks"]
                 )
 
-            if core_config and not ("global_brightness" in core_config and len(core_config) == 1):
+            if core_config and not (
+                "global_brightness" in core_config and len(core_config) == 1
+            ):
                 self._ledfx.loop.call_soon_threadsafe(self._ledfx.stop, 4)
 
             save_config(

--- a/ledfx/effects/energy.py
+++ b/ledfx/effects/energy.py
@@ -102,7 +102,9 @@ class EnergyAudioEffect(AudioReactiveEffect):
                 self.color_cycler = (self.color_cycler + 1) % 3
                 color = parse_color(
                     np.random.choice(
-                        list(self._ledfx.colors.get_all(merged=True).values())))
+                        list(self._ledfx.colors.get_all(merged=True).values())
+                    )
+                )
 
                 if self.color_cycler == 0:
                     self.lows_color = color

--- a/ledfx/effects/energy.py
+++ b/ledfx/effects/energy.py
@@ -100,7 +100,9 @@ class EnergyAudioEffect(AudioReactiveEffect):
             if self.beat_now:
                 # Cycle between 0,1,2 for lows, mids and highs
                 self.color_cycler = (self.color_cycler + 1) % 3
-                color = parse_color(np.random.choice(list(self._ledfx.colors.get_all(merged=True).values())))
+                color = parse_color(
+                    np.random.choice(
+                        list(self._ledfx.colors.get_all(merged=True).values())))
 
                 if self.color_cycler == 0:
                     self.lows_color = color

--- a/ledfx/effects/energy.py
+++ b/ledfx/effects/energy.py
@@ -100,7 +100,7 @@ class EnergyAudioEffect(AudioReactiveEffect):
             if self.beat_now:
                 # Cycle between 0,1,2 for lows, mids and highs
                 self.color_cycler = (self.color_cycler + 1) % 3
-                color = np.random.choice(tuple(self._ledfx.colors.values()))
+                color = parse_color(np.random.choice(list(self._ledfx.colors.get_all(merged=True).values())))
 
                 if self.color_cycler == 0:
                     self.lows_color = color

--- a/ledfx/effects/energy.py
+++ b/ledfx/effects/energy.py
@@ -100,11 +100,13 @@ class EnergyAudioEffect(AudioReactiveEffect):
             if self.beat_now:
                 # Cycle between 0,1,2 for lows, mids and highs
                 self.color_cycler = (self.color_cycler + 1) % 3
-                color = parse_color(
-                    np.random.choice(
-                        list(self._ledfx.colors.get_all(merged=True).values())
-                    )
-                )
+
+                color_raw = self._ledfx.colors.get_all(merged=False)
+                if len(color_raw[1]) > 0:  # if there are user colors, use them
+                    color_list = list(color_raw[1].values())
+                else:
+                    color_list = list(color_raw[0].values())
+                color = parse_color(np.random.choice(color_list))
 
                 if self.color_cycler == 0:
                     self.lows_color = color


### PR DESCRIPTION
Fix up random color selection from default OR user
Maybe missing the correct usage of collections but this is the only way I could get it to work!

Quoting from discord

Well I have a fix for the color cycler crash on the Energy effect, feels like I read a lot about python abc ( abstract base classes ) and know less than when I started. I could not get the supposed values() method to do anything sensible on the colors collection, I suspect it is not implemented, and I just don't know how to fix that bit. So for now I have leveraged the get_all() method which does exist, merging the default and user defined colors ( which I don't know if anyone uses ) and then mangle them towards the numpy choice function as a list, and finally translate it into a color type that the following code can consume. I have to believe the original author just never got this bit to work or got around to shaking it out.

Prior to fix, crash with 
 File "mtrand.pyx", line 911, in numpy.random.mtrand.RandomState.choice
ValueError: a must be 1-dimensional

Now randomly pulls a color from either list of default OR user and converts it to parsed color for further consumption