### PR TITLE
Fix DummyEffect api issue and Audio Callback / Temporal leakage

### DIFF
--- a/ledfx/api/virtual.py
+++ b/ledfx/api/virtual.py
@@ -38,7 +38,8 @@ class VirtualEndpoint(RestEndpoint):
             "active": virtual.active,
             "effect": {},
         }
-        if virtual.active_effect:
+        # TODO: protecting DummyEffect with test for no name, needs better
+        if virtual.active_effect and virtual.active_effect.name != "":
             effect_response = {}
             effect_response["config"] = virtual.active_effect.config
             effect_response["name"] = virtual.active_effect.name

--- a/ledfx/api/virtual.py
+++ b/ledfx/api/virtual.py
@@ -6,6 +6,7 @@ from aiohttp import web
 
 from ledfx.api import RestEndpoint
 from ledfx.config import save_config
+from ledfx.effects import DummyEffect
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,8 +39,8 @@ class VirtualEndpoint(RestEndpoint):
             "active": virtual.active,
             "effect": {},
         }
-        # TODO: protecting DummyEffect with test for no name, needs better
-        if virtual.active_effect and virtual.active_effect.name != "":
+        # TODO: protect from DummyEffect, future consider side effects
+        if virtual.active_effect and not isinstance(virtual.active_effect, DummyEffect):
             effect_response = {}
             effect_response["config"] = virtual.active_effect.config
             effect_response["name"] = virtual.active_effect.name

--- a/ledfx/api/virtuals.py
+++ b/ledfx/api/virtuals.py
@@ -6,6 +6,7 @@ from aiohttp import web
 from ledfx.api import RestEndpoint
 from ledfx.config import save_config
 from ledfx.utils import generate_id
+from ledfx.effects import DummyEffect
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,8 +33,8 @@ class VirtualsEndpoint(RestEndpoint):
                 "active": virtual.active,
                 "effect": {},
             }
-            # TODO: protecting DummyEffect with test for no name, needs better
-            if virtual.active_effect and virtual.active_effect.name != "":
+            # TODO: protect from DummyEffect, future consider side effects
+            if virtual.active_effect and not isinstance(virtual.active_effect, DummyEffect):
                 effect_response = {}
                 effect_response["config"] = virtual.active_effect.config
                 effect_response["name"] = virtual.active_effect.name

--- a/ledfx/api/virtuals.py
+++ b/ledfx/api/virtuals.py
@@ -32,7 +32,8 @@ class VirtualsEndpoint(RestEndpoint):
                 "active": virtual.active,
                 "effect": {},
             }
-            if virtual.active_effect:
+            # TODO: protecting DummyEffect with test for no name, needs better
+            if virtual.active_effect and virtual.active_effect.name != "":
                 effect_response = {}
                 effect_response["config"] = virtual.active_effect.config
                 effect_response["name"] = virtual.active_effect.name

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -304,11 +304,11 @@ class Virtual:
                 self.refresh_rate * self._config["transition_time"]
             )
             self.transition_frame_counter = 0
+            self.clear_transition_effect()
 
             if self._active_effect is None:
                 self._transition_effect = DummyEffect(self.pixel_count)
             else:
-                self.clear_transition_effect()
                 self._transition_effect = self._active_effect
         else:
             # no transition effect to clean up, so clear the active effect now!
@@ -343,6 +343,7 @@ class Virtual:
     def clear_effect(self):
         self.lock.acquire()
         self._ledfx.events.fire_event(EffectClearedEvent())
+        self.clear_transition_effect()
 
         if (
             self._config["transition_mode"] != "None"
@@ -358,7 +359,6 @@ class Virtual:
         else:
             # no transition effect to clean up, so clear the active effect now!
             self.clear_active_effect()
-            self.clear_transition_effect()
 
         self._ledfx.loop.call_later(
             self._config["transition_time"], self.clear_frame


### PR DESCRIPTION
Stop virtual api get calls from crashing on DummyEffect

Changing scenes with long transitions is one way to trigger this, where devices moving to DummyEffect cause crash on api call until clear.

Just don't populate effect data if active_effect object type is DummyEffect

Also fix audio callback leakage AND temporal effect leakage on double transition calls, leads to build up of runtime on audio callbacks and eventually loss of fps as we max the thread.

Discussed at rambling length in 

https://discord.com/channels/469985374052286474/1143384042683772938

