### PR TITLE
rework sentry, disable transactions for non dev.

### DIFF
--- a/ledfx/__main__.py
+++ b/ledfx/__main__.py
@@ -30,7 +30,6 @@ try:
 except ImportError:
     have_psutil = False
 
-
 import ledfx.config as config_helpers
 from ledfx.consts import (
     PROJECT_VERSION,
@@ -283,10 +282,7 @@ def main():
         else:
             p.nice(15)
 
-    if (
-        not (currently_frozen() or installed_via_pip())
-        and args.offline_mode is False
-    ):
+    if args.offline_mode is False:
         import ledfx.sentry_config  # noqa: F401
 
     if args.sentry_test:

--- a/ledfx/sentry_config.py
+++ b/ledfx/sentry_config.py
@@ -9,11 +9,11 @@ from ledfx.consts import DEV, PROJECT_VERSION
 sentry_dsn = "DSN"
 if (
     sentry_dsn
-    == "https://691086dc41fa4218860be6ed4c888145@o482797.ingest.sentry.io/5533553"
+    == "https://4c17033f52d44c3aa372c217395dc95b@o482797.ingest.sentry.io/5596233"
 ):
     sentry_sdk.init(
         sentry_dsn,
-        traces_sample_rate=1,
+        traces_sample_rate=0,
         integrations=[AioHttpIntegration()],
         release=f"ledfx@{PROJECT_VERSION}",
     )

--- a/ledfx/sentry_config.py
+++ b/ledfx/sentry_config.py
@@ -1,6 +1,3 @@
-import sentry_sdk
-from sentry_sdk.integrations.aiohttp import AioHttpIntegration
-
 from ledfx.consts import DEV, PROJECT_VERSION
 import logging
 
@@ -38,6 +35,9 @@ if DEV > 0:
 
 
 if sentry_dsn != "DSN":
+    import sentry_sdk
+    from sentry_sdk.integrations.aiohttp import AioHttpIntegration
+
     _LOGGER.info(
         f"Sentry config\ndsn first ten: {sentry_dsn[8:18]}\nsample_rate: {sample_rate}\nrelease: {release}")
     sentry_sdk.init(

--- a/ledfx/sentry_config.py
+++ b/ledfx/sentry_config.py
@@ -2,23 +2,31 @@ import sentry_sdk
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 
 from ledfx.consts import DEV, PROJECT_VERSION
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+# overall logic
+
+# default is no sentry dsn
+# sentry_dsn can be overridden by build scripts or a developer
+# if a dev sets DEV to 1 or higher in const.py, sentry is turned on
+# if they have overridden dsn it is used, else we put in a dev dsn
 
 # Place your key between the quotes if you have a sentry.io account and wish to use it.
-# Otherwise the LedFx sentry key is inserted here during deployment.
 
+# the following is modified by some build scripts during release process
 sentry_dsn = "DSN"
-if (
-    sentry_dsn
-    == "https://4c17033f52d44c3aa372c217395dc95b@o482797.ingest.sentry.io/5596233"
-):
-    sentry_sdk.init(
-        sentry_dsn,
-        traces_sample_rate=0,
-        integrations=[AioHttpIntegration()],
-        release=f"ledfx@{PROJECT_VERSION}",
-    )
-elif DEV > 0:
-    sentry_dsn = "https://de9ea3e00f334954b2f1478b90936d55@o482797.ingest.sentry.io/5886499"
+sample_rate = 0
+release = f"ledfx@{PROJECT_VERSION}"
+
+# a developer can decide to turn on sentry tracking to a specific backend,
+# along with transaction measurements if they wish to by bumping up DEV value in
+# consts.py to 1 or higher
+if DEV > 0:
+    if sentry_dsn == "DSN":
+        sentry_dsn = "https://de9ea3e00f334954b2f1478b90936d55@o482797.ingest.sentry.io/5886499"
+    sample_rate = 1
 
     from subprocess import PIPE, Popen
 
@@ -26,10 +34,18 @@ elif DEV > 0:
     (commit_hash, err) = process.communicate()
     commit_hash = commit_hash[:7].decode("utf-8")
     exit_code = process.wait()
+    release = f"ledfx@{PROJECT_VERSION}-{commit_hash}"
 
+
+if sentry_dsn != "DSN":
+    _LOGGER.info(
+        f"Sentry config\ndsn first ten: {sentry_dsn[8:18]}\nsample_rate: {sample_rate}\nrelease: {release}")
     sentry_sdk.init(
         sentry_dsn,
-        traces_sample_rate=1,
+        traces_sample_rate=sample_rate,
         integrations=[AioHttpIntegration()],
-        release=f"ledfx@{PROJECT_VERSION}-{commit_hash}",
+        release=release,
     )
+else:
+    _LOGGER.info("Sentry not configured")
+

--- a/ledfx/sentry_config.py
+++ b/ledfx/sentry_config.py
@@ -1,5 +1,6 @@
-from ledfx.consts import DEV, PROJECT_VERSION
 import logging
+
+from ledfx.consts import DEV, PROJECT_VERSION
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,7 +40,8 @@ if sentry_dsn != "DSN":
     from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 
     _LOGGER.info(
-        f"Sentry config\ndsn first ten: {sentry_dsn[8:18]}\nsample_rate: {sample_rate}\nrelease: {release}")
+        f"Sentry config\ndsn first ten: {sentry_dsn[8:18]}\nsample_rate: {sample_rate}\nrelease: {release}"
+    )
     sentry_sdk.init(
         sentry_dsn,
         traces_sample_rate=sample_rate,
@@ -48,4 +50,3 @@ if sentry_dsn != "DSN":
     )
 else:
     _LOGGER.info("Sentry not configured")
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@
     python-rtmidi~=1.5.6
     requests~=2.28.2
     sacn~=1.6.3
-    sentry-sdk==1.14.0
+    sentry-sdk==1.38.0
     samplerate>=0.1.0
     sounddevice~=0.4.2
     icmplib~=3.0.3

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ INSTALL_REQUIRES = [
     "python-rtmidi~=1.5.6",
     "requests~=2.28.2",
     "sacn~=1.6.3",
-    "sentry-sdk==1.14.0",
+    "sentry-sdk==1.38.0",
     "sounddevice~=0.4.2",
     "samplerate>=0.1.0",
     "icmplib~=3.0.3",


### PR DESCRIPTION
This change can now go in and have the same as existing behavior for pypi until we start injecting DSN for discord releases

Transaction reporting has been removed for releases, we don't farm that data yet.

We can leave pipy builds reporting to the existing backend

Add client key for the discord releases into 

Ledfx - the current pypi end point, uses key : 
https://691086dc4,,,
Ledfx-betas we can use for discord releases into 
https://4c17033f5...
Ledfx-betas-v2 can be for developer releases, and key is hard coded into this PR for such, by bumping const.py DEV to not zero
https://de9ea3e00f...

We should add filtering to Ledfx to discard 0.x incoming

All these keys can also be reworked easily.