### PR TITLE
Default to DDP on WLED

### DIFF
--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -20,6 +20,7 @@ from ledfx.utils import (
     async_fire_and_forget,
     generate_id,
     resolve_destination,
+    wled_support_DDP
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -666,40 +667,23 @@ class Devices(RegistryLoader):
             # fmt: on
             wled_count = led_info["count"]
             wled_rgbmode = led_info["rgbw"]
+            wled_build = wled_config["vid"]
+
+            if wled_support_DDP(wled_build):
+                _LOGGER.info(f"WLED build Supports DDP: {wled_build}")
+                sync_mode = "DDP"
+            else:
+                _LOGGER.info(f"WLED build pre DDP, default to UDP: {wled_build}")
+                sync_mode = "UDP"
 
             wled_config = {
                 "name": wled_name,
                 "pixel_count": wled_count,
                 "icon_name": "wled",
                 "rgbw_led": wled_rgbmode,
+                "sync_mode": sync_mode
             }
 
-            # determine sync mode
-            # UDP < 480
-            # DDP or E131 depending on: ledfx's configured preferred mode first, else the device's mode
-            # ARTNET can do one
-
-            if wled_count > 480:
-                await wled.get_sync_settings()
-                sync_mode = wled.get_sync_mode()
-            else:
-                sync_mode = "UDP"
-
-                # preferred_mode = self._ledfx.config["wled_preferences"][
-                #     "wled_preferred_mode"
-                # ]
-                # if preferred_mode:
-                #     sync_mode = preferred_mode
-                # else:
-                #     await wled.get_sync_settings()
-                #     sync_mode = wled.get_sync_mode()
-
-            if sync_mode == "ARTNET":
-                msg = f"Cannot add WLED device at {resolved_dest}. Unsupported mode: 'ARTNET', and too many pixels for UDP sync (>480)"
-                _LOGGER.warning(msg)
-                raise ValueError(msg)
-
-            wled_config["sync_mode"] = sync_mode
             device_config.update(wled_config)
 
         device_id = generate_id(device_config["name"])

--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -20,7 +20,7 @@ from ledfx.utils import (
     async_fire_and_forget,
     generate_id,
     resolve_destination,
-    wled_support_DDP
+    wled_support_DDP,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -673,7 +673,9 @@ class Devices(RegistryLoader):
                 _LOGGER.info(f"WLED build Supports DDP: {wled_build}")
                 sync_mode = "DDP"
             else:
-                _LOGGER.info(f"WLED build pre DDP, default to UDP: {wled_build}")
+                _LOGGER.info(
+                    f"WLED build pre DDP, default to UDP: {wled_build}"
+                )
                 sync_mode = "UDP"
 
             wled_config = {
@@ -681,7 +683,7 @@ class Devices(RegistryLoader):
                 "pixel_count": wled_count,
                 "icon_name": "wled",
                 "rgbw_led": wled_rgbmode,
-                "sync_mode": sync_mode
+                "sync_mode": sync_mode,
             }
 
             device_config.update(wled_config)

--- a/ledfx/devices/wled.py
+++ b/ledfx/devices/wled.py
@@ -1,13 +1,13 @@
 import logging
 
 import voluptuous as vol
-from pkg_resources import parse_version
 
 from ledfx.devices import NetworkedDevice
 from ledfx.devices.ddp import DDPDevice
 from ledfx.devices.e131 import E131Device
 from ledfx.devices.udp import UDPRealtimeDevice
 from ledfx.utils import WLED
+from ledfx.utils import wled_support_DDP
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -159,7 +159,7 @@ class WLEDDevice(NetworkedDevice):
         wled_name = wled_config["name"]
         wled_count = led_info["count"]
         wled_rgbmode = led_info["rgbw"]
-        wled_version = wled_config["ver"]
+        wled_build = wled_config["vid"]
 
         wled_config = {
             "name": wled_name,
@@ -172,10 +172,8 @@ class WLEDDevice(NetworkedDevice):
 
         # Currently *assuming* that this PR gets released in 0.13
         # https://github.com/Aircoookie/WLED/pull/1944
-        if parse_version(wled_version) >= parse_version("0.13.0"):
-            _LOGGER.info(
-                f"WLED Version Supports Sync Setting API: {wled_version}"
-            )
+        if wled_support_DDP(wled_build):
+            _LOGGER.info(f"WLED Build Supports Sync Setting API: {wled_build}")
             wled_sync_settings = await self.wled.get_sync_settings()
         # self.wled.enable_realtime_gamma()
         # self.wled.set_inactivity_timeout(self._config["timeout"])

--- a/ledfx/devices/wled.py
+++ b/ledfx/devices/wled.py
@@ -6,8 +6,7 @@ from ledfx.devices import NetworkedDevice
 from ledfx.devices.ddp import DDPDevice
 from ledfx.devices.e131 import E131Device
 from ledfx.devices.udp import UDPRealtimeDevice
-from ledfx.utils import WLED
-from ledfx.utils import wled_support_DDP
+from ledfx.utils import WLED, wled_support_DDP
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -1160,3 +1160,11 @@ class Graph:
             )
             output_file(filename=save_as, title=compound)
             show(p)
+
+
+def wled_support_DDP(build)->bool:
+    # https://github.com/Aircoookie/WLED/blob/main/CHANGELOG.md#build-2110060
+    if build >= 2110060:
+        return True
+    else:
+        return False

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -1162,7 +1162,7 @@ class Graph:
             show(p)
 
 
-def wled_support_DDP(build)->bool:
+def wled_support_DDP(build) -> bool:
     # https://github.com/Aircoookie/WLED/blob/main/CHANGELOG.md#build-2110060
     if build >= 2110060:
         return True


### PR DESCRIPTION
Default wled protocol to DDP for builds equal or greater to when it was added

https://github.com/Aircoookie/WLED/blob/main/CHANGELOG.md#build-2110060

Causes a lot of "my lights are out of sync" with UDP as default

Threw away a bunch of legacy protocol selection code comments that are just cruft now

The code changed in wled.py is for completeness, not to have two methods of checking builds, noting that the wled existing was using a strict comparison that would be incorrect for beta versions.

And yes, DDP addition is not strictly sync support...