### PR TITLE
Strobe color shift delay slider

### DIFF
--- a/ledfx/effects/real_strobe.py
+++ b/ledfx/effects/real_strobe.py
@@ -46,6 +46,11 @@ class Strobe(AudioReactiveEffect, GradientEffect):
                 description="Percussive strobe decay rate. Higher -> decays faster.",
                 default=0.5,
             ): vol.All(vol.Coerce(float), vol.Range(min=0, max=1)),
+            vol.Optional(
+                "color_shift_delay",
+                description="color shift delay for percussive strobes. Lower -> more shifts",
+                default=1,
+            ): vol.All(vol.Coerce(float), vol.Range(min=0, max=1)),
         }
     )
 
@@ -67,7 +72,7 @@ class Strobe(AudioReactiveEffect, GradientEffect):
         )
         self.last_color_shift_time = 0
         self.strobe_width = self._config["strobe_width"]
-        self.color_shift_delay_in_seconds = 1
+        self.color_shift_delay_in_seconds = self._config["color_shift_delay"]
         self.color_idx = 0
 
         self.last_strobe_time = 0

--- a/ledfx/presets.py
+++ b/ledfx/presets.py
@@ -1420,7 +1420,7 @@ ledfx_presets = {
                 "bass_strobe_decay_rate": 0,
                 "blur": 0.0,
                 "brightness": 1.0,
-                "color_shift_delay": 1.0,
+                "color_shift_delay": 0.1,
                 "color_step": 0.0625,
                 "flip": False,
                 "gradient": "linear-gradient(90deg, rgb(255, 0, 0) 0%, rgb(255, 120, 0) 14%, rgb(255, 200, 0) 28%, rgb(0, 255, 0) 42%, rgb(0, 199, 140) 56%, rgb(0, 0, 255) 70%, rgb(128, 0, 128) 84%, rgb(255, 0, 178) 98%)",

--- a/ledfx/presets.py
+++ b/ledfx/presets.py
@@ -1413,6 +1413,25 @@ ledfx_presets = {
             },
             "name": "Glitter",
         },
+        "color-shift": {
+            "config": {
+                "background_brightness": 1.0,
+                "background_color": "black",
+                "bass_strobe_decay_rate": 0,
+                "blur": 0.0,
+                "brightness": 1.0,
+                "color_shift_delay": 1.0,
+                "color_step": 0.0625,
+                "flip": False,
+                "gradient": "linear-gradient(90deg, rgb(255, 0, 0) 0%, rgb(255, 120, 0) 14%, rgb(255, 200, 0) 28%, rgb(0, 255, 0) 42%, rgb(0, 199, 140) 56%, rgb(0, 0, 255) 70%, rgb(128, 0, 128) 84%, rgb(255, 0, 178) 98%)",
+                "gradient_roll": 0.0,
+                "mirror": False,
+                "strobe_color": "black",
+                "strobe_decay_rate": 1,
+                "strobe_width": 0
+            },
+            "name": "Color shift"
+        },
     },
     "blade_power_plus": {
         "reset": {"config": {}, "name": "Reset"},


### PR DESCRIPTION
adds a slider to adjust the delay between the color changes of the bass strobe.

adds a preset where the effects of this slider can be used

Especially nice for the strobe settings where you have non-decaying strobes.
Without this setting, settings like the added preset look bad as they miss bass hits.