### PR TITLE
WIP:  Twinklefox/Twinklecat effect from FastLED/WLED

### DIFF
--- a/ledfx/effects/twinklefox.py
+++ b/ledfx/effects/twinklefox.py
@@ -7,8 +7,8 @@ from ledfx.effects.hsv_effect import HSVEffect
 
 #Second attempt at reimplementing https://gist.github.com/kriegsman/756ea6dcae8e30845b5a / twinklefox_base from https://github.com/Aircoookie/WLED/blob/main/wled00/FX.cpp
 #in a manner suited to a machine with more RAM and CPU than a microcontroller/numpy
-class Twinklefox2(AudioReactiveEffect, HSVEffect):
-    NAME = "Twinklefox v2"
+class Twinklefox(AudioReactiveEffect, HSVEffect):
+    NAME = "Twinklefox"
     CATEGORY = "Atmospheric"
 
     _power_funcs = {

--- a/ledfx/effects/twinklefox.py
+++ b/ledfx/effects/twinklefox.py
@@ -64,9 +64,13 @@ class Twinklefox(AudioReactiveEffect, HSVEffect):
 
         # Instead of generating our random values from a deterministic PRNG on every run to save RAM, we've got lots of RAM, so maintain state variables for each pixel
         # and assign fully random values to them all
-        self.speed_modifier = 1.0 + 2.0 * np.random.rand(self.pixel_count) # Initialize with a random speed modifier, otherwise the effect starts out too uniform
-        self.phase = np.random.rand(self.pixel_count) / self._config["density"] # Also a random portion of the phase cycle
-        self.hue = np.random.rand(self.pixel_count) # Random hue
+        self.speed_modifier = 1.0 + 2.0 * np.random.rand(
+            self.pixel_count
+        )  # Initialize with a random speed modifier, otherwise the effect starts out too uniform
+        self.phase = (
+            np.random.rand(self.pixel_count) / self._config["density"]
+        )  # Also a random portion of the phase cycle
+        self.hue = np.random.rand(self.pixel_count)  # Random hue
 
     def config_updated(self, config):
         self._power = 0

--- a/ledfx/effects/twinklefox.py
+++ b/ledfx/effects/twinklefox.py
@@ -1,12 +1,14 @@
+import time
+
 import numpy as np
 import voluptuous as vol
-import time
 
 from ledfx.effects.audio import AudioReactiveEffect
 from ledfx.effects.hsv_effect import HSVEffect
 
-#Second attempt at reimplementing https://gist.github.com/kriegsman/756ea6dcae8e30845b5a / twinklefox_base from https://github.com/Aircoookie/WLED/blob/main/wled00/FX.cpp
-#in a manner suited to a machine with more RAM and CPU than a microcontroller/numpy
+
+# Second attempt at reimplementing https://gist.github.com/kriegsman/756ea6dcae8e30845b5a / twinklefox_base from https://github.com/Aircoookie/WLED/blob/main/wled00/FX.cpp
+# in a manner suited to a machine with more RAM and CPU than a microcontroller/numpy
 class Twinklefox(AudioReactiveEffect, HSVEffect):
     NAME = "Twinklefox"
     CATEGORY = "Atmospheric"
@@ -59,8 +61,8 @@ class Twinklefox(AudioReactiveEffect, HSVEffect):
 
     def on_activate(self, pixel_count):
         self.last_time = time.time_ns()
-        self.speed_modifier = 1.0 + 2.0*np.random.rand(self.pixel_count)
-        self.phase = np.random.rand(self.pixel_count)/self._config["density"]
+        self.speed_modifier = 1.0 + 2.0 * np.random.rand(self.pixel_count)
+        self.phase = np.random.rand(self.pixel_count) / self._config["density"]
         self.hue = np.random.rand(self.pixel_count)
 
     def config_updated(self, config):
@@ -69,8 +71,8 @@ class Twinklefox(AudioReactiveEffect, HSVEffect):
             alpha_decay=0.05, alpha_rise=0.2
         )
 
-        self.clk_div = np.power(2, 7 - 6*self._config["speed"])
-        self.trig_thresh = (1.0/self.config["density"]) - 1.0
+        self.clk_div = np.power(2, 7 - 6 * self._config["speed"])
+        self.trig_thresh = (1.0 / self.config["density"]) - 1.0
         self.power_func = self._power_funcs[self._config["frequency_range"]]
 
     def audio_data_updated(self, data):
