### PR TITLE
Better Matrix rotation handling for non square

### DIFF
--- a/.github/workflows/ci-linting.yml
+++ b/.github/workflows/ci-linting.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CACHE_VERSION: 1
-  DEFAULT_PYTHON: 3.8
+  DEFAULT_PYTHON: 3.9
   PRE_COMMIT_HOME: ~/.cache/pre-commit
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   CACHE_VERSION: 1
-  DEFAULT_PYTHON: 3.8
+  DEFAULT_PYTHON: 3.9
 
 jobs:
   analyze-python:

--- a/hiddenimports.py
+++ b/hiddenimports.py
@@ -28,5 +28,5 @@ hiddenimports = [
     "pythonosc",
     "pythonosc.osc_message_builder",
     "pythonosc.udp_client",
-    "mss"
+    "mss",
 ]

--- a/hiddenimports.py
+++ b/hiddenimports.py
@@ -28,4 +28,5 @@ hiddenimports = [
     "pythonosc",
     "pythonosc.osc_message_builder",
     "pythonosc.udp_client",
+    "mss"
 ]

--- a/ledfx/effects/clone.py
+++ b/ledfx/effects/clone.py
@@ -92,8 +92,6 @@ class Clone(Twod):
             "RGB", frame.size, frame.bgra, "raw", "BGRX"
         )
 
-        rgb_image = rgb_image.resize(
-            (self.t_width, self.t_height), Image.BILINEAR
+        self.matrix = rgb_image.resize(
+            (self.r_width, self.r_height), Image.BILINEAR
         )
-
-        return rgb_image

--- a/ledfx/effects/equalizer2d.py
+++ b/ledfx/effects/equalizer2d.py
@@ -96,7 +96,6 @@ class Equalizer2d(Twod, GradientEffect):
         np.clip(self.r, 0, 1, out=self.r)
 
     def draw(self):
-
         if self.test:
             self.draw_test(self.m_draw)
 

--- a/ledfx/effects/imagespin.py
+++ b/ledfx/effects/imagespin.py
@@ -3,7 +3,7 @@ import timeit
 import urllib.request
 
 import voluptuous as vol
-from PIL import Image, ImageDraw
+from PIL import Image
 
 from ledfx.effects.twod import Twod
 from ledfx.utils import get_icon_path

--- a/ledfx/effects/imagespin.py
+++ b/ledfx/effects/imagespin.py
@@ -84,6 +84,7 @@ class Imagespin(Twod):
         )
 
     def do_once(self):
+        super().do_once()
         if self._config["pattern"]:
             url_path = "https://images.squarespace-cdn.com/content/v1/60cc480d9290423b888eb94a/1624780092100-4FLILMIV0YHHU45GB7XZ/Test+Pattern+t.png"
         else:
@@ -94,7 +95,7 @@ class Imagespin(Twod):
                 with urllib.request.urlopen(url_path) as url:
                     self.bass_image = Image.open(url)
                     self.bass_image.thumbnail(
-                        (self.t_width * 4, self.t_height * 4)
+                        (self.r_width * 4, self.r_height * 4)
                     )
                 _LOGGER.info(f"pre scaled {self.bass_image.size}")
 
@@ -120,19 +121,16 @@ class Imagespin(Twod):
         if self.init:
             self.do_once()
 
-        rgb_image = Image.new("RGB", (self.t_width, self.t_height))
-        rgb_draw = ImageDraw.Draw(rgb_image)
-
         if self.test:
-            self.draw_test(rgb_draw)
+            self.draw_test(self.m_draw)
             size = 1.0
             spin = 1.0
         else:
             size = self.bar + self.min_size
             spin = self.bar
 
-        image_w = int(self.t_width * size)
-        image_h = int(self.t_height * size)
+        image_w = int(self.r_width * size)
+        image_h = int(self.r_height * size)
 
         if image_w > 0 and image_h > 0:
             # make a copy of the original that we will manipulate
@@ -153,14 +151,12 @@ class Imagespin(Twod):
                 Image.BILINEAR,
             )
 
