### PR TITLE
More sustainable launchpad support part 1

### DIFF
--- a/ledfx/api/find_launchpad.py
+++ b/ledfx/api/find_launchpad.py
@@ -3,7 +3,7 @@ import logging
 from aiohttp import web
 
 from ledfx.api import RestEndpoint
-from ledfx.devices.launchpad_lib import LaunchpadBase
+from ledfx.devices.launchpad import find_launchpad
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -17,8 +17,7 @@ class FindLaunchpadDevicesEndpoint(RestEndpoint):
         """Check for launchpad present"""
 
         try:
-            lp = LaunchpadBase()
-            found = lp.find_launchpad()
+            found = find_launchpad()
         except Exception as e:
             _LOGGER.error(f"Error in checking for launchpad: {e}")
             response = {"status": "error", "error": str(e)}

--- a/ledfx/devices/launchpad.py
+++ b/ledfx/devices/launchpad.py
@@ -57,14 +57,18 @@ launchpads = [
 ]
 
 
-def find_launchpad() -> str:
+def find_launchpad() -> dict:
     lp = launchpad.LaunchpadBase()
     for pad in launchpads:
         _LOGGER.info(
             f"Searching for {pad['name']} on {pad['number']} with {pad['search']}"
         )
         if lp.Check(pad["number"], pad["search"]):
-            return pad["name"]
+            lp = pad["class"]
+            result = lp.layout
+            result["name"] = pad["name"]
+            result["segments"] = lp.segments
+            return result
     return None
 
 

--- a/ledfx/devices/launchpad.py
+++ b/ledfx/devices/launchpad.py
@@ -11,6 +11,56 @@ from ledfx.devices import MidiDevice
 
 _LOGGER = logging.getLogger(__name__)
 
+launchpads = [
+    {
+        "name": "Launchpad Mk2",
+        "search": "mk2",
+        "number": 0,
+        "class": launchpad.LaunchpadMk2(),
+    },
+    {
+        "name": "Launchpad Mini Mk3",
+        "search": "minimk3",
+        "number": 1,
+        "class": launchpad.LaunchpadMiniMk3(),
+    },
+    {
+        "name": "Launchpad Pro",
+        "search": "pad pro",
+        "number": 0,
+        "class": launchpad.LaunchpadPro(),
+    },
+    {
+        "name": "Launchpad Pro Mk3",
+        "search": "promk3",
+        "number": 0,
+        "class": launchpad.LaunchpadProMk3(),
+    },
+    {
+        "name": "Launchpad X",
+        "search": "launchpad X",
+        "number": 1,
+        "class": launchpad.LaunchpadLPX(),
+    },
+    {
+        "name": "Launchpad X",
+        "search": "LPX",
+        "number": 1,
+        "class": launchpad.LaunchpadLPX(),
+    },
+]
+
+
+def find_launchpad() -> str:
+    lp = launchpad.LaunchpadBase()
+    for pad in launchpads:
+        _LOGGER.info(
+            f"Searching for {pad['name']} on {pad['number']} with {pad['search']}"
+        )
+        if lp.Check(pad["number"], pad["search"]):
+            return pad["name"]
+    return None
+
 
 def dump_methods(instance):
     # List the class's methods
@@ -57,11 +107,9 @@ class LaunchpadDevice(MidiDevice):
     def __init__(self, ledfx, config):
         super().__init__(ledfx, config)
         self.lp = None
-        self.flush_launchpad = None
 
     def flush(self, data):
-        if self.flush_launchpad:
-            self.flush_launchpad(data)
+        self.lp.flush(data)
 
     def activate(self):
         self.lp = launchpad.Launchpad()
@@ -69,7 +117,7 @@ class LaunchpadDevice(MidiDevice):
         super().activate()
 
     def deactivate(self):
-        self.flush_launchpad(zeros((self.pixel_count, 3)))
+        self.lp.flush(zeros((self.pixel_count, 3)))
         self.lp.Close()
         self.lp = None
         super().deactivate()
