### PR TITLE
Fix installing from source using pip

### DIFF
--- a/hiddenimports.py
+++ b/hiddenimports.py
@@ -21,4 +21,8 @@ hiddenimports = [
     "icmplib",
     "flux_led",
     "voluptuous",
+    "mbedtls",
+    "mbedtls.mpi",
+    "mbedtls._platform",
+    "mbedtls._ringbuf",
 ]

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ INSTALL_REQUIRES = [
     # We can install this on all linux devices, it just won't work for anything other than a Pi
     'rpi-ws281x>=4.3.0; platform_system == "Linux"',
     "flux-led>=0.28.35",
+    "python-mbedtls~=2.6.1",
 ]
 
 


### PR DESCRIPTION
Add missing `python-mbedtls`  to `setup.py` and hidden imports for pyinstaller build