### PR TITLE
Fix failing CI builds due to aubio build failure

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,6 +25,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Build a binary wheel
         run: |
+          python -m pip install numpy --compile --pre
           python -m pip install --user -U pip wheel setuptools
           python setup.py bdist_wheel
       - name: Install LedFx
@@ -47,6 +48,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Build a binary wheel
         run: |
+          python -m pip install numpy --compile --pre
           python -m pip install --user -U pip wheel setuptools
           python setup.py bdist_wheel
       - name: Install LedFx
@@ -101,5 +103,4 @@ jobs:
 #           yarn build
 #         env:
 #           CI: true
-
 


### PR DESCRIPTION
Add numpy install to actions for windows and ubuntu to match working OSX
aubio build failure fallback has been removed from PIP so our builds started failing