@@ -79,34 +81,46 @@ class Twinklefox(AudioReactiveEffect, HSVEffect):
         )
 
     def array_sawtooth(self, a):
-        pk = self.config["phase_peak"] #I don't want to type this over and over again...
-        return np.where(a < pk, a/pk, 1.0-(a-pk)/(1-pk))
+        pk = self.config[
+            "phase_peak"
+        ]  # I don't want to type this over and over again...
+        return np.where(a < pk, a / pk, 1.0 - (a - pk) / (1 - pk))
 
     def render_hsv(self):
         now_ns = time.time_ns()
-        dt = (now_ns - self.last_time)/1.0e6 #Original twinklefox ticks in milliseconds
+        dt = (
+            now_ns - self.last_time
+        ) / 1.0e6  # Original twinklefox ticks in milliseconds
 
-        dt *= 1.0 + self._power*np.power(2,self._config["speed_reac"]*7-1)
-        #Rewrite twinklefox's clock increase in a different manner.
-        self.phase += self.speed_modifier*dt/(self.clk_div*256.0)
+        dt *= 1.0 + self._power * np.power(
+            2, self._config["speed_reac"] * 7 - 1
+        )
+        # Rewrite twinklefox's clock increase in a different manner.
+        self.phase += self.speed_modifier * dt / (self.clk_div * 256.0)
         self.last_time = now_ns
 
-
-        #Get brightness from our current phase if < 1.0
+        # Get brightness from our current phase if < 1.0
         bright = self.array_sawtooth(np.where(self.phase < 1.0, self.phase, 0))
 
-        #Determine whether to trigger a new twinkle, and if so, choose a new random hue and speed mult, and reset phase to zero
-        #Unlike original twinklefox, the deadtime for any pixel is exactly (1-density) - we rely on the speed multiplier to hide that
-        #from the viewer
-        trig_idxs = (self.phase > 1.0 + (1.0-self._config["dens_reac"]*self._power)*self.trig_thresh).nonzero()[0] #Can lows_power ever be > 1.0?  I don't think so?
+        # Determine whether to trigger a new twinkle, and if so, choose a new random hue and speed mult, and reset phase to zero
+        # Unlike original twinklefox, the deadtime for any pixel is exactly (1-density) - we rely on the speed multiplier to hide that
+        # from the viewer
+        trig_idxs = (
+            self.phase
+            > 1.0
+            + (1.0 - self._config["dens_reac"] * self._power)
+            * self.trig_thresh
+        ).nonzero()[
+            0
+        ]  # Can lows_power ever be > 1.0?  I don't think so?
         numup = len(trig_idxs)
 
-        if(numup > 0):
-            #reset phase to 0 when we trigger
-            #This is inefficient/wasteful as hell, need to rework this once it seems to be mostly OK.
+        if numup > 0:
+            # reset phase to 0 when we trigger
+            # This is inefficient/wasteful as hell, need to rework this once it seems to be mostly OK.
             self.phase[trig_idxs] = 0
             self.hue[trig_idxs] = np.random.rand(numup)
-            self.speed_modifier[trig_idxs] = 1.0+2.0*np.random.rand(numup)
+            self.speed_modifier[trig_idxs] = 1.0 + 2.0 * np.random.rand(numup)
 
         self.hsv_array[:, 0] = self.hue
         self.hsv_array[:, 1] = 1

--- a/ledfx/effects/twinklefox2.py
+++ b/ledfx/effects/twinklefox2.py
@@ -67,6 +67,8 @@ class Twinklefox2(AudioReactiveEffect, HSVEffect):
         now_ns = time.time_ns()
         dt = (now_ns - self.last_time)/1.0e6 #Original twinklefox ticks in milliseconds
 
+        reac_factor = self._lows_power*self._config["reactivity"] #Can lows_power ever be > 1.0?  I don't think so?
+        dt *= 1.0 + reac_factor
         #Rewrite twinklefox's clock increase in a different manner.
         self.phase += self.speed_modifier*dt/(self.clk_div*256.0)
         self.last_time = now_ns
