### PR TITLE
Fix tray icon and allow latest psytray lib usage, add get_icon_path()

### DIFF
--- a/ledfx/__main__.py
+++ b/ledfx/__main__.py
@@ -44,7 +44,7 @@ from ledfx.consts import (
     REQUIRED_PYTHON_VERSION,
 )
 from ledfx.core import LedFxCore
-from ledfx.utils import currently_frozen
+from ledfx.utils import currently_frozen, get_icon_path
 
 # Logger Variables
 PYUPDATERLOGLEVEL = 35
@@ -344,13 +344,7 @@ def main():
 
         from PIL import Image
 
-        current_directory = os.path.dirname(__file__)
-
-        if currently_frozen():
-            icon_location = os.path.join(current_directory, "tray.png")
-        else:
-            icon_location = os.path.normpath(
-                os.path.join(current_directory, "..", "icons", "tray.png"))
+        icon_location = get_icon_path("tray.png")
 
         icon = pystray.Icon(
             "LedFx", icon=Image.open(icon_location), title="LedFx"

--- a/ledfx/__main__.py
+++ b/ledfx/__main__.py
@@ -344,18 +344,17 @@ def main():
 
         from PIL import Image
 
+        current_directory = os.path.dirname(__file__)
+
         if currently_frozen():
-            current_directory = os.path.dirname(__file__)
             icon_location = os.path.join(current_directory, "tray.png")
         else:
-            current_directory = os.path.dirname(__file__)
-            icon_location = os.path.join(
-                current_directory, "..", "icons/" "tray.png"
-            )
+            icon_location = os.path.normpath(
+                os.path.join(current_directory, "..", "icons", "tray.png"))
+
         icon = pystray.Icon(
             "LedFx", icon=Image.open(icon_location), title="LedFx"
         )
-        icon.visible = True
     else:
         icon = None
     # icon = None
@@ -372,6 +371,9 @@ def main():
 def entry_point(icon=None):
     # have to re-parse args here :/ no way to pass them through pysicon's setup
     args = parse_args()
+
+    if icon:
+        icon.visible = True
 
     exit_code = 4
     while exit_code == 4:

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -542,6 +542,29 @@ def currently_frozen():
     return getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")
 
 
+def get_icon_path(icon_filename)->str:
+    """returns fully qualified path for icon, tests for frozen
+    and logs error if does not exist
+
+    Parameters:
+        icon_filename(str): the filename of the icon to be pathed
+
+    Returns:
+            icon_location(str): fully qualified path
+    """
+    current_directory = os.path.dirname(__file__)
+
+    if currently_frozen():
+        icon_location = os.path.join(current_directory, icon_filename)
+    else:
+        icon_location = os.path.normpath(
+            os.path.join(current_directory, "..", "icons", icon_filename))
+
+    if not os.path.isfile(icon_location):
+        _LOGGER.error(f"No icon found at {icon_location}")
+    return icon_location
+
+
 def generate_id(name):
     """Converts a name to a id"""
     part1 = re.sub("[^a-zA-Z0-9]", " ", name).lower()

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -542,7 +542,7 @@ def currently_frozen():
     return getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")
 
 
-def get_icon_path(icon_filename)->str:
+def get_icon_path(icon_filename) -> str:
     """returns fully qualified path for icon, tests for frozen
     and logs error if does not exist
 
@@ -558,7 +558,8 @@ def get_icon_path(icon_filename)->str:
         icon_location = os.path.join(current_directory, icon_filename)
     else:
         icon_location = os.path.normpath(
-            os.path.join(current_directory, "..", "icons", icon_filename))
+            os.path.join(current_directory, "..", "icons", icon_filename)
+        )
 
     if not os.path.isfile(icon_location):
         _LOGGER.error(f"No icon found at {icon_location}")


### PR DESCRIPTION
Fix pystray icon being made visible out of runtime context

See hints at https://github.com/moses-palmer/pystray/issues/6

Also Fix relative path construct to be normalised. No impact to psytray but bad example and breaks notify-py

This has been improved to move the icon file path generation out to a util function of get_icon_path

this can be reused elsewhere. It does depend on utils.py being in the code ledfx folder parrallel to the icons folder, but it puts this pathing dependency in one place.

Tested with the --tray icon

Also tested by adding notifcation into the virtual_effects rest api and posting a notification ( code not included in this PR )

![image](https://user-images.githubusercontent.com/7328740/224574876-0460369d-0554-42a4-8371-44b22f3de023.png)
