### PR TITLE
Attempt at back buffer render for Lanchpad S

### DIFF
--- a/ledfx/devices/launchpad.py
+++ b/ledfx/devices/launchpad.py
@@ -111,6 +111,11 @@ class LaunchpadDevice(MidiDevice):
                     description="Auto-Generate a virtual for each segments",
                     default=False,
                 ): bool,
+                vol.Optional(
+                    "Alpha",
+                    description="Dark and dangerous features of the damned",
+                    default=False,
+                ): bool,
             }
         )
 
@@ -120,7 +125,7 @@ class LaunchpadDevice(MidiDevice):
         _LOGGER.info("Launchpad device created")
 
     def flush(self, data):
-        self.lp.flush(data)
+        self.lp.flush(data, self._config["Alpha"])
 
     def activate(self):
         self.set_class()

--- a/ledfx/devices/launchpad.py
+++ b/ledfx/devices/launchpad.py
@@ -116,6 +116,11 @@ class LaunchpadDevice(MidiDevice):
                     description="Dark and dangerous features of the damned",
                     default=False,
                 ): bool,
+                vol.Optional(
+                    "Diagnostic",
+                    description="enable timing diagnostics in logger",
+                    default=False,
+                ): bool,
             }
         )
 
@@ -125,7 +130,7 @@ class LaunchpadDevice(MidiDevice):
         _LOGGER.info("Launchpad device created")
 
     def flush(self, data):
-        self.lp.flush(data, self._config["Alpha"])
+        self.lp.flush(data, self._config["Alpha"], self._config["Diagnostic"])
 
     def activate(self):
         self.set_class()

--- a/ledfx/devices/launchpad.py
+++ b/ledfx/devices/launchpad.py
@@ -142,7 +142,9 @@ class LaunchpadDevice(MidiDevice):
         _LOGGER.info(f"Launchpad device class: {self.lp.__class__.__name__}")
 
     def deactivate(self):
-        self.lp.flush(zeros((self.pixel_count, 3)))
+        self.lp.flush(zeros((self.pixel_count, 3)),
+                      self._config["Alpha"],
+                      self._config["Diagnostic"])
         self.lp.Close()
         self.lp = None
         super().deactivate()

--- a/ledfx/devices/launchpad_lib.py
+++ b/ledfx/devices/launchpad_lib.py
@@ -2049,7 +2049,7 @@ class LaunchpadS(LaunchpadPro):
 
         if not alpha:
             # Speculating write on channel 1 to reset everything
-#            self.midi.RawWrite(0x90, 0x00, 0x0C)
+            #            self.midi.RawWrite(0x90, 0x00, 0x0C)
             # simple update mode, display and write buffer 0
             self.midi.RawWrite(0xB0, 0x00, 0x20)
 

--- a/ledfx/devices/launchpad_lib.py
+++ b/ledfx/devices/launchpad_lib.py
@@ -170,7 +170,7 @@ class RtmidiWrap:
         self.devOut.send_message([stat, dat1, dat2])
 
     # -------------------------------------------------------------------------------------
-    # -- sends a running status 2 byte message
+    # -- sends a running status 2 byte message MADNESS
     # -------------------------------------------------------------------------------------
     def RawWriteTwo(self, dat1, dat2):
         self.devOut.send_message([dat1, dat2])
@@ -2033,6 +2033,8 @@ class LaunchpadS(LaunchpadPro):
 
         # 92 is Note on, channel 3 ( 3 - 1) followed by 2 color pixel data bytes
         # pixel data = 0x0C | 0x30 green | 0x03 red
+        # code now supports running mode where status byte is only sent at
+        # start of frame
         if diag:
             start = timeit.default_timer()
 

--- a/ledfx/devices/launchpad_lib.py
+++ b/ledfx/devices/launchpad_lib.py
@@ -2074,5 +2074,5 @@ class LaunchpadS(LaunchpadPro):
                 self.frame = 0
             else:
                 self.frame += 1
-            _LOGGER.error(f"Launchpad S flush {self.fps} : {now - start}")
+            _LOGGER.info(f"Launchpad S flush {self.fps} : {now - start}")
             self.lasttime = nowint

--- a/ledfx/devices/launchpad_lib.py
+++ b/ledfx/devices/launchpad_lib.py
@@ -169,6 +169,11 @@ class RtmidiWrap:
     def RawWrite(self, stat, dat1, dat2):
         self.devOut.send_message([stat, dat1, dat2])
 
+    # -------------------------------------------------------------------------------------
+    # -- sends a running status 2 byte message
+    # -------------------------------------------------------------------------------------
+    def RawWriteTwo(self, dat1, dat2):
+        self.devOut.send_message([dat1, dat2])
 
 # ==========================================================================
 # CLASS LaunchpadBase
@@ -1896,7 +1901,8 @@ class LaunchpadProMk3(LaunchpadPro):
 # ==========================================================================
 # CLASS Launchpad S
 #
-# Got to start somewhere
+# It's an older code sir, but it checks out.
+# https://www.bhphotovideo.com/lit_files/88417.pdf
 # ==========================================================================
 class LaunchpadS(LaunchpadPro):
     layout = {"pixels": 81, "rows": 9}
@@ -2043,7 +2049,7 @@ class LaunchpadS(LaunchpadPro):
                         self.midi.RawWrite(0x92, out1, out2)
                         send_status = False
                     else:
-                        self.midi.RawWrite(out1, out2)
+                        self.midi.RawWriteTwo(out1, out2)
                 else:
                     self.midi.RawWrite(0x92, out1, out2)
 


### PR DESCRIPTION
Backbuffer render and switch is now the default

Old slow style code has been removed

Two switches added into the launchpad device config

Alpha to turn on risky alpha code, in this case running status write, which although seen to work, does not change the frame render time. This can ONLY be due to lower layer interlocks beyond our control.

Diagnostic to turn on FPS and frame render timing diagnostics. Don't want those left in by default.

Testing by Matt, seen to be functional