### PR TITLE
Change order of WLED protocols for drop down to DDP default

### DIFF
--- a/ledfx/devices/wled.py
+++ b/ledfx/devices/wled.py
@@ -22,7 +22,7 @@ class WLEDDevice(NetworkedDevice):
         {
             vol.Optional(
                 "sync_mode",
-                description="Streaming protocol to WLED device. Recommended: DDP for all",
+                description="Streaming protocol to WLED device. Recommended: DDP for 0.13 or later. Use UDP for older versions.",
                 default="DDP",
             ): vol.In(["DDP", "UDP", "E131"]),
             vol.Optional(

--- a/ledfx/devices/wled.py
+++ b/ledfx/devices/wled.py
@@ -22,9 +22,9 @@ class WLEDDevice(NetworkedDevice):
         {
             vol.Optional(
                 "sync_mode",
-                description="Streaming protocol to WLED device. Recommended: UDP<480px, DDP>480px",
-                default="UDP",
-            ): vol.In(["UDP", "DDP", "E131"]),
+                description="Streaming protocol to WLED device. Recommended: DDP for all",
+                default="DDP",
+            ): vol.In(["DDP", "UDP", "E131"]),
             vol.Optional(
                 "timeout",
                 description="Time between LedFx effect off and WLED effect activate",


### PR DESCRIPTION
change order of WLED protocols to force default to DDP on manual add device

default field appears to be ignored, so list order is the only thing that currently works
