### PR TITLE
Prevent crash from race condition and empty virtual data

### DIFF
--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -138,7 +138,9 @@ class Device(BaseRegistry):
             return
 
         for pixels, start, end in data:
-            self._pixels[start : end + 1] = pixels
+            # protect against an empty race condition
+            if pixels.shape[0] != 0:
+                self._pixels[start : end + 1] = pixels
 
         if self.priority_virtual:
             if virtual_id == self.priority_virtual.id:


### PR DESCRIPTION
As per

https://github.com/LedFx/LedFx/issues/425

With 10+ segments in a virtual, adding more MAY cause a crash where the data being copied into to device range is empty and therefore is an incompatible shape. By checking for actual data as cheaply as reasonable this crash condition is now just a passive pass that is healthy the next time round the cycle.

It is likely always possible to trigger as a race condition, but becomes "likely" at 10+

Prior to fix, adding another virtual segment to a large span against my 4096 panel was a 50 / 50 crash scenario at 10+

With fix, I have been able to fill up the 4096 panel with 21 virtuals and confirm healthy render via use of pixels effect

![screenshot-127 0 0 1_8888-2023 07 16-13_50_02](https://github.com/LedFx/LedFx/assets/7328740/07bf811d-a559-47a8-b6c4-76885e4d357d)
