### PR TITLE
Fix live refresh rate update on edit device settings

### DIFF
--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -107,6 +107,7 @@ class Device(BaseRegistry):
             if virtual.is_device == self.id:
                 segments = [[self.id, 0, self.pixel_count - 1, False]]
                 virtual.update_segments(segments)
+                virtual.invalidate_cached_props()
 
         for virtual in self._virtuals_objs:
             virtual.deactivate_segments()


### PR DESCRIPTION
Missing call to virtuals invalidate cached properties on new parent device config

Tested by adding debug code into WLED device flush function, debugging effective frame rate

Prior to fix would only transition on ledfx restart Now transitions when device config is changed

Fix is passive unless device config is updated, and absolute worst case introduces a new derivation of the relevant cached properties