### PR TITLE
Fix effect leakage on changing effects

### DIFF
--- a/ledfx/effects/temporal.py
+++ b/ledfx/effects/temporal.py
@@ -18,8 +18,6 @@ DEFAULT_RATE = 1.0 / 10.0
 
 @Effect.no_registration
 class TemporalEffect(Effect):
-    _thread_active = False
-    _thread = None
 
     CONFIG_SCHEMA = vol.Schema(
         {
@@ -30,6 +28,11 @@ class TemporalEffect(Effect):
             ): vol.All(vol.Coerce(float), vol.Range(min=0.1, max=10)),
         }
     )
+
+    def __init__(self, ledfx, config):
+        super().__init__(ledfx, config)
+        self._thread_active = False
+        self._thread = None
 
     def thread_function(self):
         while self._thread_active:

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -297,6 +297,7 @@ class Virtual:
         else:
             self.clear_transition_effect()
 
+        self.clear_active_effect()
         self._active_effect = effect
         self._active_effect.activate(self)
         self._ledfx.events.fire_event(

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -295,9 +295,10 @@ class Virtual:
                 self.clear_transition_effect()
                 self._transition_effect = self._active_effect
         else:
+            # no transition effect to clean up, so clear the active effect now!
+            self.clear_active_effect()
             self.clear_transition_effect()
 
-        self.clear_active_effect()
         self._active_effect = effect
         self._active_effect.activate(self)
         self._ledfx.events.fire_event(


### PR DESCRIPTION
that could lead to CPU hogging and general cumulative damage

Effects were orphaned without being deactivated. We were just building new effect instances on top.

For temporal effects, threads would be left running servicing the effect themselves, with non trivial led counts, this could quickly exhaust CPU and lead to slow down across the system, as the threads could preempt all other behaviours.

For audio effects the registered effect handler would still be running, but there would not be extra context switching with thread servicing, just cumulative runtime, that would lead to a different kind of death.

Virtual segment edit scenario was exposing due to multiple effect switching from the front end and my large panel use case for that testing.

With this fix in place, I cannot slow the system down doing aggressive segment edits and general effect changes, temporal and audio reactive

NOTE: the temporal thread has been moved to a per instance implementation, rather than a single for the class, to allow the deactivate to not kill other active temporal effects.

An alternative implementation could use a counting semaphore, but that gets a little messy for me.

Further testing found the only path that was a risk is when transition effect is None, or transition time = 0

In this case there was no copy of the active effect to transition effect, and it was just written over, leaving the instance / thread running.

Where there is a transition effect, when it timed out on its frame count it would clean up. 

So the active effect was moved up into the relevant part of the transition effect check else case.

Tested by dumping the active effect serviced in temporal thread loop, ensuring it always goes down to the final instance only, with manual effect and segment edit cases.

debug is NOT being checked in,