### PR TITLE
Prevent wled device crash on resync

### DIFF
--- a/ledfx/devices/wled.py
+++ b/ledfx/devices/wled.py
@@ -115,7 +115,7 @@ class WLEDDevice(NetworkedDevice):
 
     async def resolve_address(self, success_callback=None):
         await super().resolve_address(success_callback)
-        self._destination = self.subdevice._destination = self._destination
+        self.subdevice._destination = self._destination
 
     def flush(self, data):
         self.subdevice.flush(data)

--- a/ledfx/devices/wled.py
+++ b/ledfx/devices/wled.py
@@ -113,6 +113,10 @@ class WLEDDevice(NetworkedDevice):
             self.subdevice.deactivate()
         super().deactivate()
 
+    async def resolve_address(self, success_callback=None):
+        await super().resolve_address(success_callback)
+        self._destination = self.subdevice._destination = self._destination
+
     def flush(self, data):
         self.subdevice.flush(data)
 


### PR DESCRIPTION
Ensure Wled copies _destination address on resolved callback into subdevice _destination

Otherwise flush to wled device passed to subdevice flush had window of opportunity for _destination = None