@@ -78,7 +80,7 @@ class Twinklefox2(AudioReactiveEffect, HSVEffect):
         #Determine whether to trigger a new twinkle, and if so, choose a new random hue and speed mult, and reset phase to zero
         #Unlike original twinklefox, the deadtime for any pixel is exactly (1-density) - we rely on the speed multiplier to hide that
         #from the viewer
-        trig_idxs = (self.phase > 1.0 + self.trig_thresh).nonzero()[0]
+        trig_idxs = (self.phase > 1.0 + (1.0-reac_factor)*self.trig_thresh).nonzero()[0]
         numup = len(trig_idxs)
 
         if(numup > 0):

--- a/ledfx/effects/twinklefox2.py
+++ b/ledfx/effects/twinklefox2.py
@@ -1,0 +1,93 @@
+import numpy as np
+import voluptuous as vol
+import time
+
+from ledfx.effects.audio import AudioReactiveEffect
+from ledfx.effects.hsv_effect import HSVEffect
+
+#Second attempt at reimplementing https://gist.github.com/kriegsman/756ea6dcae8e30845b5a / twinklefox_base from https://github.com/Aircoookie/WLED/blob/main/wled00/FX.cpp
+#in a manner suited to a machine with more RAM and CPU than a microcontroller/numpy
+class Twinklefox2(AudioReactiveEffect, HSVEffect):
+    NAME = "Twinklefox v2"
+    CATEGORY = "Atmospheric"
+
+    CONFIG_SCHEMA = vol.Schema(
+        {
+            vol.Optional(
+                "speed",
+                description="Effect Speed",
+                default=0.5,
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=1.0)),
+            vol.Optional(
+                "phase_peak",
+                description="Phase peak",
+                default=0.33,
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.00001, max=1.0)),
+            vol.Optional(
+                "density",
+                description="Twinkle density",
+                default=0.625,
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.00001, max=1.0)),
+            vol.Optional(
+                "reactivity",
+                description="Audio Reactive modifier",
+                default=0.2,
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.00001, max=1.0)),
+        }
+    )
+
+    def __init__(self, ledfx, config):
+        super().__init__(ledfx, config)
+
+    def on_activate(self, pixel_count):
+        self.last_time = time.time_ns()
+        self.speed_modifier = np.ones(self.pixel_count)
+        self.phase = np.ones(self.pixel_count)
+        self.hue = np.random.rand(self.pixel_count)
+
+    def config_updated(self, config):
+        self._lows_power = 0
+        self._lows_filter = self.create_filter(
+            alpha_decay=0.05, alpha_rise=0.2
+        )
+
+        self.clk_div = np.power(2, 7 - 6*self._config["speed"])
+        self.trig_thresh = (1.0/self.config["density"]) - 1.0
+
+    def audio_data_updated(self, data):
+        self._lows_power = self._lows_filter.update(
+            data.lows_power(filtered=False)
+        )
+
+    def array_sawtooth(self, a):
+        pk = self.config["phase_peak"] #I don't want to type this over and over again...
+        return np.where(a < pk, a/pk, 1.0-(a-pk)/(1-pk))
+
+    def render_hsv(self):
+        now_ns = time.time_ns()
+        dt = (now_ns - self.last_time)/1.0e6 #Original twinklefox ticks in milliseconds
+
+        #Rewrite twinklefox's clock increase in a different manner.
+        self.phase += self.speed_modifier*dt/(self.clk_div*256.0)
+        self.last_time = now_ns
+
+
+        #Get brightness from our current phase if < 1.0
+        bright = self.array_sawtooth(np.where(self.phase < 1.0, self.phase, 0))
+
+        #Determine whether to trigger a new twinkle, and if so, choose a new random hue and speed mult, and reset phase to zero
+        #Unlike original twinklefox, the deadtime for any pixel is exactly (1-density) - we rely on the speed multiplier to hide that
+        #from the viewer
+        trig_idxs = (self.phase > 1.0 + self.trig_thresh).nonzero()[0]
+        numup = len(trig_idxs)
+
+        if(numup > 0):
+            #reset phase to 0 when we trigger
+            #This is inefficient/wasteful as hell, need to rework this once it seems to be mostly OK.
+            self.phase[trig_idxs] = 0
+            self.hue[trig_idxs] = np.random.rand(numup)
+            self.speed_modifier[trig_idxs] = 1.0+2.0*np.random.rand(numup)
+
+        self.hsv_array[:, 0] = self.hue
+        self.hsv_array[:, 1] = 1
+        self.hsv_array[:, 2] = bright

