### PR TITLE
Update rtMid dependency version to 1.5.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@
     psutil>=5.8.0
     pyserial~=3.5
     pystray>=0.17
-    python-rtmidi~=1.5.3
+    python-rtmidi~=1.5.6
     requests~=2.28.2
     sacn~=1.6.3
     sentry-sdk==1.14.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ INSTALL_REQUIRES = [
     "psutil>=5.8.0",
     "pyserial>=3.5",
     "pystray>=0.17",
-    "python-rtmidi~=1.5.3",
+    "python-rtmidi~=1.5.6",
     "requests~=2.28.2",
     "sacn~=1.6.3",
     "sentry-sdk==1.14.0",


### PR DESCRIPTION
After struggling to install ledfx on my raspberry pi (with a fresh install of raspberry pi os) I diagnosed the issue to the inability of installing python-rtmidi on the rpi.

I opened an issue at the python-rtmidi repo (https://github.com/SpotlightKid/python-rtmidi/issues/176) and it has been solved in the new update 1.5.6

This merge also updates the dependency to use 1.5.6 in the requirements.txt and setup.py

This is my first time contributing so feedback about my pull request is always welcome!  :)