### PR TITLE
Fixed ZeroDivisionError

### DIFF
--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -555,7 +555,10 @@ class Virtual:
                 else:
                     # calculates how far in we are in the transition
                     # 0 = previous effect and 1 = next effect
-                    weight = self.transition_frame_counter / self.transition_frame_total
+                    weight = (
+                        self.transition_frame_counter
+                        / self.transition_frame_total
+                    )
 
                 self.frame_transitions(
                     self.transitions, frame, transition_frame, weight

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -548,9 +548,15 @@ class Virtual:
                     max(self.transition_frame_counter, 0),
                     self.transition_frame_total,
                 )
-                weight = (
-                    self.transition_frame_counter / self.transition_frame_total
-                )
+
+                if self.transition_frame_total == 0:
+                    # the transition should happen immediately
+                    weight = 1
+                else:
+                    # calculates how far in we are in the transition
+                    # 0 = previous effect and 1 = next effect
+                    weight = self.transition_frame_counter / self.transition_frame_total
+
                 self.frame_transitions(
                     self.transitions, frame, transition_frame, weight
                 )


### PR DESCRIPTION
Currently, only when in expert mode, "virtuals" have a transition time of 0 by default. This maybe should be fixed too, but for now I've just fixed a ZeroDivisionError which is always good I guess...

Exception this fixes:

```
Aug 19 12:08:05 ledfx-server python3[58142]: Exception in thread Thread-2 (thread_function):
Aug 19 12:08:05 ledfx-server python3[58142]: Traceback (most recent call last):
Aug 19 12:08:05 ledfx-server python3[58142]:   File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
Aug 19 12:08:05 ledfx-server python3[58142]:     self.run()
Aug 19 12:08:05 ledfx-server python3[58142]:   File "/usr/lib/python3.10/threading.py", line 953, in run
Aug 19 12:08:05 ledfx-server python3[58142]:     self._target(*self._args, **self._kwargs)
Aug 19 12:08:05 ledfx-server python3[58142]:   File "/home/sean/LedFx/ledfx/virtuals.py", line 482, in thread_function
Aug 19 12:08:05 ledfx-server python3[58142]:     self.assembled_frame = self.assemble_frame()
Aug 19 12:08:05 ledfx-server python3[58142]:   File "/home/sean/LedFx/ledfx/virtuals.py", line 552, in assemble_frame
Aug 19 12:08:05 ledfx-server python3[58142]:     self.transition_frame_counter / self.transition_frame_total
Aug 19 12:08:05 ledfx-server python3[58142]: ZeroDivisionError: float division by zero
```