### PR TITLE
General led count crash fixes

### DIFF
--- a/ledfx/effects/bands_matrix.py
+++ b/ledfx/effects/bands_matrix.py
@@ -40,10 +40,11 @@ class BandsMatrixAudioEffect(AudioReactiveEffect, GradientEffect):
         self.r = self.melbank(filtered=True, size=self.pixel_count)
 
     def render(self):
+        bands_active = min(self._config["band_count"], self.pixel_count)
         out = np.tile(self.r, (3, 1)).T
         np.clip(out, 0, 1, out=out)
-        out_split = np.array_split(out, self._config["band_count"], axis=0)
-        for i in range(self._config["band_count"]):
+        out_split = np.array_split(out, bands_active, axis=0)
+        for i in range(bands_active):
             band_width = len(out_split[i])
             volume = int(out_split[i].max() * band_width)
             out_split[i][volume:] = self.bkg_color

--- a/ledfx/effects/blocks.py
+++ b/ledfx/effects/blocks.py
@@ -27,12 +27,12 @@ class BlocksAudioEffect(AudioReactiveEffect, GradientEffect):
         self.r = self.melbank(filtered=True, size=self.pixel_count)
 
     def render(self):
+        blocks_active = min(self._config["block_count"], self.pixel_count)
+
         out = np.tile(self.r, (3, 1))
-        out_split = np.array_split(out, self._config["block_count"], axis=1)
-        for i in range(self._config["block_count"]):
-            color = self.get_gradient_color(i / self._config["block_count"])[
-                :, np.newaxis
-            ]
+        out_split = np.array_split(out, blocks_active, axis=1)
+        for i in range(blocks_active):
+            color = self.get_gradient_color(i / blocks_active)[:, np.newaxis]
             out_split[i] = np.multiply(
                 out_split[i], (out_split[i].max() * color)
             )

--- a/ledfx/effects/equalizer.py
+++ b/ledfx/effects/equalizer.py
@@ -38,8 +38,11 @@ class EQAudioEffect(AudioReactiveEffect, GradientEffect):
         np.clip(self.r, 0, 1, out=self.r)
 
     def render(self):
-        r_split = np.array_split(self.r, self._config["gradient_repeat"])
-        for i in range(self._config["gradient_repeat"]):
+        gradient_repeat = min(
+            self._config["gradient_repeat"], self.pixel_count
+        )
+        r_split = np.array_split(self.r, gradient_repeat)
+        for i in range(gradient_repeat):
             band_width = len(r_split[i])
             # length (volume) of band
             volume = int(r_split[i].mean() * band_width)


### PR DESCRIPTION
Will add multiple effect fixes to this PR. 
All fixes are generated against poisoned configs that occur when finding a bad configuration against 3 leds, that can be seen to be valid after fix

bands matrix has same exposure as already fixed in bands, add cap to band count to led count
blocks has the same exposure as above, similar fix
equaliser has the same exposure as above, similar fix

Pass completed, all 2D effects had the weakness, all other effects appear good