### PR TITLE
Make bokeh graph support run time dependant

### DIFF
--- a/ledfx/devices/nanoleaf.py
+++ b/ledfx/devices/nanoleaf.py
@@ -66,7 +66,7 @@ class NanoleafDevice(NetworkedDevice):
 
     def activate(self):
         if self.config["sync_mode"] == "UDP":
-            _LOGGER.info(f"Activating UDP stream mode...")
+            _LOGGER.info("Activating UDP stream mode...")
             payload = {
                 "write": {
                     "command": "display",
@@ -159,7 +159,7 @@ class NanoleafDevice(NetworkedDevice):
             self.write_udp()
 
     def get_token(self):
-        _LOGGER.info(f"acquiring nanoleaf auth token...")
+        _LOGGER.info("acquiring nanoleaf auth token...")
         response = requests.post(self.url("new"))
 
         if response and response.status_code == 200:
@@ -185,7 +185,7 @@ class NanoleafDevice(NetworkedDevice):
         ).json()
 
         _LOGGER.debug(f"nanoleaf config response: {nanoleaf_config}")
-        _LOGGER.info(f"parsing panel layout...")
+        _LOGGER.info("parsing panel layout...")
 
         panels = [
             {"x": i["x"], "y": i["y"], "panelId": i["panelId"]}

--- a/ledfx/effects/metro.py
+++ b/ledfx/effects/metro.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 
 from ledfx.color import parse_color, validate_color
 from ledfx.effects.audio import AudioReactiveEffect
-from ledfx.utils import Graph
+from ledfx.utils import Graph, bokeh_available
 
 # Metro intent is to flash a pattern on led strips so end users can look for
 # sync between separate light strips due to protocol, wifi conditions or other
@@ -18,7 +18,9 @@ from ledfx.utils import Graph
 class MetroEffect(AudioReactiveEffect):
     NAME = "Metro"
     CATEGORY = "Diagnostic"
-    HIDDEN_KEYS = ["background_brightness", "blur", "mirror", "capture"]
+    HIDDEN_KEYS = ["background_brightness", "blur", "mirror"]
+    if not bokeh_available:
+        HIDDEN_KEYS.append("capture")
 
     start_time = timeit.default_timer()
 

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -26,16 +26,20 @@ import voluptuous as vol
 
 from ledfx.config import save_config
 
-# UNCOMMENT TO ENABLE BOKEH GRAPHING ALONG WITH FUNCTION dump_graph()
-# from bokeh.io import output_file, show
-# from bokeh.layouts import column
-# from bokeh.models import Label
-# from bokeh.palettes import Category10
-# from bokeh.plotting import figure
-# from itertools import cycle
-# from ledfx.config import get_default_config_directory
-
 # from asyncio import coroutines, ensure_future
+
+try:
+    from bokeh.io import output_file, show
+    from bokeh.layouts import column
+    from bokeh.models import Label
+    from bokeh.palettes import Category10
+    from bokeh.plotting import figure
+    from itertools import cycle
+    from ledfx.config import get_default_config_directory
+    bokeh_available = True
+except ImportError:
+    bokeh_available = False
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1047,113 +1051,109 @@ class Graph:
             jitter (bool): If true, will dump the jitter graph
             only_jitter (bool): If true, will only dump the jitter graph
         """
-        # THIS CODE HAS BEEN STUBBED TO REMOVE BOKEH DEPENDENCY
+        if not bokeh_available:
+            _LOGGER.info("Bokeh is disabled dump is disabled")
+        else:
+            if sub_title:
+                compound = f"{self.title} : {sub_title}"
+            else:
+                compound = self.title
 
-        _LOGGER.info("Bokeh is disabled dump is disabled")
+            _LOGGER.info(f"Attempting to dump graph {compound}")
+            TOOLS = "xpan,xwheel_zoom,box_zoom,reset,save,box_select"
+            colors = cycle(Category10[10])
 
-        # UNCOMMENT ALL FOLLOW CODE TO ENABLE BOKEH GRAPHING
-        # ALSO ENABLE THE import sectoin at the top of this file
+            vals_fig = figure(
+                title=compound,
+                x_axis_label="sec since start",
+                y_axis_label=self.y_title,
+                tools=TOOLS,
+                active_scroll="xwheel_zoom",
+                width=1200,
+                height=600,
+            )
 
-        # if sub_title:
-        #     compound = f"{self.title} : {sub_title}"
-        # else:
-        #     compound = self.title
-        #
-        # _LOGGER.info(f"Attempting to dump graph {compound}")
-        # TOOLS = "xpan,xwheel_zoom,box_zoom,reset,save,box_select"
-        # colors = cycle(Category10[10])
-        #
-        # vals_fig = figure(
-        #     title=compound,
-        #     x_axis_label="sec since start",
-        #     y_axis_label=self.y_title,
-        #     tools=TOOLS,
-        #     active_scroll="xwheel_zoom",
-        #     width=1200,
-        #     height=600,
-        # )
-        #
-        # for a_range in self.ranges.values():
-        #     if len(a_range.list_x()) > 0:
-        #         vals_fig.line(
-        #             a_range.list_x(),
-        #             a_range.list_y(),
-        #             legend_label=a_range.key,
-        #             line_width=2,
-        #             color=next(colors),
-        #         )
-        #
-        # for tag in self.tags:
-        #     label = Label(
-        #         x=tag.x,
-        #         y=tag.y,
-        #         text=tag.text,
-        #         text_font_size="12pt",
-        #         text_color=tag.color,
-        #         angle=1.57,
-        #     )
-        #     vals_fig.add_layout(label)
-        #
-        # if self.y_axis_max is not None:
-        #     vals_fig.y_range.end = self.y_axis_max
-        #
-        # vals_fig.legend.click_policy = "hide"
-        #
-        # if jitter or only_jitter:
-        #     jitter_title = f"{compound} jitter"
-        #
-        #     jitter_fig = figure(
-        #         title=jitter_title,
-        #         x_axis_label="sec since start",
-        #         x_range=vals_fig.x_range,
-        #         y_axis_label="periodic secs",
-        #         tools=TOOLS,
-        #         active_scroll="xwheel_zoom",
-        #         width=1200,
-        #         height=600,
-        #     )
-        #
-        #     for a_range in self.ranges.values():
-        #         # Calculte jitter for range x and prestuff so len is same
-        #         # don't use numpy due to some side effects
-        #         x = a_range.list_x()
-        #         if len(x) > 0:
-        #             jitter = [x[i + 1] - x[i] for i in range(len(x) - 1)]
-        #             jitter.insert(0, 0.0)
-        #             jitter_fig.circle(
-        #                 a_range.list_x(),
-        #                 jitter,
-        #                 legend_label=a_range.key,
-        #                 size=3,
-        #                 color=next(colors),
-        #             )
-        #
-        #     for tag in self.tags:
-        #         label = Label(
-        #             x=tag.x,
-        #             y=0.001,
-        #             text=tag.text,
-        #             text_font_size="12pt",
-        #             text_color=tag.color,
-        #             angle=1.57,
-        #             text_baseline="middle",
-        #         )
-        #
-        #         jitter_fig.add_layout(label)
-        #
-        #     jitter_fig.legend.click_policy = "hide"
-        #
-        # # work out layour according to requested graphs
-        # if only_jitter:
-        #     p = column(jitter_fig)
-        # elif jitter:
-        #     p = column(vals_fig, jitter_fig)
-        # else:
-        #     p = column(vals_fig)
-        #
-        # save_as = os.path.join(
-        #     get_default_config_directory(),
-        #     f"{re.sub('[^A-Za-z0-9]+', '_', compound)}.html",
-        # )
-        # output_file(filename=save_as, title=compound)
-        # show(p)
+            for a_range in self.ranges.values():
+                if len(a_range.list_x()) > 0:
+                    vals_fig.line(
+                        a_range.list_x(),
+                        a_range.list_y(),
+                        legend_label=a_range.key,
+                        line_width=2,
+                        color=next(colors),
+                    )
+
+            for tag in self.tags:
+                label = Label(
+                    x=tag.x,
+                    y=tag.y,
+                    text=tag.text,
+                    text_font_size="12pt",
+                    text_color=tag.color,
+                    angle=1.57,
+                )
+                vals_fig.add_layout(label)
+
+            if self.y_axis_max is not None:
+                vals_fig.y_range.end = self.y_axis_max
+
+            vals_fig.legend.click_policy = "hide"
+
+            if jitter or only_jitter:
+                jitter_title = f"{compound} jitter"
+
+                jitter_fig = figure(
+                    title=jitter_title,
+                    x_axis_label="sec since start",
+                    x_range=vals_fig.x_range,
+                    y_axis_label="periodic secs",
+                    tools=TOOLS,
+                    active_scroll="xwheel_zoom",
+                    width=1200,
+                    height=600,
+                )
+
+                for a_range in self.ranges.values():
+                    # Calculte jitter for range x and prestuff so len is same
+                    # don't use numpy due to some side effects
+                    x = a_range.list_x()
+                    if len(x) > 0:
+                        jitter = [x[i + 1] - x[i] for i in range(len(x) - 1)]
+                        jitter.insert(0, 0.0)
+                        jitter_fig.circle(
+                            a_range.list_x(),
+                            jitter,
+                            legend_label=a_range.key,
+                            size=3,
+                            color=next(colors),
+                        )
+
+                for tag in self.tags:
+                    label = Label(
+                        x=tag.x,
+                        y=0.001,
+                        text=tag.text,
+                        text_font_size="12pt",
+                        text_color=tag.color,
+                        angle=1.57,
+                        text_baseline="middle",
+                    )
+
+                    jitter_fig.add_layout(label)
+
+                jitter_fig.legend.click_policy = "hide"
+
+            # work out layour according to requested graphs
+            if only_jitter:
+                p = column(jitter_fig)
+            elif jitter:
+                p = column(vals_fig, jitter_fig)
+            else:
+                p = column(vals_fig)
+
+            save_as = os.path.join(
+                get_default_config_directory(),
+                f"{re.sub('[^A-Za-z0-9]+', '_', compound)}.html",
+            )
+            output_file(filename=save_as, title=compound)
+            show(p)


### PR DESCRIPTION
Far more graceful disable of Bokeh graphing.

If the lib elements are not available to import at program start, try / except and set bokeh_available accordingly

In the Metro example that uses the graphing capability, if bokeh is NOT available, hide the capture button

To support bokeh graphs, simply pip install bokeh on a need basis...profit...

Tested by running with bokeh not in my virtual env, then with bokeh present, and removing again. Ensure it behaves as expected.

Also remove flake8 fails from nanoleaf