### PR TITLE
obey the -vv flag for file logging

### DIFF
--- a/ledfx/__main__.py
+++ b/ledfx/__main__.py
@@ -76,7 +76,7 @@ def setup_logging(loglevel, config_dir):
     console_loglevel = loglevel or logging.WARNING
     console_logformat = "[%(levelname)-8s] %(name)-30s : %(message)s"
 
-    file_loglevel = logging.INFO
+    file_loglevel = loglevel or logging.INFO
     file_logformat = "%(asctime)-8s %(name)-30s %(levelname)-8s %(message)s"
 
     root_logger = logging.getLogger()


### PR DESCRIPTION
Existing functionality will ONLY log INFO to file log.

This change makes it obey the -vv switch to up logging to file of debug

This will be of aid to triaging field issues. 

If the -vv switch is not used there will be no change.

Its odd that default for console is only WARNING, but not touching that.