### PR TITLE
Protect against no priority virtual

### DIFF
--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -277,6 +277,8 @@ class Device(BaseRegistry):
         _LOGGER.debug(
             f"Device {self.id}: Added segment {virtual_id, start_pixel, end_pixel}"
         )
+        # We have added a segment, therefore the priority virtual may of changed
+        self.invalidate_cached_props()
 
     def clear_virtual_segments(self, virtual_id):
         self._segments = [


### PR DESCRIPTION
Always invalidate virtuals cache on adding segments, prevents orphaned priority virtual problem

This only fires when adding segments, can only improve scenario so that the priority virtual is current

Protects against reproducible scenario when switching between overlaid virtuals towards a device.

priority_virtual value could become none if a flush hit prior to there being any defined segments, and would not be revisited. Would leave device rendering nothing.

This would also mean that adding any sgements later would never update the device refresh rate.

Tested with 1000 effect changes across 13 virtuals including various cross overs into the scenario of interest.

Everything is good after test session including the specific scenario addressed by fix.