--- a/ledfx/effects/twinklefox2.py
+++ b/ledfx/effects/twinklefox2.py
@@ -59,8 +59,8 @@ class Twinklefox2(AudioReactiveEffect, HSVEffect):
 
     def on_activate(self, pixel_count):
         self.last_time = time.time_ns()
-        self.speed_modifier = np.ones(self.pixel_count)
-        self.phase = np.ones(self.pixel_count)
+        self.speed_modifier = 1.0 + 2.0*np.random.rand(self.pixel_count)
+        self.phase = np.random.rand(self.pixel_count)/self._config["density"]
         self.hue = np.random.rand(self.pixel_count)
 
     def config_updated(self, config):

--- a/ledfx/effects/twinklefox2.py
+++ b/ledfx/effects/twinklefox2.py
@@ -16,7 +16,7 @@ class Twinklefox2(AudioReactiveEffect, HSVEffect):
             vol.Optional(
                 "speed",
                 description="Effect Speed",
-                default=0.5,
+                default=0.25,
             ): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=1.0)),
             vol.Optional(
                 "phase_peak",
@@ -26,12 +26,17 @@ class Twinklefox2(AudioReactiveEffect, HSVEffect):
             vol.Optional(
                 "density",
                 description="Twinkle density",
-                default=0.625,
+                default=0.30,
             ): vol.All(vol.Coerce(float), vol.Range(min=0.00001, max=1.0)),
             vol.Optional(
-                "reactivity",
-                description="Audio Reactive modifier",
+                "speed_reac",
+                description="Audio Reactivity (speed)",
                 default=0.2,
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.00001, max=1.0)),
+            vol.Optional(
+                "dens_reac",
+                description="Audio Reactivity (density)",
+                default=0.8,
             ): vol.All(vol.Coerce(float), vol.Range(min=0.00001, max=1.0)),
         }
     )
@@ -67,8 +72,7 @@ class Twinklefox2(AudioReactiveEffect, HSVEffect):
         now_ns = time.time_ns()
         dt = (now_ns - self.last_time)/1.0e6 #Original twinklefox ticks in milliseconds
 
-        reac_factor = self._lows_power*self._config["reactivity"] #Can lows_power ever be > 1.0?  I don't think so?
-        dt *= 1.0 + reac_factor
+        dt *= 1.0 + self._lows_power*np.power(2,self._config["speed_reac"]*7-1)
         #Rewrite twinklefox's clock increase in a different manner.
         self.phase += self.speed_modifier*dt/(self.clk_div*256.0)
         self.last_time = now_ns
@@ -80,7 +84,7 @@ class Twinklefox2(AudioReactiveEffect, HSVEffect):
         #Determine whether to trigger a new twinkle, and if so, choose a new random hue and speed mult, and reset phase to zero
         #Unlike original twinklefox, the deadtime for any pixel is exactly (1-density) - we rely on the speed multiplier to hide that
         #from the viewer
-        trig_idxs = (self.phase > 1.0 + (1.0-reac_factor)*self.trig_thresh).nonzero()[0]
+        trig_idxs = (self.phase > 1.0 + (1.0-self._config["dens_reac"]*self._lows_power)*self.trig_thresh).nonzero()[0] #Can lows_power ever be > 1.0?  I don't think so?
         numup = len(trig_idxs)
 
         if(numup > 0):

--- a/ledfx/effects/twinklefox2.py
+++ b/ledfx/effects/twinklefox2.py
@@ -11,6 +11,14 @@ class Twinklefox2(AudioReactiveEffect, HSVEffect):
     NAME = "Twinklefox v2"
     CATEGORY = "Atmospheric"
 
