### PR TITLE
Fix WLED named devices not rendering in browser

### DIFF
--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -619,7 +619,7 @@ class Devices(RegistryLoader):
             await device.async_initialize()
 
         device_config = device.config
-
+        device_config["name"] = wled_name
         # Update and save the configuration
         self._ledfx.config["devices"].append(
             {


### PR DESCRIPTION
If you have he default "WLED" server name in WLED / Settings / User interface / Server Description existing code mangles this name with the last 6 digits of the mac address for differentiation. however, async update of the device details loses the mangle. The side effect is that although all effects work right to the light stirp there is no rendered effect in the browser.

Can't fully explain why just reapplying the mangled name where I do works, but I can't break it. Tried some other approaches and none of them worked!

Reapply the mangled name post async_initialise to ensure it is passed into device config and in the creation of the virtual.

Just trying in virtual only was not successful, must be re-applied before appending the device config. Displayed name is the mangled name

Tested with adding device with other names, all works Tested with adding WLED, gets mangled and all works Changed displayed name via settings, still all works

Can't break it, can't quite explain the full detail and what the async is doing