### PR TITLE
Fix DDP support in edit device / config / sync mode

### DIFF
--- a/ledfx/devices/wled.py
+++ b/ledfx/devices/wled.py
@@ -58,6 +58,7 @@ class WLEDDevice(NetworkedDevice):
             },
             "DDP": {
                 "name": None,
+                "port": 4048,
                 "ip_address": None,
                 "pixel_count": None,
             },


### PR DESCRIPTION
Add port key into the DDP device configs. It is a default required key when running code in

https://github.com/LedFx/LedFx/blob/main/ledfx/devices/ddp.py#L61

I am not aware if this is supposed to be editable, but seen to work!

Switch to DDP in edit device / config / sync mode to reproduce failure

Now works end to end