### PR TITLE
Many more mutex protections

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -776,10 +776,10 @@ class AudioReactiveEffect(Effect):
 
     def _audio_data_updated(self):
         self.melbank.cache_clear()
+        self.lock.acquire()
         if self.is_active:
-            self.lock.acquire()
             self.audio_data_updated(self.audio)
-            self.lock.release()
+        self.lock.release()
 
     def audio_data_updated(self, data):
         """

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -264,7 +264,7 @@ class Virtual:
             if self.pixel_count != _pixel_count:
                 self.transitions = Transitions(self.pixel_count)
                 if self._active_effect is not None:
-                    self._active_effect.deactivate()
+                    self._active_effect._deactivate()
                     if self.pixel_count > 0:
                         self._active_effect.activate(self)
 
@@ -290,6 +290,7 @@ class Virtual:
         self.set_effect(effect)
 
     def set_effect(self, effect):
+        self.lock.acquire()
         if not self._devices:
             error = f"Virtual {self.id}: Cannot activate, no configured device segments"
             _LOGGER.warning(error)
@@ -324,7 +325,7 @@ class Virtual:
                 self.id,
             )
         )
-
+        self.lock.release()
         try:
             self.active = True
         except RuntimeError:
@@ -340,6 +341,7 @@ class Virtual:
         self._active_effect = None
 
     def clear_effect(self):
+        self.lock.acquire()
         self._ledfx.events.fire_event(EffectClearedEvent())
 
         if (
@@ -361,18 +363,20 @@ class Virtual:
         self._ledfx.loop.call_later(
             self._config["transition_time"], self.clear_frame
         )
+        self.lock.release()
 
     def clear_transition_effect(self):
         if self._transition_effect is not None:
-            self._transition_effect.deactivate()
+            self._transition_effect._deactivate()
         self._transition_effect = None
 
     def clear_active_effect(self):
         if self._active_effect is not None:
-            self._active_effect.deactivate()
+            self._active_effect._deactivate()
         self._active_effect = None
 
     def clear_frame(self):
+        self.lock.acquire()
         self.clear_active_effect()
         self.clear_transition_effect()
 
@@ -383,8 +387,10 @@ class Virtual:
             self._ledfx.events.fire_event(
                 VirtualUpdateEvent(self.id, self.assembled_frame)
             )
-
+            self.lock.release()
             self.deactivate()
+        else:
+            self.lock.release()
 
     def force_frame(self, color):
         """
@@ -479,6 +485,9 @@ class Virtual:
             if not self._active:
                 break
             start_time = timeit.default_timer()
+            # we need to lock before we test, or we could deactivate
+            # between test and execution
+            self.lock.acquire()
             if (
                 self._active_effect
                 and self._active_effect.is_active
@@ -499,6 +508,7 @@ class Virtual:
                     self._ledfx.events.fire_event(
                         VirtualUpdateEvent(self.id, self.assembled_frame)
                     )
+            self.lock.release()
 
             # adjust for the frame assemble time, min allowed sleep 1 ms
             # this will be more frame accurate on high res sleep systems
@@ -519,7 +529,6 @@ class Virtual:
         """
         Assembles the frame to be flushed.
         """
-        self.lock.acquire()
         # Get and process active effect frame
         self._active_effect._render()
         frame = self._active_effect.get_pixels()
@@ -579,7 +588,6 @@ class Virtual:
 
             np.multiply(frame, self._config["max_brightness"], frame)
             np.multiply(frame, self._ledfx.config["global_brightness"], frame)
-        self.lock.release()
         return frame
 
     def activate(self):


### PR DESCRIPTION
Ramblings at

https://discord.com/channels/469985374052286474/1142496786460721162

FIXES

1) More atomic protection for audio data updated that may access pixel_count, so make sure the check for active is locked in with the call, so don't risk getting pre-empted in the gap..

2) Wrap effect deactivate so that all child and parent deactivate is protected under lock mutex, otherwise effects that deleted things in their own deactivate could be exposed to a render running in parrallel as those elements were deleted. Change all calls to effect deactivate to _deactivate

3) Add lock mutex to virtual.set_effect(), virtual.clear_effect(), virtual.clear_frame() as all of these manipulate _active_effect and _transition_effect and could set them to None while a frame_assemble was in flight

4) Move assemble_frame() lock mutex protection out to the main thread loop so it encapsulates the test for active, or a clear can sneak in between the test and assemble

TESTING

Parallel postman CLI scripts

Several thousand effect changes @250ms focused on effects with specific weaknesses that can be reproduced under pressure
a few thousand effect delete calls @1000ms to kill effects randomly across devices

Final test will be 1 hour run of above but with all effects enabled

Required to run clean with no crashes or lock ups and user interface to be responsive with manual manipulation at the end

Retested segment edit scripts

Considered to run clean now. Could not run more than a few minutes prior without hitting crash conditions with these aggressive scripts

