### PR TITLE
Fix orphaned devices with multiple virtuals

### DIFF
--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -268,7 +268,7 @@ class Device(BaseRegistry):
         self._segments = [
             segment for segment in self._segments if segment[0] != virtual_id
         ]
-        if virtual_id == self.priority_virtual:
+        if virtual_id == self.priority_virtual.id:
             self.invalidate_cached_props()
 
     def clear_segments(self):

--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -268,8 +268,9 @@ class Device(BaseRegistry):
         self._segments = [
             segment for segment in self._segments if segment[0] != virtual_id
         ]
-        if virtual_id == self.priority_virtual.id:
-            self.invalidate_cached_props()
+        if self.priority_virtual:
+            if virtual_id == self.priority_virtual.id:
+                self.invalidate_cached_props()
 
     def clear_segments(self):
         self._segments = []

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -359,7 +359,7 @@ class Virtual:
                 VirtualUpdateEvent(self.id, self.assembled_frame)
             )
 
-            self._active = False
+            self.deactivate()
 
     def force_frame(self, color):
         """


### PR DESCRIPTION
Fix poor handling of priority_virtual cache invalidation, which could lead to an orphaned device only taking updates from a virtual that could be deactivated. Therefore other virtuals would not get flushed.

A bare setting of _active to False instead of the deactivate call and a incorrect comparison to check if the priority_virtual was getting disabled, and therefore flush the cache properties of the device.

Tested by not being able to reproduce the original issue

Set 2 or 3 virtuals on a device

Turn them on and off in various orders and ensure the active virtuals are still rendered to device

It is not possible to know which virtual is the priority_virtual without invasive debug, so just fuzz them all!