### PR TITLE
_gaussian_kernel1d() div zero crash, melt and sparkle

### DIFF
--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -92,6 +92,8 @@ def _gaussian_kernel1d(sigma, order, array_len):
     # Choose a radius for the filter kernel large enough to include all significant elements. Using
     # a radius of 4 standard deviations (rounded to int) will only truncate tail values that are of
     # the order of 1e-5 or smaller. For very small sigma values, just use a minimal radius.
+    # trapping very small values of sigma to arbitarily 0.00001 to preven div zero crash
+    sigma = max(0.00001, sigma)
     radius = max(1, int(round(4.0 * sigma)))
     radius = min(int((array_len - 1) / 2), radius)
     radius = max(radius, 1)


### PR DESCRIPTION
Cap minimum for sigma in _gaussian_kernel1d() to prevent -0.5 / sigma * sigma div by zero error

Expresses in melt and sparkle when pushing Strobe Blur to Zero.

Could change range of the melt and sparkle slider, but leaves this land mine for other usage, which is currently limited

0.00001 value is entirely arbitrary