### PR TITLE
drop python-mbedtls for linux/arm*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,6 @@
     yappi~=1.4
     zeroconf~=0.39.4
     flux-led>=0.28.35
-    python-mbedtls~=2.7.1; (sys_platform == 'linux' and platform_machine != 'aarch64') or sys_platform == 'win32' or sys_platform == 'darwin'
+    python-mbedtls~=2.7.1; (platform_system == 'Linux' and platform_machine != 'aarch64') or platform_system == 'Windows' or platform_system == 'Darwin'
     python-osc~=1.8.3
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from platform import release
-
 from setuptools import setup
 
 import ledfx.consts as const
@@ -53,13 +51,12 @@ INSTALL_REQUIRES = [
     'uvloop>=0.16.0; platform_system != "Windows"',
     # We can install this on all linux devices, it just won't work for anything other than a Pi
     'rpi-ws281x>=4.3.0; platform_system == "Linux"',
+    # No whl for arm linux need to be build from source
+    'python-mbedtls~=2.7.1; (platform_system == "Linux" and platform_machine != "aarch64") or platform_system == "Windows" or platform_system == "Darwin"',
     "flux-led>=0.28.35",
     "python-osc~=1.8.3",
 ]
 
-osstring = release()
-if not ("rpi" in osstring or "raspi" in osstring):
-    INSTALL_REQUIRES.append("python-mbedtls~=2.7.1")
 
 setup(
     name=PROJECT_PACKAGE_NAME,


### PR DESCRIPTION
This need to remove python-mbedtls so if some one like hue need to compile python-mbedtls from source there is no binary on pypi.org