### PR TITLE
General clean

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@
     pyserial~=3.5
     pystray>=0.17
     python-rtmidi~=1.4.9
-    requests~=2.24.0
+    requests~=2.28.2
     sacn~=1.6.3
     sentry-sdk==1.14.0
     samplerate>=0.1.0

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,9 @@ INSTALL_REQUIRES = [
     "pyserial>=3.5",
     "pystray>=0.17",
     "pyupdater>=3.1.0",
-    "requests>=2.24.0",
+    "requests~=2.28.2",
     "sacn~=1.6.3",
-    "sentry-sdk~=1.4.3",
+    "sentry-sdk==1.14.0",
     "sounddevice~=0.4.2",
     "samplerate>=0.1.0",
     "icmplib~=3.0.3",
@@ -51,7 +51,7 @@ INSTALL_REQUIRES = [
     'uvloop>=0.16.0; platform_system != "Windows"',
     # We can install this on all linux devices, it just won't work for anything other than a Pi
     'rpi-ws281x>=4.3.0; platform_system == "Linux"',
-    "flux-led>=0.28.36",
+    "flux-led>=0.28.35",
 ]
 
 


### PR DESCRIPTION
remover warning by upgrading requests

C:\Users\xxx\AppData\Local\Programs\Python\Python311\Lib\site-packages\requestsinit.py:89: RequestsDependencyWarning: urllib3 (1.26.15) or chardet (3.0.4) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({}) doesn't match a supported "

Match some versions in setup.py to requirements.txt