### PR TITLE
Protect against priority virtual race condition on startup crash

### DIFF
--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -144,9 +144,13 @@ class Device(BaseRegistry):
                 self.flush(frame)
                 # _LOGGER.debug(f"Device {self.id} flushed by Virtual {virtual_id}")
 
-                self._ledfx.events.fire_event(DeviceUpdateEvent(self.id, frame))
+                self._ledfx.events.fire_event(
+                    DeviceUpdateEvent(self.id, frame)
+                )
         else:
-            _LOGGER.warning(f"Flush skipped as {self.id} has no priority_virtual")
+            _LOGGER.warning(
+                f"Flush skipped as {self.id} has no priority_virtual"
+            )
 
     def assemble_frame(self):
         """

--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -138,12 +138,15 @@ class Device(BaseRegistry):
         for pixels, start, end in data:
             self._pixels[start : end + 1] = pixels
 
-        if virtual_id == self.priority_virtual.id:
-            frame = self.assemble_frame()
-            self.flush(frame)
-            # _LOGGER.debug(f"Device {self.id} flushed by Virtual {virtual_id}")
+        if self.priority_virtual:
+            if virtual_id == self.priority_virtual.id:
+                frame = self.assemble_frame()
+                self.flush(frame)
+                # _LOGGER.debug(f"Device {self.id} flushed by Virtual {virtual_id}")
 
-            self._ledfx.events.fire_event(DeviceUpdateEvent(self.id, frame))
+                self._ledfx.events.fire_event(DeviceUpdateEvent(self.id, frame))
+        else:
+            _LOGGER.warning(f"Flush skipped as {self.id} has no priority_virtual")
 
     def assemble_frame(self):
         """


### PR DESCRIPTION
Protect against access of priority_virtual.id when priority_virtual has not been initialised.

Race condition at start up for pixel rich system.

Reproducable with FPP @ 4096 + WLED @(500 + 100 + 400)

With copy and span virtuals in config

Without fix, reproducable crash.

With fix, starts healthy.

Fix is passive, in that for normal operation, nothing new happens, it can only defend against the crash condition.