### PR TITLE
Scene API support for per virtual

### DIFF
--- a/ledfx/api/scenes.py
+++ b/ledfx/api/scenes.py
@@ -219,7 +219,6 @@ class ScenesEndpoint(RestEndpoint):
                 "reason": "JSON Decoding failed",
             }
             return web.json_response(data=response, status=400)
-        import json
 
         scene_name = data.get("name")
         scene_tags = data.get("scene_tags")
@@ -247,7 +246,6 @@ class ScenesEndpoint(RestEndpoint):
         scene_config["scene_payload"] = scene_payload
         scene_config["scene_midiactivate"] = scene_midiactivate
 
-        _LOGGER.info("Outside the mind")
         if "virtuals" not in data.keys():
             for virtual in self._ledfx.virtuals.values():
                 effect = {}
@@ -258,22 +256,14 @@ class ScenesEndpoint(RestEndpoint):
                 scene_config["virtuals"][virtual.id] = effect
         else:
             virtuals = data.get("virtuals")
-            _LOGGER.info("Defined virtuals, dumping")
-            _LOGGER.info(json.dumps(virtuals, indent=4))
 
             for virtualid in virtuals:
-                _LOGGER.info(f"Dumping a {virtualid}")
                 virtual = data.get("virtuals")[virtualid]
-                _LOGGER.info(virtual)
                 if bool(virtual):
-                    _LOGGER.info("Virual is not empty, so add to scene")
                     effect = {}
                     effect["type"] = virtual["type"]
                     effect["config"] = virtual["config"]
                     scene_config["virtuals"][virtualid] = effect
-
-        _LOGGER.info("Dumping scene_config")
-        _LOGGER.info(json.dumps(scene_config, indent=4))
 
         # Update the scene if it already exists, else create it
         self._ledfx.config["scenes"][scene_id] = scene_config

--- a/ledfx/api/scenes.py
+++ b/ledfx/api/scenes.py
@@ -72,6 +72,9 @@ class ScenesEndpoint(RestEndpoint):
                 "reason": "JSON Decoding failed",
             }
             return web.json_response(data=response, status=400)
+        import json
+        _LOGGER.info("Dumping from put")
+        _LOGGER.info(json.dumps(data, indent=4))
 
         action = data.get("action")
         if action is None:
@@ -216,6 +219,7 @@ class ScenesEndpoint(RestEndpoint):
                 "reason": "JSON Decoding failed",
             }
             return web.json_response(data=response, status=400)
+        import json
 
         scene_name = data.get("name")
         scene_tags = data.get("scene_tags")
@@ -242,13 +246,34 @@ class ScenesEndpoint(RestEndpoint):
         scene_config["scene_tags"] = scene_tags
         scene_config["scene_payload"] = scene_payload
         scene_config["scene_midiactivate"] = scene_midiactivate
-        for virtual in self._ledfx.virtuals.values():
-            effect = {}
-            if virtual.active_effect:
-                effect["type"] = virtual.active_effect.type
-                effect["config"] = virtual.active_effect.config
-                # effect['name'] = virtual.active_effect.name
-            scene_config["virtuals"][virtual.id] = effect
+
+        _LOGGER.info("Outside the mind")
+        if "virtuals" not in data.keys():
+            for virtual in self._ledfx.virtuals.values():
+                effect = {}
+                if virtual.active_effect:
+                    effect["type"] = virtual.active_effect.type
+                    effect["config"] = virtual.active_effect.config
+                    # effect['name'] = virtual.active_effect.name
+                scene_config["virtuals"][virtual.id] = effect
+        else:
+            virtuals = data.get("virtuals")
+            _LOGGER.info("Defined virtuals, dumping")
+            _LOGGER.info(json.dumps(virtuals, indent=4))
+
+            for virtualid in virtuals:
+                _LOGGER.info(f"Dumping a {virtualid}")
+                virtual = data.get("virtuals")[virtualid]
+                _LOGGER.info(virtual)
+                if bool(virtual):
+                    _LOGGER.info("Virual is not empty, so add to scene")
+                    effect = {}
+                    effect["type"] = virtual["type"]
+                    effect["config"] = virtual["config"]
+                    scene_config["virtuals"][virtualid] = effect
+
+        _LOGGER.info("Dumping scene_config")
+        _LOGGER.info(json.dumps(scene_config, indent=4))
 
         # Update the scene if it already exists, else create it
         self._ledfx.config["scenes"][scene_id] = scene_config

--- a/ledfx/api/scenes.py
+++ b/ledfx/api/scenes.py
@@ -72,10 +72,6 @@ class ScenesEndpoint(RestEndpoint):
                 "reason": "JSON Decoding failed",
             }
             return web.json_response(data=response, status=400)
-        import json
-
-        _LOGGER.info("Dumping from put")
-        _LOGGER.info(json.dumps(data, indent=4))
 
         action = data.get("action")
         if action is None:


### PR DESCRIPTION
This support for per virtual config is extensible.

Default behavior where there is no virtuals key field is as before

Where a virtuals key field is listed, then for all virtuals carried, if they are not empty, then they are added to the scene config and save.

There may need to be more future logic for virtual off etc. That will be across front end and back end but can be incrementally developed.

For Further Study