### PR TITLE
add rest endpoint for find_openrgb and find_launchpad

### DIFF
--- a/ledfx/api/find_launchpad.py
+++ b/ledfx/api/find_launchpad.py
@@ -25,7 +25,7 @@ class FindLaunchpadDevicesEndpoint(RestEndpoint):
             return web.json_response(data=response, status=500)
 
         if found is None:
-            _LOGGER.error(f"Failed to find launchpad")
+            _LOGGER.error("Failed to find launchpad")
             response = {"status": "error", "error": "Failed to find launchpad"}
             return web.json_response(data=response, status=500)
 

--- a/ledfx/api/find_launchpad.py
+++ b/ledfx/api/find_launchpad.py
@@ -1,0 +1,34 @@
+import logging
+
+from aiohttp import web
+from ledfx.devices.launchpad_lib import LaunchpadBase
+
+from ledfx.api import RestEndpoint
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class FindLaunchpadDevicesEndpoint(RestEndpoint):
+    """REST end-point for detecting and reporting Launchpad device"""
+
+    ENDPOINT_PATH = "/api/find_launchpad"
+
+    async def get(self, request) -> web.Response:
+        """Check for launchpad present"""
+
+        try:
+            lp = LaunchpadBase()
+            found = lp.find_launchpad()
+        except Exception as e:
+            _LOGGER.error(f"Error in checking for launchpad: {e}")
+            response = {"status": "error", "error": str(e)}
+            return web.json_response(data=response, status=500)
+
+        if found is None:
+            _LOGGER.error(f"Failed to find launchpad")
+            response = {"status": "error", "error": "Failed to find launchpad"}
+            return web.json_response(data=response, status=500)
+
+        _LOGGER.info(f"Found launchpad: {found}")
+        response = {"status": "success", "device": found}
+        return web.json_response(data=response, status=200)

--- a/ledfx/api/find_openrgb.py
+++ b/ledfx/api/find_openrgb.py
@@ -9,20 +9,30 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class FindOpenRGBDevicesEndpoint(RestEndpoint):
-    """REST end-point for detecting and reporting OpenRGB devices"""
+    """REST end-point for detecting and reporting OpenRGB devices
+       optional params for server and port"""
 
     ENDPOINT_PATH = "/api/find_openrgb"
 
-    async def post(self) -> web.Response:
+    async def get(self, request) -> web.Response:
         """Check for an openrgb server and report devices"""
+
+        if "server" in request.query.keys():
+            server = request.query["server"]
+        else:
+            server = "127.0.0.1"
+
+        if "port" in request.query.keys():
+            port = int(request.query["port"])
+        else:
+            port = 6742
+
         try:
-            client = OpenRGBClient()
+            client = OpenRGBClient(address=server, port=port)
         except Exception as e:
             _LOGGER.error(f"Failed to connect to OpenRGB server: {e}")
             response = {"status": "error", "error": str(e)}
             return web.json_response(data=response, status=500)
-
-        print(client.devices)
 
         devices = []
         for device in client.devices:

--- a/ledfx/api/find_openrgb.py
+++ b/ledfx/api/find_openrgb.py
@@ -27,10 +27,7 @@ class FindOpenRGBDevicesEndpoint(RestEndpoint):
         devices = []
         for device in client.devices:
             devices.append(
-                {
-                    "name": device.name,
-                    "type": device.type,
-                }
+                {"name": device.name, "type": device.type, "id": device.id}
             )
         response = {"status": "success", "devices": devices}
         return web.json_response(data=response, status=200)

--- a/ledfx/api/find_openrgb.py
+++ b/ledfx/api/find_openrgb.py
@@ -27,7 +27,13 @@ class FindOpenRGBDevicesEndpoint(RestEndpoint):
         devices = []
         for device in client.devices:
             devices.append(
-                {"name": device.name, "type": device.type, "id": device.id}
+                {
+                    "name": device.name,
+                    "type": device.type,
+                    "id": device.id,
+                    "leds": len(device.leds)
+                }
             )
+
         response = {"status": "success", "devices": devices}
         return web.json_response(data=response, status=200)

--- a/ledfx/api/find_openrgb.py
+++ b/ledfx/api/find_openrgb.py
@@ -1,0 +1,36 @@
+import logging
+
+from aiohttp import web
+from openrgb import OpenRGBClient
+
+from ledfx.api import RestEndpoint
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class FindOpenRGBDevicesEndpoint(RestEndpoint):
+    """REST end-point for detecting and reporting OpenRGB devices"""
+
+    ENDPOINT_PATH = "/api/find_openrgb"
+
+    async def post(self) -> web.Response:
+        """Check for an openrgb server and report devices"""
+        try:
+            client = OpenRGBClient()
+        except Exception as e:
+            _LOGGER.error(f"Failed to connect to OpenRGB server: {e}")
+            response = {"status": "error", "error": str(e)}
+            return web.json_response(data=response, status=500)
+
+        print(client.devices)
+
+        devices = []
+        for device in client.devices:
+            devices.append(
+                {
+                    "name": device.name,
+                    "type": device.type,
+                }
+            )
+        response = {"status": "success", "devices": devices}
+        return web.json_response(data=response, status=200)

--- a/ledfx/devices/launchpad_lib.py
+++ b/ledfx/devices/launchpad_lib.py
@@ -57,6 +57,7 @@ class RtmidiWrap:
                         )
                         continue
                     for port, pname in enumerate(ports):
+                        _LOGGER.info(f"SearchDevices: {port} {pname}")
                         if str(pname.lower()).find(name.lower()) >= 0:
                             _LOGGER.info(f"{port} {pname}")
                             ret.append(port)

--- a/ledfx/devices/launchpad_lib.py
+++ b/ledfx/devices/launchpad_lib.py
@@ -243,6 +243,19 @@ class LaunchpadBase:
     def EventRaw(self):
         return self.midi.ReadRaw()
 
+    def find_launchpad(self)->str:
+        if self.Check(0, "mk2"):
+            return "Launchpad Mk2"
+        elif self.Check(1, "minimk3"):
+            return "Launchpad Mini Mk3"
+        elif self.Check(0, "pad pro"):
+            return "Launchpad Pro"
+        elif self.Check(0, "promk3"):
+            return "Launchpad Pro Mk3"
+        elif self.Check(1, "Launchpad X") or self.Check(1, "LPX"):
+            return "Launchpad X"
+        return None
+
 
 # ==========================================================================
 # CLASS Launchpad


### PR DESCRIPTION
find_openrgb

Optional params added to override default server:port of localhost:6742

Bare call will just query the local server

```GET http://localhost:8888/api/find_openrgb```

To override server and / or port use

```GET http://localhost:8888/api/find_openrgb?server=1.2.3.4&port=5678```

Response on no server running

```
{
    "status": "error",
    "error": "timed out"
}
```

Response on Server found but no devices

```
{
    "status": "success",
    "devices": []
}
```

response with devices
```
{
    "status": "success",
    "devices": [
        {
            "name": "ASRock Z370 Gaming K6",
            "type": 0,
            "id": 0,
            "leds": 1
        },
        {
            "name": "ASUS ROG STRIX 3080 O10G V2 WHITE",
            "type": 2,
            "id": 1,
            "leds": 22
        },
        {
            "name": "Razer Deathadder V2",
            "type": 6,
            "id": 2,
            "leds": 2
        }
    ]
}
```

find_launchpad

```
GET http://localhost:8888/api/find_launchpad
```

response when no launchpad present

```
{
    "status": "error",
    "error": "Failed to find launchpad"
}
```

response when launchpad found
```
{
    "status": "success",
    "device": "Launchpad X"
}
```