### PR TITLE
Fix crash on less that 4 pixels and blur

### DIFF
--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -355,6 +355,8 @@ class Effect(BaseRegistry):
                 casting="unsafe",
             )
         # If the configured blur is greater than 0 we need to blur it
+        # do not apply blur if we have 3 or less pixels as the matrix math
+        # demands it!
         if self.configured_blur != 0.0 and self.pixel_count > 3:
             kernel = _gaussian_kernel1d(self.configured_blur, 0, len(pixels))
             pixels[:, 0] = np.convolve(pixels[:, 0], kernel, mode="same")

--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -355,7 +355,7 @@ class Effect(BaseRegistry):
                 casting="unsafe",
             )
         # If the configured blur is greater than 0 we need to blur it
-        if self.configured_blur != 0.0:
+        if self.configured_blur != 0.0 and self.pixel_count > 3:
             kernel = _gaussian_kernel1d(self.configured_blur, 0, len(pixels))
             pixels[:, 0] = np.convolve(pixels[:, 0], kernel, mode="same")
             pixels[:, 1] = np.convolve(pixels[:, 1], kernel, mode="same")


### PR DESCRIPTION
Just don't run blur when we don't have enough pixels

Tested against virtuals with 1,2,3 and 4 pixels.

Would crash before, now does not