-            # render bass_sized_img into rgb_image centered with alpha
-            rgb_image.paste(
+            # render bass_sized_img into self.matrix centered with alpha
+            self.matrix.paste(
                 bass_sized_img,
                 (
-                    int((self.t_width - bass_sized_img.width) / 2),
-                    int((self.t_height - bass_sized_img.height) / 2),
+                    int((self.r_width - bass_sized_img.width) / 2),
+                    int((self.r_height - bass_sized_img.height) / 2),
                 ),
                 bass_sized_img,
             )
-
-        return rgb_image

--- a/ledfx/effects/twod.py
+++ b/ledfx/effects/twod.py
@@ -114,13 +114,19 @@ class Twod(AudioReactiveEffect):
     def image_to_pixels(self):
         # image should be the right size to map in, at this point
         if self.flip:
-            self.matrix = self.matrix.transpose(Image.Transpose.FLIP_TOP_BOTTOM)
+            self.matrix = self.matrix.transpose(
+                Image.Transpose.FLIP_TOP_BOTTOM
+            )
         if self.mirror:
-            self.matrix = self.matrix.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
+            self.matrix = self.matrix.transpose(
+                Image.Transpose.FLIP_LEFT_RIGHT
+            )
         if self.rotate != 0:
             self.matrix = self.matrix.transpose(self.rotate)
         if self.matrix.size != (self.t_width, self.t_height):
-            _LOGGER.error(f"Image is wrong size {self.matrix.size} vs {self.r_width}x{self.r_height}")
+            _LOGGER.error(
+                f"Image is wrong size {self.matrix.size} vs {self.r_width}x{self.r_height}"
+            )
 
         rgb_array = np.frombuffer(self.matrix.tobytes(), dtype=np.uint8)
         rgb_array = rgb_array.astype(np.float32)
@@ -194,7 +200,6 @@ class Twod(AudioReactiveEffect):
         pass
 
     def render(self):
-
         if self.init:
             self.do_once()
 

--- a/ledfx/effects/twod.py
+++ b/ledfx/effects/twod.py
@@ -3,7 +3,7 @@ import timeit
 
 import numpy as np
 import voluptuous as vol
-from PIL import Image
+from PIL import Image, ImageDraw
 
 from ledfx.effects import Effect
 from ledfx.effects.audio import AudioReactiveEffect
@@ -73,48 +73,61 @@ class Twod(AudioReactiveEffect):
         # on change of effect
         self.t_height = self._virtual.config["rows"]
         self.t_width = self.pixel_count // self.t_height
+        self.init = True
 
     def config_updated(self, config):
         self.diag = self._config["diag"]
         self.test = self._config["test"]
 
-        # cannot get t_height here, pixel_count is not set yet on first call :-(
+        # We will render in to native image size of the matrix on rotation
+        # This saves us from having to do ugly resizing and aliasing effects
+        # as well as a small performance boost
+        # we need to accout for swapping vertical and horizotal for 90 / 270
+
         self.flip = self._config["flip vertical"]
         self.mirror = self._config["flip horizontal"]
 
         self.rotate = 0
         if self._config["rotate"] == 1:
             self.rotate = Image.Transpose.ROTATE_90
+            self.flip, self.mirror = self.mirror, self.flip
         if self._config["rotate"] == 2:
             self.rotate = Image.Transpose.ROTATE_180
         if self._config["rotate"] == 3:
             self.rotate = Image.Transpose.ROTATE_270
+            self.flip, self.mirror = self.mirror, self.flip
+        self.init = True
 
-    def image_to_pixels(self, rgb_image):
+    def do_once(self):
+        # defer things that can't be done when pixel_count is not known
+        # so therefore cannot be addressed in config_updated
+        self.init = False
+
+        if self._config["rotate"] == 1 or self._config["rotate"] == 3:
+            # swap width and height for render
+            self.r_width = self.t_height
+            self.r_height = self.t_width
+        else:
+            self.r_width = self.t_width
+            self.r_height = self.t_height
+
+    def image_to_pixels(self):
         # image should be the right size to map in, at this point
         if self.flip:
-            rgb_image = rgb_image.transpose(Image.Transpose.FLIP_TOP_BOTTOM)
+            self.matrix = self.matrix.transpose(Image.Transpose.FLIP_TOP_BOTTOM)
         if self.mirror:
-            rgb_image = rgb_image.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
+            self.matrix = self.matrix.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
         if self.rotate != 0:
-            rgb_image = rgb_image.transpose(self.rotate)
+            self.matrix = self.matrix.transpose(self.rotate)
+        if self.matrix.size != (self.t_width, self.t_height):
+            _LOGGER.error(f"Image is wrong size {self.matrix.size} vs {self.r_width}x{self.r_height}")
 
-        # rgb_image should be the matching size to the display
-        # TODO: Add speculative resize
-        rgb_resized = rgb_image.resize(
-            (self.t_width, self.t_height), Image.BICUBIC
-        )
-        rgb_bytes = rgb_resized.tobytes()
-        rgb_array = np.frombuffer(rgb_bytes, dtype=np.uint8)
+        rgb_array = np.frombuffer(self.matrix.tobytes(), dtype=np.uint8)
         rgb_array = rgb_array.astype(np.float32)
         rgb_array = rgb_array.reshape(int(rgb_array.shape[0] / 3), 3)
 
         copy_length = min(self.pixels.shape[0], rgb_array.shape[0])
         self.pixels[:copy_length, :] = rgb_array[:copy_length, :]
-
-        # self.pixels = rgb_array
-
-        return rgb_image
 
     def log_sec(self):
         self.start = timeit.default_timer()
@@ -140,11 +153,11 @@ class Twod(AudioReactiveEffect):
         self.last = end
         return self.log
 
-    def try_dump(self, rgb_image):
+    def try_dump(self):
         if self.last_dump != self._config["dump"]:
             self.last_dump = self._config["dump"]
             # show image on screen
-            rgb_image.show()
+            self.matrix.show()
             _LOGGER.info(
                 f"dump {self.t_width}x{self.t_height} R: {self.rotate} F: {self.flip} M: {self.mirror}"
             )
@@ -176,17 +189,22 @@ class Twod(AudioReactiveEffect):
 
     def draw(self):
         # this should be implemented in the child class
-        # should render into a PIL image at the final size for display
-        # and return it!
+        # should render into self.matrix at the final size
+        # for display using self.m_draw
         pass
 
     def render(self):
-        # TODO: Move this and rgb_image into do_once function
+
+        if self.init:
+            self.do_once()
 
         self.log_sec()
 
-        rgb_image = self.draw()
-        rgb_image = self.image_to_pixels(rgb_image)
+        self.matrix = Image.new("RGB", (self.r_width, self.r_height))
+        self.m_draw = ImageDraw.Draw(self.matrix)
+
+        self.draw()
+        self.image_to_pixels()
 
         self.try_log()
-        self.try_dump(rgb_image)
+        self.try_dump()


### PR DESCRIPTION
All twod effects will now handle width / height that is the result of rotation
All final rendering will be into native resolution with no rescale / aliasing implications

implement self.matrix Image and self.m_draw ImageDraw in the base twod class
Use in inherited effects
Always render into an image at the rotation width / height to avoid aliasing on resize All buried in twod class
Move do_once into twod as a base class method

Testing all effects on 128x128 and 16x32 panels

Tested test and rotation in all effects

Generally played with features

