### PR TITLE
Better clear effect behaviour including transitions

### DIFF
--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -22,12 +22,17 @@ class DummyEffect:
 
     def __init__(self, pixel_count):
         self.pixels = np.zeros((pixel_count, 3))
+        self.pixel_count = pixel_count
 
     def _render(self):
-        pass
+        # we don't need a self.lock as we don't do anything in deactivate
+        # self.pixels will be valid while this instance is in scope
+        self.render()
 
     def render(self):
-        pass
+        # we need to clear this each render frame as transitions reuse
+        # active effect pixel space
+        self.pixels = np.zeros((self.pixel_count, 3))
 
     def get_pixels(self):
         return self.pixels

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -342,13 +342,21 @@ class Virtual:
     def clear_effect(self):
         self._ledfx.events.fire_event(EffectClearedEvent())
 
-        self._transition_effect = self._active_effect
-        self._active_effect = DummyEffect(self.pixel_count)
+        if (
+            self._config["transition_mode"] != "None"
+            and self._config["transition_time"] > 0
+        ):
+            self._transition_effect = self._active_effect
+            self._active_effect = DummyEffect(self.pixel_count)
 
-        self.transition_frame_total = (
-            self.refresh_rate * self._config["transition_time"]
-        )
-        self.transition_frame_counter = 0
+            self.transition_frame_total = (
+                self.refresh_rate * self._config["transition_time"]
+            )
+            self.transition_frame_counter = 0
+        else:
+            # no transition effect to clean up, so clear the active effect now!
+            self.clear_active_effect()
+            self.clear_transition_effect()
 
         self._ledfx.loop.call_later(
             self._config["transition_time"], self.clear_frame


### PR DESCRIPTION
dummy effect render pixels to protect transitions
handle clear_effect more like set_effect to ensure similar transition behavior

Tested with long transition times as per videos in https://discord.com/channels/469985374052286474/1142496786460721162/1142577077028135054

Also tested with zero transition time

Temporarily removed the divide by zero protection to ensure it was not handled better, but then put it back in.