+    _power_funcs = {
+        "Beat": "beat_power",
+        "Bass": "bass_power",
+        "Lows (beat+bass)": "lows_power",
+        "Mids": "mids_power",
+        "High": "high_power",
+    }
+
     CONFIG_SCHEMA = vol.Schema(
         {
             vol.Optional(
@@ -28,6 +36,11 @@ class Twinklefox2(AudioReactiveEffect, HSVEffect):
                 description="Twinkle density",
                 default=0.30,
             ): vol.All(vol.Coerce(float), vol.Range(min=0.00001, max=1.0)),
+            vol.Optional(
+                "frequency_range",
+                description="Frequency range for the beat detection",
+                default="Lows (beat+bass)",
+            ): vol.In(list(_power_funcs.keys())),
             vol.Optional(
                 "speed_reac",
                 description="Audio Reactivity (speed)",
@@ -51,17 +64,18 @@ class Twinklefox2(AudioReactiveEffect, HSVEffect):
         self.hue = np.random.rand(self.pixel_count)
 
     def config_updated(self, config):
-        self._lows_power = 0
-        self._lows_filter = self.create_filter(
+        self._power = 0
+        self._power_filter = self.create_filter(
             alpha_decay=0.05, alpha_rise=0.2
         )
 
         self.clk_div = np.power(2, 7 - 6*self._config["speed"])
         self.trig_thresh = (1.0/self.config["density"]) - 1.0
+        self.power_func = self._power_funcs[self._config["frequency_range"]]
 
     def audio_data_updated(self, data):
-        self._lows_power = self._lows_filter.update(
-            data.lows_power(filtered=False)
+        self._power = self._power_filter.update(
+            getattr(data, self.power_func)()
         )
 
     def array_sawtooth(self, a):
@@ -72,7 +86,7 @@ class Twinklefox2(AudioReactiveEffect, HSVEffect):
         now_ns = time.time_ns()
         dt = (now_ns - self.last_time)/1.0e6 #Original twinklefox ticks in milliseconds
 
-        dt *= 1.0 + self._lows_power*np.power(2,self._config["speed_reac"]*7-1)
+        dt *= 1.0 + self._power*np.power(2,self._config["speed_reac"]*7-1)
         #Rewrite twinklefox's clock increase in a different manner.
         self.phase += self.speed_modifier*dt/(self.clk_div*256.0)
         self.last_time = now_ns
@@ -84,7 +98,7 @@ class Twinklefox2(AudioReactiveEffect, HSVEffect):
         #Determine whether to trigger a new twinkle, and if so, choose a new random hue and speed mult, and reset phase to zero
         #Unlike original twinklefox, the deadtime for any pixel is exactly (1-density) - we rely on the speed multiplier to hide that
         #from the viewer
-        trig_idxs = (self.phase > 1.0 + (1.0-self._config["dens_reac"]*self._lows_power)*self.trig_thresh).nonzero()[0] #Can lows_power ever be > 1.0?  I don't think so?
+        trig_idxs = (self.phase > 1.0 + (1.0-self._config["dens_reac"]*self._power)*self.trig_thresh).nonzero()[0] #Can lows_power ever be > 1.0?  I don't think so?
         numup = len(trig_idxs)
 
         if(numup > 0):


### PR DESCRIPTION
This is an initial attempt at porting the Twinklefox/Twinklecat effect (these only differ in the brightness ramp behavior, set ramp peak to 0 for "cat") from WLED to LedFX and adding sound reactivity.

This WIP PR includes two implementations - a mostly direct port of the microcontroller-oriented original implementation, and one (v2) that is a rewrite to be more suitable to a machine with more RAM/CPU than a microcontroller, leveraging numpy's goodness.

For the most part, I think v2 is going to supersede the original port to the point where I'll delete the v1 commits prior to any merging, but I'm including v1 here as a reference.  So far it really looks like getting sound reactivity (which does not exist in any other implementation I am aware of) working in a reasonable fashion requires having the "density" value be reactive to sound, and that's not sanely possible with the original implementation.

v2 currently has the limitation that the deadtime is directly proportional to the on-time for each pixel.  This is mostly masked by the random speed multiplier for each pixel activation, but the difference isn't that apparent to the viewer.

I could really use some advice on the sound reactivity aspects (see comments) and tips on how to make this work better with "traditional" Christmas music.  (My goal here is to have this react well to my parents' Christmas playlist when I go to visit them for the holidays next week.  I do not expect this to be anywhere close to a mergeable state by then, but I'm hoping for some tips on getting it to a more usable state.)