### PR TITLE
rtmidi bump to 1.5.1

### DIFF
--- a/ledfx/devices/nanoleaf.py
+++ b/ledfx/devices/nanoleaf.py
@@ -66,7 +66,7 @@ class NanoleafDevice(NetworkedDevice):
 
     def activate(self):
         if self.config["sync_mode"] == "UDP":
-            _LOGGER.info(f"Activating UDP stream mode...")
+            _LOGGER.info("Activating UDP stream mode...")
             payload = {
                 "write": {
                     "command": "display",
@@ -159,7 +159,7 @@ class NanoleafDevice(NetworkedDevice):
             self.write_udp()
 
     def get_token(self):
-        _LOGGER.info(f"acquiring nanoleaf auth token...")
+        _LOGGER.info("acquiring nanoleaf auth token...")
         response = requests.post(self.url("new"))
 
         if response and response.status_code == 200:
@@ -185,7 +185,7 @@ class NanoleafDevice(NetworkedDevice):
         ).json()
 
         _LOGGER.debug(f"nanoleaf config response: {nanoleaf_config}")
-        _LOGGER.info(f"parsing panel layout...")
+        _LOGGER.info("parsing panel layout...")
 
         panels = [
             {"x": i["x"], "y": i["y"], "panelId": i["panelId"]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@
     psutil>=5.8.0
     pyserial~=3.5
     pystray>=0.17
-    python-rtmidi~=1.4.9
+    python-rtmidi~=1.5.0
     requests~=2.28.2
     sacn~=1.6.3
     sentry-sdk==1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@
     psutil>=5.8.0
     pyserial~=3.5
     pystray>=0.17
-    python-rtmidi~=1.5.0
+    python-rtmidi~=1.5.1
     requests~=2.28.2
     sacn~=1.6.3
     sentry-sdk==1.14.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ INSTALL_REQUIRES = [
     "psutil>=5.8.0",
     "pyserial>=3.5",
     "pystray>=0.17",
-    "python-rtmidi~=1.5.0",
+    "python-rtmidi~=1.5.1",
     "requests~=2.28.2",
     "sacn~=1.6.3",
     "sentry-sdk==1.14.0",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ INSTALL_REQUIRES = [
     "psutil>=5.8.0",
     "pyserial>=3.5",
     "pystray>=0.17",
-    "python-rtmidi~=1.4.9",
+    "python-rtmidi~=1.5.0",
     "requests~=2.28.2",
     "sacn~=1.6.3",
     "sentry-sdk==1.14.0",


### PR DESCRIPTION
bump rtmidi to 1.5.1 to pick up post fixes from rtmidi team for breakage in windows in 1.5.0

Originally intended to address

https://github.com/SpotlightKid/python-rtmidi/issues/115

Resolve build from source issues in 3.11 on MacOS

Was blocked on missing bin for windows in rtmidi 1.5.0 see https://github.com/SpotlightKid/python-rtmidi/issues/150

Tested good on 1.5.1 for windows with launchpad

Simply did not work on 1.5.0