### PR TITLE
Add slider for melbank filter mapping into RGB channels

### DIFF
--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -254,8 +254,8 @@ class Effect(BaseRegistry):
     def __init__(self, ledfx, config):
         self._ledfx = ledfx
         self._config = {}
-        self.update_config(config)
         self.lock = threading.Lock()
+        self.update_config(config)
 
     def __del__(self):
         if self._active:
@@ -292,8 +292,7 @@ class Effect(BaseRegistry):
         _LOGGER.info(f"Effect {self.NAME} deactivated.")
 
     def update_config(self, config):
-        # TODO: Sync locks to ensure everything is thread safe
-
+        self.lock.acquire()
         validated_config = type(self).schema()(config)
         prior_config = self._config
 
@@ -319,6 +318,7 @@ class Effect(BaseRegistry):
         for base in valid_classes:
             if base.config_updated != super(base, base).config_updated:
                 base.config_updated(self, self._config)
+        self.lock.release()
 
         _LOGGER.debug(
             f"Effect {self.NAME} config updated to {validated_config}."

--- a/ledfx/effects/spectrum.py
+++ b/ledfx/effects/spectrum.py
@@ -8,7 +8,16 @@ class SpectrumAudioEffect(AudioReactiveEffect):
     NAME = "Spectrum"
     CATEGORY = "Classic"
 
-    CONFIG_SCHEMA = vol.Schema({})
+    CONFIG_SCHEMA = vol.Schema({
+        vol.Optional(
+            "RGB Mix",
+            description="How the melbank filters are applied to the RGB values",
+            default=0,
+        ): vol.All(vol.Coerce(int), vol.Range(min=0, max=5)),
+    })
+
+    rgb_mixes = [[0, 1, 2], [0, 2, 1], [1, 0, 2],
+                 [1, 2, 0], [2, 0, 1], [2, 1, 0]]
 
     def on_activate(self, pixel_count):
         self.out = np.zeros((pixel_count, 3))
@@ -18,18 +27,20 @@ class SpectrumAudioEffect(AudioReactiveEffect):
         # prevent crashes from segment edit / led count changes
         if self._b_filter is not None:
             self._b_filter.value = None
+        self.rgb_mix = self.rgb_mixes[self._config["RGB Mix"]]
 
     def config_updated(self, config):
         # Create all the filters used for the effect
         self._b_filter = self.create_filter(alpha_decay=0.1, alpha_rise=0.5)
+        self.rgb_mix = self.rgb_mixes[self._config["RGB Mix"]]
 
     def audio_data_updated(self, data):
         # Grab the filtered and interpolated melbank data
         # Grab the filtered melbank
         y = self.melbank(filtered=False, size=self.pixel_count)
-        self.out[:, 0] = self.melbank(filtered=True, size=self.pixel_count)
-        self.out[:, 1] = np.abs(y - self._prev_y)
-        self.out[:, 2] = self._b_filter.update(y)
+        self.out[:, self.rgb_mix[0]] = self.melbank(filtered=True, size=self.pixel_count)
+        self.out[:, self.rgb_mix[1]] = np.abs(y - self._prev_y)
+        self.out[:, self.rgb_mix[2]] = self._b_filter.update(y)
         self.out *= 1000
 
         self._prev_y = y


### PR DESCRIPTION
As discussed in, along with video at

https://discord.com/channels/469985374052286474/1170158058173911130

A user was looking for color options on the spectrum effect, however, implementation is not really in the dimension of base colors, as it is 

RED a direct plot of freq response
GREEN some kind of difference between last frame freq powers and this frame
BLUE a decaying hostoric filter freq power, with a some clamping on attack, and slow decay

This PR adds a slider for all 6 combinations of mapping those 3 sources into RGB, so the underlying intent of this effect is not changed, we just have some new variations, where 0 is the original and default.

IMPORTANT: While testing isolated a crash in pitchSpectrum due to update_config() preempting a render() pass and flushing key vals to None

This is a day zero issue, that can hit any effect that modifies key variables in update_config()

Added lock in base effect class for update_config() and removed a TODO:

Could crash well under 50 mirror transitions, now appears bullet proof under a lot of abuse.

