### PR TITLE
Protect Audio update callback from segment changes

### DIFF
--- a/ledfx/effects/energy.py
+++ b/ledfx/effects/energy.py
@@ -61,6 +61,11 @@ class EnergyAudioEffect(AudioReactiveEffect):
         self.mids_idx = 0
         self.highs_idx = 0
 
+        # make sure the p_filter is flushed from prior lifecycles
+        # prevent crashes from segment edit / led count changes
+        if self._p_filter is not None:
+            self._p_filter.value = None
+
     def config_updated(self, config):
         # scale decay value between 0.1 and 0.2
         decay_sensitivity = (self._config["sensitivity"] - 0.1) * 0.7

--- a/ledfx/effects/melt_and_sparkle.py
+++ b/ledfx/effects/melt_and_sparkle.py
@@ -77,6 +77,7 @@ class MeltSparkle(AudioReactiveEffect, HSVEffect):
         self.dt = 0
 
         self.strobe_overlay = np.zeros(self.pixel_count)
+        self.onsets_queue = queue.Queue()
 
     def deactivate(self):
         empty_queue(self.onsets_queue)

--- a/ledfx/effects/pitchSpectrum.py
+++ b/ledfx/effects/pitchSpectrum.py
@@ -35,6 +35,11 @@ class PitchSpectrumAudioEffect(AudioReactiveEffect, GradientEffect):
         }
     )
 
+    def on_activate(self, pixel_count):
+        # protect from changes to the pixel count during segment edits
+        self.avg_midi = None
+        self.filtered_melbank = None
+
     def config_updated(self, config):
         self.avg_midi = None
         self.filtered_melbank = None

--- a/ledfx/effects/spectrum.py
+++ b/ledfx/effects/spectrum.py
@@ -14,6 +14,12 @@ class SpectrumAudioEffect(AudioReactiveEffect):
         self.out = np.zeros((pixel_count, 3))
         self._prev_y = np.zeros(pixel_count)
 
+        # make sure the b_filter is flushed from prior lifecycles
+        # prevent crashes from segment edit / led count changes
+        if self._b_filter is not None:
+            self._b_filter.value = None
+
+
     def config_updated(self, config):
         # Create all the filters used for the effect
         self._b_filter = self.create_filter(alpha_decay=0.1, alpha_rise=0.5)

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -232,6 +232,8 @@ class Virtual:
 
     def update_segments(self, segments_config):
         self.lock.acquire()
+        if self._active_effect is not None:
+            self._active_effect.lock.acquire()
         segments_config = [list(item) for item in segments_config]
         _segments = self.SEGMENTS_SCHEMA(segments_config)
 
@@ -269,6 +271,8 @@ class Virtual:
 
             mode = self._config["transition_mode"]
             self.frame_transitions = self.transitions[mode]
+        if self._active_effect is not None:
+            self._active_effect.lock.release()
         self.lock.release()
 
     def set_preset(self, preset_info):


### PR DESCRIPTION
Protect effect audio update callbacks from segment changes by having the segment change grab the pre-existing lock on their active effect, which is already used to protect audio update callback

This is the next set of protections where effects access pixel count data or similar from their audio callback, that gets modified by segment reconfiguration

Makes effects like Power solid under segment edit, where as prior they were easy to crash out

There are four effects remaining with their own crashes under segment edit, unrelated to this...

These have now been addressed, all are variants of filters not being reset in on_activate() or in the case of melt and sparkle a queue that is destroyed in deactivate, but only established in init