### PR TITLE
Flush transition effects in a segment edit scenario

### DIFF
--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -262,6 +262,8 @@ class Virtual:
             # eg. devices might be reordered, but total pixel count is same
             # so no need to restart the effect
             if self.pixel_count != _pixel_count:
+                # chenging segments is a deep edit, just flush any transition
+                self.clear_transition_effect()
                 self.transitions = Transitions(self.pixel_count)
                 if self._active_effect is not None:
                     self._active_effect._deactivate()


### PR DESCRIPTION
Changing segment counts can leave active transitions with shape mismatch as they try to use old virtual pixelcount vs new pixelcount during the numpy function manipulation, leading to a crash

As segment edit is a very intentional administrator level like edit, just flush the transition effect if it is active and avoid any possible side effects.

Testing

Manual and via postman rest api calls for easy reproduction.

Set a virtual with 5 second transition
Change effect
As the transition is still in effect, edit virtual segments

Before fix
Leads to crash as per https://github.com/LedFx/LedFx/issues/463

After fix, no crash, transition moves straigth to active effect