@@ -77,168 +125,22 @@ class LaunchpadDevice(MidiDevice):
     async def add_postamble(self):
         _LOGGER.info("Doing post creation things for LP...")
         if self.config["create_segments"]:
-            # Generate virtuals for segments
-            self.sub_v("TopBar", "mdi:table-row", [[72, 79]], 1)
-            self.sub_v("Logo", "launchpad", [[80, 80]], 1)
-            self.sub_v(
-                "RightBar",
-                "mdi:table-column",
-                [
-                    [8, 8],
-                    [17, 17],
-                    [26, 26],
-                    [35, 35],
-                    [44, 44],
-                    [53, 53],
-                    [62, 62],
-                    [71, 71],
-                ],
-                1,
-            )
-            self.sub_v(
-                "Matrix",
-                "mdi:grid",
-                [
-                    [0, 7],
-                    [9, 16],
-                    [18, 25],
-                    [27, 34],
-                    [36, 43],
-                    [45, 52],
-                    [54, 61],
-                    [63, 70],
-                ],
-                8,
+            for segment in self.lp.segments:
+                self.sub_v(segment)
+
+    def validate_launchpad(self) -> str:
+        for pad in launchpads:
+            _LOGGER.info(
+                f"Validating {pad['name']} on {pad['number']} with {pad['search']}"
             )
 
-    # Need a flush variant for each supported Launchpad, and assign in validate
-    def flush_launchpadLPX(self, data):
-        try:
-            # we will use RawWriteSysEx(self, lstMessage, timeStamp=0)
-            # this function adds the preamble 240 and post amble 247
-            #
-            # This message can be sent to Lighting Custom Modes and the Programmer mode
-            # to light up LEDs. The LED indices used always correspond to those of
-            # Programmer mode, regardless of the layout selected:
-            #
-            # Host => Launchpad X:
-            # Hex: F0h 00h 20h 29h 02h 0Ch 03h <colourspec> [<colourspec> […]] F7h
-            # Dec: 240 0   32  41  2   12   3  <colourspec> [<colourspec> […]] 247
-            #
-            # the <colourspec> is structured as follows:
-            # - Lighting type (1 byte)
-            # - LED index (1 byte)  ---- WARNING, each row starts at 11, 21, 31 etc
-            # - Lighting data (1 – 3 bytes)
-            # Lighting types:
-            # - 0: Static colour from palette 1 byte specifying palette entry.
-            # - 1: Flashing colour, 2 bytes specifying Colour B and Colour A.
-            # - 2: Pulsing colour, 1 byte specifying palette entry.
-            # - 3: RGB colour, 3 bytes for Red, Green and Blue (127: Max, 0: Min).
-            #
-            # The message may contain up to 81 <colourspec> entries to light up the entire
-            # Launchpad X surface.
-            # Example:
-
-            # Host => Launchpad X:
-            # Hex: F0h 00h 20h 29h 02h 0Ch 03h 00h 0Bh 0Dh 01h 0Ch 15h 17h 02h 0Dh 25h F7h
-            # Dec: 240  0  32  41   2  12   3   0  11  13   1  12  21  23   2  13  37  247
-            #
-            # Sending this message to the Launchpad X in Programmer layout sets up the
-            # bottom left pad to static yellow, the pad next to it to flashing green
-            # (between dim and bright green), and the pad next to that pulsing turquoise
-            #
-            # in summary
-            # [ 3 = RGB, Pos = layout BE CAREFUL, R,G, B max 127 ]
-            # example of send RED pixel at row 3 pixel 6
-            # send_buffer.extend([3, 35, 127, 0, 0])
-
-            #            start = timeit.default_timer()
-
-            # stuff the send buffer with the command preamble
-            send_buffer = [0, 32, 41, 2, 12, 3]
-
-            # prebump the programmer mode index up a row and just before
-            pgm_mode_pos = 10
-            for idx, pixel in enumerate(data):
-                # check for row bumps, position is specific to programmer mode
-                if idx % 9 == 0:
-                    pgm_mode_pos += 1
-                send_buffer.extend(
-                    [
-                        3,
-                        pgm_mode_pos,
-                        max(min(int(pixel[0] // 2), 127), 0),
-                        max(min(int(pixel[1] // 2), 127), 0),
-                        max(min(int(pixel[2] // 2), 127), 0),
-                    ]
-                )
-                pgm_mode_pos += 1
-            self.lp.midi.RawWriteSysEx(send_buffer)
-            # took = timeit.default_timer() - start
-            # _LOGGER.info(f"Updated Pixels: {took} ")
-
-        except RuntimeError:
-            _LOGGER.error("Error in LaunchpadLPX handling")
-
-    def validate_launchpad(self):
-        # try the first Mk2
-        if self.lp.Check(0, "mk2"):
-            self.lp = launchpad.LaunchpadMk2()
-            if self.lp.Open(0, "mk2"):
-                _LOGGER.info(" - Launchpad Mk2: OK")
-                self.flush_launchpad = None  # replace with flush_launchpadMk2
-            else:
-                _LOGGER.error(" - Launchpad Mk2: ERROR")
-                return
-
-        # try the first Mini Mk3
-        elif self.lp.Check(1, "minimk3"):
-            self.lp = launchpad.LaunchpadMiniMk3()
-            if self.lp.Open(1, "minimk3"):
-                _LOGGER.info(" - Launchpad Mini Mk3: OK")
-                self.flush_launchpad = None  # replace with flush_launchpadMk3
-            else:
-                _LOGGER.error(" - Launchpad Mini Mk3: ERROR")
-                return
-
-        # try the first Pro
-        elif self.lp.Check(0, "pad pro"):
-            self.lp = launchpad.LaunchpadPro()
-            if self.lp.Open(0, "pad pro"):
-                _LOGGER.info(" - Launchpad Pro: OK")
-                self.flush_launchpad = None  # replace with flush_launchpadPro
-            else:
-                _LOGGER.error(" - Launchpad Pro: ERROR")
-                return
-
-        # try the first Pro Mk3
-        elif self.lp.Check(0, "promk3"):
-            self.lp = launchpad.LaunchpadProMk3()
-            if self.lp.Open(0):
-                _LOGGER.info(" - Launchpad Pro Mk3: OK")
-                self.flush_launchpad = (
-                    None  # replace with flush_launchpadProMk3
-                )
-            else:
-                _LOGGER.error(" - Launchpad Pro Mk3: ERROR")
-                return
-
-        # try the first X
-        # Notice that this is already built-in in the LPX class' methods Check() and Open,
-        # but we're using the one from above!
-        elif self.lp.Check(1, "Launchpad X") or self.lp.Check(1, "LPX"):
-            self.lp = launchpad.LaunchpadLPX()
-            # Open() includes looking for "LPX" and "Launchpad X"
-            if self.lp.Open(1):
-                _LOGGER.info(" - Launchpad X: OK")
-                self.flush_launchpad = self.flush_launchpadLPX
-            else:
-                _LOGGER.error(" - Launchpad X: ERROR")
-                self.flush_launchpad = None
-                return
-
-        # nope
-        else:
-            _LOGGER.error(" - No Launchpad available")
-            self.flush_launchpad = None
-            return
+            if self.lp.Check(pad["number"], pad["search"]):
+                self.lp = pad["class"]
+                if self.lp.Open(pad["number"], pad["search"]):
+                    _LOGGER.info(f" - {pad['name']}: OK")
+                    return pad["name"]
+                else:
+                    _LOGGER.error(f" - {pad['name']}: ERROR")
+                    return None
+        _LOGGER.error(" validate - No Launchpad available")
+        return None

--- a/ledfx/devices/launchpad_lib.py
+++ b/ledfx/devices/launchpad_lib.py
@@ -45,6 +45,11 @@ class RtmidiWrap:
     def SearchDevices(self, name, output=True, input=True, quiet=True):
         ret = []
         available_apis = rtmidi.get_compiled_api()
+        _LOGGER.info("TEMP MIDI DEBUG-----------")
+        _LOGGER.info(self.apis.items())
+        _LOGGER.info(available_apis)
+        _LOGGER.info("TEMP MIDI DEBUG END-------")
+
         for api, api_name in sorted(self.apis.items()):
             if api in available_apis:
                 if output:

--- a/ledfx/devices/launchpad_lib.py
+++ b/ledfx/devices/launchpad_lib.py
@@ -244,19 +244,6 @@ class LaunchpadBase:
     def EventRaw(self):
         return self.midi.ReadRaw()
 
-    def find_launchpad(self) -> str:
-        if self.Check(0, "mk2"):
-            return "Launchpad Mk2"
-        elif self.Check(1, "minimk3"):
-            return "Launchpad Mini Mk3"
-        elif self.Check(0, "pad pro"):
-            return "Launchpad Pro"
-        elif self.Check(0, "promk3"):
-            return "Launchpad Pro Mk3"
-        elif self.Check(1, "Launchpad X") or self.Check(1, "LPX"):
-            return "Launchpad X"
-        return None
-
 
 # ==========================================================================
 # CLASS Launchpad
@@ -314,6 +301,11 @@ class Launchpad(LaunchpadBase):
     # |   |   |   |   |   |   |   |   |  |8/8|  8
     # +---+---+---+---+---+---+---+---+  +---+
     #
+
+    segments = []
+
+    def flush(self, data):
+        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
 
     # -------------------------------------------------------------------------------------
     # -- Returns the raw value of the last button change as a list:
@@ -448,6 +440,11 @@ class LaunchpadPro(LaunchpadBase):
     #
 
     COLORS = {"black": 0, "off": 0, "white": 3, "red": 5, "green": 17}
+
+    segments = []
+
+    def flush(self, data):
+        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
 
     # -------------------------------------------------------------------------------------
     # -- Opens one of the attached Launchpad MIDI devices.
@@ -665,6 +662,11 @@ class LaunchpadMk2(LaunchpadPro):
     #        +---+---+---+---+---+---+---+---+  +---+
     #
 
+    segments = []
+
+    def flush(self, data):
+        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
+
     # -------------------------------------------------------------------------------------
     # -- Opens one of the attached Launchpad MIDI devices.
     # -- Uses search string "Mk2", by default.
@@ -773,6 +775,11 @@ class LaunchControlXL(LaunchpadBase):
     #     +---+---+---+---+---+---+---+---+
     #
     #
+
+    segments = []
+
+    def flush(self, data):
+        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
 
     # -------------------------------------------------------------------------------------
     # -- Opens one of the attached Control XL MIDI devices.
@@ -889,6 +896,11 @@ class LaunchControl(LaunchControlXL):
     #  0  |0/0|   |   |   |   |   |   |7/0|  |8/0||9/0|
     #     +---+---+---+---+---+---+---+---+  +---++---+
 
+    segments = []
+
+    def flush(self, data):
+        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
+
     # -------------------------------------------------------------------------------------
     # -- Opens one of the attached Control MIDI devices.
     # -- Uses search string "Control MIDI", by default.
@@ -964,6 +976,11 @@ class LaunchKeyMini(LaunchpadBase):
     #    SLIDERS:           41..48
     #    SLIDER (MASTER):   7
     #
+
+    segments = []
+
+    def flush(self, data):
+        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
 
     # -------------------------------------------------------------------------------------
     # -- Opens one of the attached LaunchKey devices.
@@ -1059,6 +1076,11 @@ class Dicer(LaunchpadBase):
     #     +-----+                                                 +-----+
     #
     #
+
+    segments = []
+
+    def flush(self, data):
+        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
 
     # -------------------------------------------------------------------------------------
     # -- Opens one of the attached Dicer devices.
@@ -1200,6 +1222,11 @@ class LaunchpadMiniMk3(LaunchpadPro):
 
     # 	COLORS = {'black':0, 'off':0, 'white':3, 'red':5, 'green':17 }
 
+    segments = []
+
+    def flush(self, data):
+        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
+
     # -------------------------------------------------------------------------------------
     # -- Opens one of the attached Launchpad MIDI devices.
     # -- Uses search string "MiniMk3", by default.
@@ -1303,6 +1330,41 @@ class LaunchpadLPX(LaunchpadPro):
     # -- So the old strategy of simply looking for "LPX" will not work.
     # -- Workaround: If the user doesn't request a specific name, we'll just
     # -- search for "Launchpad X" and "LPX"...
+
+    segments = [
+        ("TopBar", "mdi:table-row", [[72, 79]], 1),
+        ("Logo", "launchpad", [[80, 80]], 1),
+        (
+            "RightBar",
+            "mdi:table-column",
+            [
+                [8, 8],
+                [17, 17],
+                [26, 26],
+                [35, 35],
+                [44, 44],
+                [53, 53],
+                [62, 62],
+                [71, 71],
+            ],
+            1,
+        ),
+        (
+            "Matrix",
+            "mdi:grid",
+            [
+                [0, 7],
+                [9, 16],
+                [18, 25],
+                [27, 34],
+                [36, 43],
+                [45, 52],
+                [54, 61],
+                [63, 70],
+            ],
+            8,
+        ),
+    ]
 
     # -------------------------------------------------------------------------------------
     # Overrides "LaunchpadPro" method
@@ -1463,6 +1525,74 @@ class LaunchpadLPX(LaunchpadPro):
         else:
             return None
 
+    def flush(self, data):
+        try:
+            # we will use RawWriteSysEx(self, lstMessage, timeStamp=0)
+            # this function adds the preamble 240 and post amble 247
+            #
+            # This message can be sent to Lighting Custom Modes and the Programmer mode
+            # to light up LEDs. The LED indices used always correspond to those of
+            # Programmer mode, regardless of the layout selected:
+            #
+            # Host => Launchpad X:
+            # Hex: F0h 00h 20h 29h 02h 0Ch 03h <colourspec> [<colourspec> […]] F7h
+            # Dec: 240 0   32  41  2   12   3  <colourspec> [<colourspec> […]] 247
+            #
+            # the <colourspec> is structured as follows:
+            # - Lighting type (1 byte)
+            # - LED index (1 byte)  ---- WARNING, each row starts at 11, 21, 31 etc
+            # - Lighting data (1 – 3 bytes)
+            # Lighting types:
+            # - 0: Static colour from palette 1 byte specifying palette entry.
+            # - 1: Flashing colour, 2 bytes specifying Colour B and Colour A.
+            # - 2: Pulsing colour, 1 byte specifying palette entry.
+            # - 3: RGB colour, 3 bytes for Red, Green and Blue (127: Max, 0: Min).
+            #
+            # The message may contain up to 81 <colourspec> entries to light up the entire
+            # Launchpad X surface.
+            # Example:
+
+            # Host => Launchpad X:
+            # Hex: F0h 00h 20h 29h 02h 0Ch 03h 00h 0Bh 0Dh 01h 0Ch 15h 17h 02h 0Dh 25h F7h
+            # Dec: 240  0  32  41   2  12   3   0  11  13   1  12  21  23   2  13  37  247
+            #
+            # Sending this message to the Launchpad X in Programmer layout sets up the
+            # bottom left pad to static yellow, the pad next to it to flashing green
+            # (between dim and bright green), and the pad next to that pulsing turquoise
+            #
+            # in summary
+            # [ 3 = RGB, Pos = layout BE CAREFUL, R,G, B max 127 ]
+            # example of send RED pixel at row 3 pixel 6
+            # send_buffer.extend([3, 35, 127, 0, 0])
+
+            #            start = timeit.default_timer()
+
+            # stuff the send buffer with the command preamble
+            send_buffer = [0, 32, 41, 2, 12, 3]
+
+            # prebump the programmer mode index up a row and just before
+            pgm_mode_pos = 10
+            for idx, pixel in enumerate(data):
+                # check for row bumps, position is specific to programmer mode
+                if idx % 9 == 0:
+                    pgm_mode_pos += 1
+                send_buffer.extend(
+                    [
+                        3,
+                        pgm_mode_pos,
+                        max(min(int(pixel[0] // 2), 127), 0),
+                        max(min(int(pixel[1] // 2), 127), 0),
+                        max(min(int(pixel[2] // 2), 127), 0),
+                    ]
+                )
+                pgm_mode_pos += 1
+            self.lp.midi.RawWriteSysEx(send_buffer)
+            # took = timeit.default_timer() - start
+            # _LOGGER.info(f"Updated Pixels: {took} ")
+
+        except RuntimeError:
+            _LOGGER.error("Error in LaunchpadLPX handling")
+
 
 # ==========================================================================
 # CLASS MidiFighter64
@@ -1513,6 +1643,11 @@ class MidiFighter64(LaunchpadBase):
     #        |   |   |   |   |   |   |   |   | 7
     #        +---+---+---+---+---+---+---+---+
     #
+
+    segments = []
+
+    def flush(self, data):
+        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
 
     # -------------------------------------------------------------------------------------
     # -- Add some LED mode "constants" for better usability.
@@ -1727,6 +1862,11 @@ class LaunchpadProMk3(LaunchpadPro):
     #        +---+---+---+---+---+---+---+---+
     #        |   |   |   |   |   |   |   |/10|        10
     #        +---+---+---+---+---+---+---+---+
+
+    segments = []
+
+    def flush(self, data):
+        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
 
     # -------------------------------------------------------------------------------------
     # -- Opens one of the attached Launchpad MIDI devices.

--- a/ledfx/devices/launchpad_lib.py
+++ b/ledfx/devices/launchpad_lib.py
@@ -45,10 +45,6 @@ class RtmidiWrap:
     def SearchDevices(self, name, output=True, input=True, quiet=True):
         ret = []
         available_apis = rtmidi.get_compiled_api()
-        _LOGGER.info("TEMP MIDI DEBUG-----------")
-        _LOGGER.info(self.apis.items())
-        _LOGGER.info(available_apis)
-        _LOGGER.info("TEMP MIDI DEBUG END-------")
 
         for api, api_name in sorted(self.apis.items()):
             if api in available_apis:
@@ -178,6 +174,15 @@ class RtmidiWrap:
 #
 # ==========================================================================
 class LaunchpadBase:
+    # these are defaults that need to be overridden in inheriting classes
+    layout = {"pixels": 0, "rows": 0}
+    segments = []
+
+    def flush(self, data):
+        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
+
+    # end defaults
+
     def __init__(self):
         self.midi = RtmidiWrap()  # midi interface instance (singleton)
         self.idOut = None
@@ -306,11 +311,6 @@ class Launchpad(LaunchpadBase):
     # |   |   |   |   |   |   |   |   |  |8/8|  8
     # +---+---+---+---+---+---+---+---+  +---+
     #
-
-    segments = []
-
-    def flush(self, data):
-        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
 
     # -------------------------------------------------------------------------------------
     # -- Returns the raw value of the last button change as a list:
@@ -445,11 +445,6 @@ class LaunchpadPro(LaunchpadBase):
     #
 
     COLORS = {"black": 0, "off": 0, "white": 3, "red": 5, "green": 17}
-
-    segments = []
-
-    def flush(self, data):
-        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
 
     # -------------------------------------------------------------------------------------
     # -- Opens one of the attached Launchpad MIDI devices.
@@ -667,11 +662,6 @@ class LaunchpadMk2(LaunchpadPro):
     #        +---+---+---+---+---+---+---+---+  +---+
     #
 
-    segments = []
-
-    def flush(self, data):
-        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
-
     # -------------------------------------------------------------------------------------
     # -- Opens one of the attached Launchpad MIDI devices.
     # -- Uses search string "Mk2", by default.
@@ -780,11 +770,6 @@ class LaunchControlXL(LaunchpadBase):
     #     +---+---+---+---+---+---+---+---+
     #
     #
-
-    segments = []
-
-    def flush(self, data):
-        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
 
     # -------------------------------------------------------------------------------------
     # -- Opens one of the attached Control XL MIDI devices.
@@ -901,11 +886,6 @@ class LaunchControl(LaunchControlXL):
     #  0  |0/0|   |   |   |   |   |   |7/0|  |8/0||9/0|
     #     +---+---+---+---+---+---+---+---+  +---++---+
 
-    segments = []
-
-    def flush(self, data):
-        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
-
     # -------------------------------------------------------------------------------------
     # -- Opens one of the attached Control MIDI devices.
     # -- Uses search string "Control MIDI", by default.
@@ -981,11 +961,6 @@ class LaunchKeyMini(LaunchpadBase):
     #    SLIDERS:           41..48
     #    SLIDER (MASTER):   7
     #
-
-    segments = []
-
-    def flush(self, data):
-        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
 
     # -------------------------------------------------------------------------------------
     # -- Opens one of the attached LaunchKey devices.
@@ -1081,11 +1056,6 @@ class Dicer(LaunchpadBase):
     #     +-----+                                                 +-----+
     #
     #
-
-    segments = []
-
-    def flush(self, data):
-        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
 
     # -------------------------------------------------------------------------------------
     # -- Opens one of the attached Dicer devices.
@@ -1227,11 +1197,6 @@ class LaunchpadMiniMk3(LaunchpadPro):
 
     # 	COLORS = {'black':0, 'off':0, 'white':3, 'red':5, 'green':17 }
 
-    segments = []
-
-    def flush(self, data):
-        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
-
     # -------------------------------------------------------------------------------------
     # -- Opens one of the attached Launchpad MIDI devices.
     # -- Uses search string "MiniMk3", by default.
@@ -1335,7 +1300,7 @@ class LaunchpadLPX(LaunchpadPro):
     # -- So the old strategy of simply looking for "LPX" will not work.
     # -- Workaround: If the user doesn't request a specific name, we'll just
     # -- search for "Launchpad X" and "LPX"...
-
+    layout = {"pixels": 81, "rows": 9}
     segments = [
         ("TopBar", "mdi:table-row", [[72, 79]], 1),
         ("Logo", "launchpad", [[80, 80]], 1),
@@ -1649,11 +1614,6 @@ class MidiFighter64(LaunchpadBase):
     #        +---+---+---+---+---+---+---+---+
     #
 
-    segments = []
-
-    def flush(self, data):
-        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
-
     # -------------------------------------------------------------------------------------
     # -- Add some LED mode "constants" for better usability.
     # -------------------------------------------------------------------------------------
@@ -1867,11 +1827,6 @@ class LaunchpadProMk3(LaunchpadPro):
     #        +---+---+---+---+---+---+---+---+
     #        |   |   |   |   |   |   |   |/10|        10
     #        +---+---+---+---+---+---+---+---+
-
-    segments = []
-
-    def flush(self, data):
-        _LOGGER.error(f"flush not implemented for {self.__class__.__name__}")
 
     # -------------------------------------------------------------------------------------
     # -- Opens one of the attached Launchpad MIDI devices.

--- a/ledfx/devices/launchpad_lib.py
+++ b/ledfx/devices/launchpad_lib.py
@@ -1586,7 +1586,7 @@ class LaunchpadLPX(LaunchpadPro):
                     ]
                 )
                 pgm_mode_pos += 1
-            self.lp.midi.RawWriteSysEx(send_buffer)
+            self.midi.RawWriteSysEx(send_buffer)
             # took = timeit.default_timer() - start
             # _LOGGER.info(f"Updated Pixels: {took} ")
 


### PR DESCRIPTION
Move basic define search and config to data driven
Move segment definition and flush within specific class instance, only Launchpad X implemented so far
Added Launchpad S detection but no supporting class, this will presently just break beyond detection

Tested with Launchpad X on windows, device creation, deletion, activation, with and without segments auto creation
Tested on unsported mk2 for default responses.

now supports return of device params on call to 

```http://localhost:8888/api/find_launchpad```

as per

```{
    "status": "success",
    "device": {
        "pixels": 81,
        "rows": 9,
        "name": "Launchpad X",
        "segments": [
            [
                "TopBar",
                "mdi:table-row",
                [
                    [
                        72,

