### PR TITLE
Move to sentry-v2-dev / sentry-v2-rel

### DIFF
--- a/.github/workflows/publish-release-pypi.yml
+++ b/.github/workflows/publish-release-pypi.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup sentry config
         shell: bash
         env:
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN_PYPI }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN_V2_REL }}
         run: |
           sed -i 's,DSN,'"$SENTRY_DSN"',' ./ledfx/sentry_config.py
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}

--- a/ledfx/sentry_config.py
+++ b/ledfx/sentry_config.py
@@ -22,8 +22,9 @@ release = f"ledfx@{PROJECT_VERSION}"
 # along with transaction measurements if they wish to by bumping up DEV value in
 # consts.py to 1 or higher
 if DEV > 0:
-    if sentry_dsn == "DSN":
-        sentry_dsn = "https://de9ea3e00f334954b2f1478b90936d55@o482797.ingest.sentry.io/5886499"
+    # if a developer has overridden dsn, use it, else inject a dev dsn
+    if len(sentry_dsn) == 3:  # avoid string replace problems with existing scripts
+        sentry_dsn = "https://b192934eebd517c86bf7e9c512b3888a@o482797.ingest.sentry.io/4506350241841152"
     sample_rate = 1
 
     from subprocess import PIPE, Popen


### PR DESCRIPTION
THIS WILL BE RE-WRITTEN FOR POETRY


Avoid DSN string replace risk

Move to brand new key, in this case ledfx-v2-dev where intention is

ledfx-v2-rel
client key / DSN
https://dc6070345a8dfa1f2f24433d16f7a133@o482797.ingest.sentry.io/4506350233321472

We can use this for crash traces on Pypi and normal release instances. I will look to see if I can add a secret into the repo and change the script for pypi accordingly. @Blade (GMT+1) , we will need to add that client key into the normal non pypi release process as well.

ledfx-v2-dev
client key / DSN
https://b192934eebd517c86bf7e9c512b3888a@o482797.ingest.sentry.io/4506350241841152

We can use this for dev tracing by bumping the value of DEV in consts.py to non zero, I will tweak up a PR shortly to use this client key

Tested with forced crash in dev mode.
Will need official builds to test / validate release intent