### PR TITLE
add debug for platform and python under DEBUG

### DIFF
--- a/ledfx/__main__.py
+++ b/ledfx/__main__.py
@@ -300,6 +300,20 @@ def update_ledfx(icon=None):
             "You're all up to date, enjoy the light show!",
         )
 
+def log_packages():
+    from pkg_resources import working_set
+    from platform import python_version, python_build, python_implementation
+    from platform import  processor, system, release
+
+    _LOGGER.debug(f"{system()} : {release()} : {processor()}")
+    _LOGGER.debug(
+        f"{python_version()} : {python_build()} : {python_implementation()}")
+    _LOGGER.debug("Packages")
+    dists = [d for d in working_set]
+    dists.sort(key=lambda x: x.project_name)
+    for dist in dists:
+        _LOGGER.debug(f"{dist.project_name} : {dist.version}")
+
 
 def main():
     """Main entry point allowing external calls"""
@@ -362,6 +376,9 @@ def main():
     else:
         icon = None
     # icon = None
+
+    if _LOGGER.isEnabledFor(logging.DEBUG):
+        log_packages()
 
     # if have_updater and not args.offline_mode and currently_frozen():
     #     update_ledfx(icon)

--- a/ledfx/__main__.py
+++ b/ledfx/__main__.py
@@ -300,14 +300,23 @@ def update_ledfx(icon=None):
             "You're all up to date, enjoy the light show!",
         )
 
+
 def log_packages():
+    from platform import (
+        processor,
+        python_build,
+        python_implementation,
+        python_version,
+        release,
+        system,
+    )
+
     from pkg_resources import working_set
-    from platform import python_version, python_build, python_implementation
-    from platform import  processor, system, release
 
     _LOGGER.debug(f"{system()} : {release()} : {processor()}")
     _LOGGER.debug(
-        f"{python_version()} : {python_build()} : {python_implementation()}")
+        f"{python_version()} : {python_build()} : {python_implementation()}"
+    )
     _LOGGER.debug("Packages")
     dists = [d for d in working_set]
     dists.sort(key=lambda x: x.project_name)


### PR DESCRIPTION
Implemented while looking at why zeroconf / auto wled detect is broken between 0.30.0 and 0.47.0 zeroconf

Sample output with -vv arg

[DEBUG   ] __main__                       : Windows : 10 : Intel64 Family 6 Model 158 Stepping 10, GenuineIntel
[DEBUG   ] __main__                       : 3.11.0 : ('main', 'Oct 24 2022 18:26:48') : CPython
[DEBUG   ] __main__                       : Packages
[DEBUG   ] __main__                       : Cython : 0.29.32
[DEBUG   ] __main__                       : Pillow : 9.3.0
[DEBUG   ] __main__                       : PyJWT : 2.6.0
[DEBUG   ] __main__                       : aiohttp : 3.8.3
[DEBUG   ] __main__                       : aiohttp-cors : 0.7.0
[DEBUG   ] __main__                       : aiosignal : 1.3.1
[DEBUG   ] __main__                       : async-timeout : 4.0.2
[DEBUG   ] __main__                       : attrs : 22.1.0
[DEBUG   ] __main__                       : aubio : 0.4.9
[DEBUG   ] __main__                       : certifi : 2020.12.5
[DEBUG   ] __main__                       : cffi : 1.15.1
[DEBUG   ] __main__                       : chardet : 3.0.4
[DEBUG   ] __main__                       : charset-normalizer : 2.1.1
[DEBUG   ] __main__                       : colorama : 0.4.6
[DEBUG   ] __main__                       : frozenlist : 1.3.3
[DEBUG   ] __main__                       : getversion : 1.0.2
[DEBUG   ] __main__                       : gmail : 0.6.3
[DEBUG   ] __main__                       : idna : 2.10
[DEBUG   ] __main__                       : ifaddr : 0.2.0
[DEBUG   ] __main__                       : loguru : 0.6.0
[DEBUG   ] __main__                       : mido : 1.2.10
[DEBUG   ] __main__                       : multidict : 5.0.2
[DEBUG   ] __main__                       : notify-py : 0.3.42
[DEBUG   ] __main__                       : numpy : 1.23.5
[DEBUG   ] __main__                       : openrgb-python : 0.2.15
[DEBUG   ] __main__                       : packaging : 23.0
[DEBUG   ] __main__                       : paho-mqtt : 1.5.1
[DEBUG   ] __main__                       : pip : 22.3.1
[DEBUG   ] __main__                       : psutil : 5.9.4
[DEBUG   ] __main__                       : pycparser : 2.21
[DEBUG   ] __main__                       : pypiwin32 : 223
[DEBUG   ] __main__                       : pyserial : 3.5
[DEBUG   ] __main__                       : pystray : 0.19.4
[DEBUG   ] __main__                       : python-rtmidi : 1.4.9
[DEBUG   ] __main__                       : pytz : 2022.7.1
[DEBUG   ] __main__                       : pywin32 : 305
[DEBUG   ] __main__                       : requests : 2.24.0
[DEBUG   ] __main__                       : sacn : 1.6.4
[DEBUG   ] __main__                       : samplerate : 0.1.0
[DEBUG   ] __main__                       : sentry-sdk : 1.4.3
[DEBUG   ] __main__                       : setuptools : 65.5.0
[DEBUG   ] __main__                       : setuptools-scm : 7.1.0
[DEBUG   ] __main__                       : six : 1.16.0
[DEBUG   ] __main__                       : snakeviz : 2.1.1
[DEBUG   ] __main__                       : sounddevice : 0.4.5
[DEBUG   ] __main__                       : stdlib-list : 0.8.0
[DEBUG   ] __main__                       : tcp-latency : 0.0.12
[DEBUG   ] __main__                       : tornado : 6.2
[DEBUG   ] __main__                       : twilio : 7.16.5
[DEBUG   ] __main__                       : typing-extensions : 4.4.0
[DEBUG   ] __main__                       : urllib3 : 1.25.11
[DEBUG   ] __main__                       : voluptuous : 0.12.2
[DEBUG   ] __main__                       : win32-setctime : 1.1.0
[DEBUG   ] __main__                       : yappi : 1.4.0
[DEBUG   ] __main__                       : yarl : 1.8.1
[DEBUG   ] __main__                       : zeroconf : 0.47.3
