### PR TITLE
Remove CI build deprecation warnings

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,7 +13,7 @@ jobs:
         python: [3.8,3.9,3.10.x]
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.4.0
       - name: Install build dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y \
@@ -39,7 +39,7 @@ jobs:
         python: [3.8,3.9,3.10.x]
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.4.0
       - name: Setup Python ${{ matrix.python }}
         id: python
         uses: actions/setup-python@v4.5.0
@@ -61,7 +61,7 @@ jobs:
         python: [3.8,3.9,3.10.x]
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.4.0
       - name: Install build dependencies
         run: |
           brew install portaudio
@@ -86,7 +86,7 @@ jobs:
 #         node-version: [10, 12, 14]
 #     steps:
 #       - name: Check out code from GitHub
-#         uses: actions/checkout@v2
+#         uses: actions/checkout@v3.4.0
 #       - name: Use Node.js ${{ matrix.node-version }}
 #         uses: actions/setup-node@v2
 #         with:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,7 +20,7 @@ jobs:
           gcc libatlas3-base portaudio19-dev
       - name: Setup Python ${{ matrix.python }}
         id: python
-        uses: actions/setup-python@v2.2.1
+        uses: actions/setup-python@v4.5.0
         with:
           python-version: ${{ matrix.python }}
       - name: Build a binary wheel
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Python ${{ matrix.python }}
         id: python
-        uses: actions/setup-python@v2.2.1
+        uses: actions/setup-python@v4.5.0
         with:
           python-version: ${{ matrix.python }}
       - name: Build a binary wheel
@@ -67,7 +67,7 @@ jobs:
           brew install portaudio
       - name: Setup Python ${{ matrix.python }}
         id: python
-        uses: actions/setup-python@v2.2.1
+        uses: actions/setup-python@v4.5.0
         with:
           python-version: ${{ matrix.python }}
       - name: Build a binary wheel


### PR DESCRIPTION
Upgrade actions to latest releases for setup-python and checkout to remove deprecation warnings that were soon to become errors

ci-builds now run clean


Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2.2.1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.Show less

Build LedFx (Ubuntu) (3.9)The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

