### PR TITLE
Initial LIFX protocol support

### DIFF
--- a/ledfx/devices/lifx.py
+++ b/ledfx/devices/lifx.py
@@ -1,0 +1,77 @@
+import logging
+import numpy as np
+import voluptuous as vol
+from lifxdev.devices import light, multizone # Import the lifxdev library
+from ledfx.devices import NetworkedDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class LifxDevice(NetworkedDevice):
+    """LIFX device support"""
+
+    CONFIG_SCHEMA = vol.Schema(
+        {
+            vol.Required(
+                "pixel_count",
+                description="Number of individual pixels",
+                default=1,
+            ): vol.All(int, vol.Range(min=1)),
+        }
+    )
+
+    def __init__(self, ledfx, config):
+        super().__init__(ledfx, config)
+        self._device_type = "LIFX"
+        if config["pixel_count"] > 1:
+            self.bulb = multizone.LifxMultiZone(config["ip_address"], label=config["name"])
+        else:
+            self.bulb = light.LifxLight(config["ip_address"], label=config["name"])
+
+    def activate(self):
+        super().activate()
+        self.bulb.set_power(True)
+
+    def deactivate(self):
+        super().deactivate()
+        self.bulb.set_power(False)
+
+    def rgb_to_hsb(self, r, g, b):
+        r, g, b = r / 255.0, g / 255.0, b / 255.0
+        max_color = max(r, g, b)
+        min_color = min(r, g, b)
+        brightness = max_color
+
+        delta = max_color - min_color
+        saturation = 0 if max_color == 0 else (delta / max_color)
+
+        if delta == 0:
+            hue = 0
+        elif max_color == r:
+            hue = (60 * ((g - b) / delta) + 360) % 360
+        elif max_color == g:
+            hue = (60 * ((b - r) / delta) + 120) % 360
+        elif max_color == b:
+            hue = (60 * ((r - g) / delta) + 240) % 360
+        hue = float(hue)
+
+        return hue, float(saturation), float(brightness)
+
+    def flush(self, data):
+        try:
+            byteData = data.astype(np.dtype("B")).reshape(-1, 3)
+            zone_colors = []
+
+            for pixel in byteData:
+                rgb = pixel.tolist()
+                hsb = self.rgb_to_hsb(rgb[0], rgb[1], rgb[2])
+                zone_colors.append((hsb[0], hsb[1], hsb[2], 3000))
+
+            if len(zone_colors) > 1:
+                # print(zone_colors)
+                self.bulb.set_multizone(zone_colors, duration=0, index=0, ack_required=False)
+            else:
+                self.bulb.set_color(zone_colors[0], duration=0, ack_required=False)
+
+        except Exception as e:
+            _LOGGER.error("Error connecting to bulb: %s", e)

--- a/lifxdev/colors/color.py
+++ b/lifxdev/colors/color.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import dataclasses
+import random
+from typing import Union
+
+import numpy as np
+
+from lifxdev.messages import packet
+
+KELVIN = 5500
+
+@dataclasses.dataclass
+class Hsbk:
+    """Human-readable HSBK tuple"""
+
+    hue: float
+    saturation: float
+    brightness: float
+    kelvin: int
+
+    @classmethod
+    def from_packet(cls, hsbk: packet.Hsbk) -> "Hsbk":
+        """Create a HSBK tuple from a message packet"""
+        max_hue = hsbk.get_max("hue") + 1
+        max_saturation = hsbk.get_max("saturation")
+        max_brightness = hsbk.get_max("brightness")
+
+        hue = 360 * hsbk["hue"] / max_hue
+        saturation = hsbk["saturation"] / max_saturation
+        brightness = hsbk["brightness"] / max_brightness
+        kelvin = hsbk["kelvin"]
+
+        return cls(hue=hue, saturation=saturation, brightness=brightness, kelvin=kelvin)
+
+    @classmethod
+    def from_tuple(cls, hsbk: Union[tuple, "Hsbk"]) -> "Hsbk":
+        """Create a HSBK tuple from a normal tuple. Assume input is human-readable"""
+        if isinstance(hsbk, Hsbk):
+            return hsbk
+        hue, saturation, brightness, kelvin = hsbk
+        return cls(hue=hue, saturation=saturation, brightness=brightness, kelvin=kelvin)
+
+    def max_brightness(self, brightness: float) -> "Hsbk":
+        """Force the brightness to be at most a specific value"""
+        if self.brightness > brightness:
+            return dataclasses.replace(self, brightness=brightness)
+        return self
+
+    def to_packet(self) -> packet.Hsbk:
+        """Create a message packet from an HSBK tuple"""
+        hsbk = packet.Hsbk()
+        max_hue = hsbk.get_max("hue") + 1
+        max_saturation = hsbk.get_max("saturation")
+        max_brightness = hsbk.get_max("brightness")
+
+        hsbk["hue"] = int(self.hue * max_hue / 360) % max_hue
+        hsbk["saturation"] = min(int(self.saturation * max_saturation), max_saturation)
+        hsbk["brightness"] = min(int(self.brightness * max_brightness), max_brightness)
+        hsbk["kelvin"] = int(self.kelvin)
+        return hsbk
+

--- a/lifxdev/devices/device.py
+++ b/lifxdev/devices/device.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import socket
+from collections.abc import Callable
+
+from lifxdev.messages import packet
+from lifxdev.messages import device_messages
+
+
+class LifxDevice:
+    """LIFX device control"""
+
+    def __init__(
+        self,
+        ip: str,
+        *,
+        mac_addr: str | None = None,
+        port: int = packet.LIFX_PORT,
+        buffer_size: int = packet.BUFFER_SIZE,
+        timeout: float = packet.TIMEOUT_S,
+        verbose: bool = False,
+        comm_init: Callable | None = None,
+    ):
+        """Create a LIFX device from an IP address
+
+        Args:
+            ip: (str) IP addess of the device.
+            mac_addr: (str) Mac address of the device.
+            port: (int) UDP port of the device.
+            buffer_size: (int) Buffer size for receiving UDP responses.
+            broadcast: (bool) Whether the IP address is a broadcast address.
+            verbose: (bool) Use logging.info instead of logging.debug.
+            comm_init: (function) This function (no args) creates a socket object.
+        """
+        if comm_init:
+            comm = comm_init()
+        else:
+            comm = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        comm.settimeout(timeout)
+        comm.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        udp_sender = packet.UdpSender(
+            mac_addr=mac_addr,
+            ip=ip,
+            port=port,
+            comm=comm,
+            buffer_size=buffer_size,
+        )
+        self._comm = packet.PacketComm(udp_sender, verbose, timeout)
+        self._verbose = verbose
+
+    @property
+    def ip(self) -> str:
+        return self._comm.ip
+
+    def send_msg(
+        self,
+        payload: packet.LifxMessage,
+        *,
+        ack_required: bool = False,
+        verbose: bool = False,
+    ) -> packet.LifxResponse | None:
+        """Send a message to a device.
+
+        This can be used to send any LIFX message to the device. Functions
+        that send messages to the device will all wrap this function. This
+        function can be used when a wrapper for a message is not available.
+
+        Args:
+            payload: (packet.LifxMessage) LIFX message to send to a device.
+            ack_required: (bool) Require an acknowledgement from the device.
+            verbose: (bool) Log messages as info instead of debug.
+        """
+        response = self.send_recv(payload, ack_required=ack_required, verbose=verbose)
+        if response:
+            return response.pop()
+
+    def send_recv(
+        self,
+        payload: packet.LifxMessage,
+        *,
+        res_required: bool = False,
+        ack_required: bool = False,
+        ip: str | None = None,
+        port: int | None = None,
+        mac_addr: str | None = None,
+        comm: socket.socket | None = None,
+        retry_recv: bool = False,
+        verbose: bool = False,
+    ) -> list[packet.LifxResponse] | None:
+        """Send a message to a device or broadcast address.
+
+        This can be used to send any LIFX message to the device. Functions
+        that send messages to the device will all wrap this function. This
+        function can be used when a wrapper for a message is not available.
+
+        Args:
+            payload: (packet.LifxMessage) LIFX message to send to a device.
+            res_required: (bool) Require a response from the light.
+            ack_required: (bool) Require an acknowledgement from the device.
+            ip: (str) Override the IP address.
+            port: (int) Override the UDP port.
+            mac_addr: (str) Override the MAC address.
+            comm: (socket) Override the UDP socket.
+            retry_recv: (bool) Re-run recv_from until there are no more packets.
+            verbose: (bool) Log messages as info instead of debug.
+        """
+        if res_required and ack_required:
+            raise ValueError("Cannot set both res_required and ack_required to True.")
+        return self._comm.send_recv(
+            payload=payload,
+            res_required=res_required,
+            ack_required=ack_required,
+            ip=ip,
+            port=port,
+            mac_addr=mac_addr,
+            comm=comm,
+            retry_recv=retry_recv,
+            verbose=verbose or self._verbose,
+        )
+
+    def get_power(self) -> bool:
+        """Return True if the light is powered on."""
+        response = self.send_recv(device_messages.GetPower(), res_required=True)
+        assert response is not None
+        return response.pop().payload["level"]
+
+    def set_power(self, state: bool, *, ack_required=False) -> packet.LifxResponse | None:
+        """Set power state on the device"""
+        power = device_messages.SetPower(level=state)
+        response = self.send_recv(power, ack_required=ack_required)
+        if response:
+            return response.pop()

--- a/lifxdev/devices/device_manager.py
+++ b/lifxdev/devices/device_manager.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import collections
+import dataclasses
+import enum
+import functools
+import logging
+import pathlib
+from collections.abc import Callable
+from typing import Any
+
+import yaml
+
+from lifxdev.colors import color
+from lifxdev.devices import device
+from lifxdev.devices import light
+from lifxdev.devices import multizone
+from lifxdev.devices import tile
+from lifxdev.messages import packet
+from lifxdev.messages import device_messages
+
+
+CONFIG_PATH = pathlib.Path.home() / ".lifx" / "devices.yaml"
+
+
+class DeviceConfigError(Exception):
+    pass
+
+
+class DeviceDiscoveryError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class ProductInfo:
+    ip: str
+    port: int
+    label: str
+    product_name: str
+    device: light.LifxLight
+
+
+class DeviceGroup:
+    """Class for managing groups of devices"""
+
+    def __init__(self, devices_and_groups: dict[str, Any]):
+        """Create a device group.
+
+        Args:
+            devices_and_groups: (dict) Dictionary containing devices and subgroups.
+        """
+        self._devices_and_groups = devices_and_groups
+
+        # Get easy access to all devices in the device group
+        self._all_devices: dict[str, Any] = {}
+        self._all_groups: dict[str, Any] = {}
+        for name, device_or_group in self._devices_and_groups.items():
+            if isinstance(device_or_group, type(self)):
+                self._all_groups[name] = device_or_group
+                for sub_name, sub_device in device_or_group.get_all_devices().items():
+                    self._all_devices[sub_name] = sub_device
+                for sub_name, sub_group in device_or_group.get_all_groups().items():
+                    self._all_groups[sub_name] = sub_group
+            else:
+                self._all_devices[name] = device_or_group
+
+        # Organizing devices by type is useful for setting colormaps
+        self._devices_by_type = collections.defaultdict(list)
+        for lifx_device in self._all_devices.values():
+            device_type = DeviceType[_DEVICE_TYPES_R[type(lifx_device).__name__]]
+            self._devices_by_type[device_type].append(lifx_device)
+
+    def get_all_devices(self) -> dict[str, Any]:
+        return self._all_devices
+
+    def get_all_groups(self) -> dict[str, "DeviceGroup"]:
+        return self._all_groups
+
+    def get_device(self, name: str) -> Any:
+        return self._all_devices[name]
+
+    def get_group(self, name: str) -> "DeviceGroup":
+        return self._all_groups[name]
+
+    def has_device(self, name: str) -> bool:
+        return name in self._all_devices
+
+    def has_group(self, name: str) -> bool:
+        return name in self._all_groups
+
+    def set_color(self, hsbk: color.Hsbk | light.COLOR_T, *, duration: float = 0.0) -> None:
+        """Set the color of all lights in the device group.
+
+        Args:
+            hsbk: (color.Hsbk) Human-readable HSBK tuple.
+            duration: (float) The time in seconds to make the color transition.
+        """
+
+        for target in self._all_devices.values():
+            target.set_color(hsbk, duration=duration, ack_required=False)
+
+    def set_power(self, state: bool, *, duration: float = 0.0) -> None:
+        """Set power state on all lights in the device group.
+
+        Args:
+            state: (bool) True powers on the light. False powers it off.
+            duration: (float) The time in seconds to make the color transition.
+        """
+        for target in self._all_devices.values():
+            target.set_power(state, duration=duration, ack_required=False)
+
+# Convienence for validating type names in config files
+class DeviceType(enum.Enum):
+    group = 0
+    light = 1
+    infrared = 2
+    multizone = 3
+    tile = 4
+
+
+# Mapping and reverse mapping from config file type name to class
+_DEVICE_TYPES = {
+    "group": DeviceGroup,
+    "light": light.LifxLight,
+    "infrared": light.LifxInfraredLight,
+    "multizone": multizone.LifxMultiZone,
+    "tile": tile.LifxTile,
+}
+_DEVICE_TYPES_R = {value.__name__: key for key, value in _DEVICE_TYPES.items()}
+
+
+def _require_config_loaded(function: Callable) -> Callable:
+    """Require configuration to be loaded before calling a class method"""
+
+    @functools.wraps(function)
+    def _run(self, *args, **kwargs) -> Any:
+        if not self._root_device_group:
+            raise DeviceConfigError("Device config not loaded.")
+        return function(self, *args, **kwargs)
+
+    return _run
+
+
+class DeviceManager(device.LifxDevice):
+    """Device manager
+
+    Class for device discovery and loading configs.
+    """
+
+    def __init__(
+        self,
+        config_path: str | pathlib.Path = CONFIG_PATH,
+        *,
+        buffer_size: int = packet.BUFFER_SIZE,
+        timeout: float = packet.TIMEOUT_S,
+        verbose: bool = False,
+        comm_init: Callable | None = None,
+    ):
+        """Create a LIFX device manager.
+
+        Args:
+            config_path: (str) Path to the device config. If non-existant, do not load.
+            buffer_size: (int) Buffer size for receiving UDP responses.
+            timeout: (float) UDP response timeout.
+            nonblock_delay: (float) Delay time to wait for messages when nonblocking.
+            verbose: (bool) Use logging.info instead of logging.debug.
+            comm_init: (function) This function (no args) creates a socket object.
+        """
+        super().__init__(
+            ip="255.255.255.255",
+            buffer_size=buffer_size,
+            timeout=timeout,
+            verbose=verbose,
+            comm_init=comm_init,
+        )
+
+        self._timeout = timeout
+        self._comm_init = comm_init
+
+        # Load product identification
+        products = pathlib.Path(__file__).parent / "products.yaml"
+        with products.open() as f:
+            product_list = yaml.safe_load(f).pop().get("products", [])
+
+        # For easily recovering product info via get_product_class
+        self._products: dict[str, Any] = {}
+        for product in product_list:
+            self._products[product["pid"]] = product
+
+        # Load config sets the self._root_device_group variable
+        self._discovered_device_group: DeviceGroup | None = None
+        self._root_device_group: DeviceGroup | None = None
+        self._config_path = pathlib.Path(config_path)
+        if self._config_path.exists():
+            self.load_config()
+
+    @property
+    def discovered(self) -> DeviceGroup:
+        """The discovered group"""
+        if not self._discovered_device_group:
+            raise DeviceDiscoveryError("Device discovery has not been performed.")
+        return self._discovered_device_group
+
+    @property
+    @_require_config_loaded
+    def root(self) -> DeviceGroup:
+        """The root device group"""
+        assert self._root_device_group
+        return self._root_device_group
+
+    def discover(self, num_retries: int = 10) -> dict[str, ProductInfo]:
+        """Discover devices on the network
+
+        Args:
+            num_retries: (int) Number of GetService calls made.
+        """
+
+        logging.info("Scanning for LIFX devices.")
+        state_service_dict: dict[str, packet.LifxResponse] = {}
+        # Disabling the timeout speeds up discovery
+        for _ in range(num_retries):
+            search_responses = self.get_devices_on_network() or []
+            for response in search_responses:
+                ip = response.addr[0]
+                state_service_dict[ip] = response
+
+        logging.info("Getting device info for discovered devices.")
+        device_dict: dict[str, ProductInfo] = {}
+        for ip, state_service in state_service_dict.items():
+            port = state_service.payload["port"]
+            try:
+                label = self.get_label(ip, port=port)
+                product_dict = self.get_product_info(ip, port=port)
+            except packet.NoResponsesError as e:
+                logging.error(e)
+                continue
+
+            product_name = product_dict["name"]
+            device_klass = product_dict["class"]
+
+            product_info = ProductInfo(
+                ip=ip,
+                port=port,
+                label=label,
+                product_name=product_name,
+                device=device_klass(
+                    ip,
+                    port=port,
+                    label=label,
+                    comm_init=self._comm_init,
+                    timeout=self._timeout,
+                    verbose=self._verbose,
+                ),
+            )
+            device_dict[label] = product_info
+
+        return device_dict
+
+    def get_devices_on_network(self) -> list[packet.LifxResponse] | None:
+        """Get device info from one or more devices.
+
+        Returns:
+            A list of StateService responses.
+        """
+        return self.send_recv(device_messages.GetService(), res_required=True, retry_recv=True)
+
+    def get_label(
+        self,
+        ip: str,
+        *,
+        port: int = packet.LIFX_PORT,
+        mac_addr: str | None = None,
+        verbose: bool = False,
+    ) -> str:
+        """Get the label of a device
+
+        Args:
+            ip: (str) Override the IP address.
+            port: (int) Override the UDP port.
+            mac_addr: (str) Override the MAC address.
+            verbose: (bool) Use logging.info instead of logging.debug.
+        """
+        response = self.send_recv(
+            device_messages.GetLabel(),
+            res_required=True,
+            ip=ip,
+            port=port,
+            mac_addr=mac_addr,
+            verbose=verbose,
+        )
+        assert response
+        return response.pop().payload["label"]
+
+    def get_product_info(
+        self,
+        ip: str,
+        *,
+        port: int = packet.LIFX_PORT,
+        mac_addr: str | None = None,
+        verbose: bool = False,
+    ) -> dict[str, Any]:
+        """Get the Python class needed to control a LIFX product.
+
+        Args:
+            ip: (str) Override the IP address.
+            port: (int) Override the UDP port.
+            mac_addr: (str) Override the MAC address.
+            verbose: (bool) Use logging.info instead of logging.debug.
+        """
+        response = self.send_recv(
+            device_messages.GetVersion(),
+            res_required=True,
+            ip=ip,
+            port=port,
+            mac_addr=mac_addr,
+            verbose=verbose,
+        )
+        assert response
+        product_id = response.pop().payload["product"]
+
+        # Get the class definition from the product info
+        product = self._products[product_id]
+        features = product["features"]
+        if features["multizone"]:
+            klass = multizone.LifxMultiZone
+        elif features["matrix"]:
+            klass = tile.LifxTile
+        elif features["infrared"]:
+            klass = light.LifxInfraredLight
+        else:
+            klass = light.LifxLight
+
+        product["class"] = klass
+        return product
+
+    def load_config(self, config_path: str | pathlib.Path | None = None) -> None:
+        """Load a config and populate device groups.
+
+        Args:
+            config_path: (str) Path to the device config.
+        """
+        config_path = pathlib.Path(config_path or self._config_path)
+        with config_path.open() as f:
+            config_dict = yaml.safe_load(f)
+
+        self._root_device_group = self._load_device_group(config_dict)
+
+    def _load_device_group(
+        self, config_dict: dict[str, Any], max_brightness: float = 1.0
+    ) -> DeviceGroup:
+        """Recursively load a device group from a config dict."""
+        devices_and_groups: dict[str, Any] = {}
+        for name, conf in config_dict.items():
+            # Validate the type name
+            type_name = conf.get("type")
+            if not type_name:
+                raise DeviceConfigError(f"Device/group {name!r} missing 'type' field.")
+            try:
+                device_type = DeviceType[type_name]
+            except KeyError:
+                raise DeviceConfigError(f"Invalid type for device {name!r}: {type_name}")
+
+            # Check that the IP address is present
+            ip = conf.get("ip")
+            if not (ip or device_type == DeviceType.group):
+                raise DeviceConfigError(f"Device {name!r} has no IP address.")
+
+            mb_key = "max-brightness"
+            conf_mb = conf.get(mb_key)
+            if conf_mb is not None:
+                if conf_mb <= 0:
+                    raise ValueError(f"{name}:{mb_key}: must be greater than zero.")
+                elif conf_mb > 1:
+                    raise ValueError(f"{name}:{mb_key}: must be less than or equal to one.")
+                elif conf_mb < max_brightness:
+                    max_brightness = conf_mb
+
+            kwargs = {}
+            if device_type in [DeviceType.multizone, DeviceType.tile]:
+                length_key = "length"
+                length = conf.get(length_key)
+                if not isinstance(length, int):
+                    raise ValueError(f"{name}:{length_key}: must be an integer.")
+                if length <= 0:
+                    raise ValueError(f"{name}:{length_key}: must be greater than zero.")
+                kwargs[length_key] = length
+
+            # Recurse through group listing
+            if device_type == DeviceType.group:
+                group_devices = conf.get("devices")
+                devices_and_groups[name] = self._load_device_group(group_devices, max_brightness)
+
+            else:
+                port = conf.get("port", packet.LIFX_PORT)
+                klass = _DEVICE_TYPES[device_type.name]
+                devices_and_groups[name] = klass(
+                    ip,
+                    port=port,
+                    label=name,
+                    max_brightness=max_brightness,
+                    comm_init=self._comm_init,
+                    verbose=self._verbose,
+                    **kwargs,
+                )
+
+        return DeviceGroup(devices_and_groups)
+
+    @_require_config_loaded
+    def get_all_devices(self) -> dict[str, Any]:
+        assert self._root_device_group is not None
+        return self._root_device_group.get_all_devices()
+
+    @_require_config_loaded
+    def get_all_groups(self) -> dict[str, DeviceGroup]:
+        assert self._root_device_group is not None
+        return self._root_device_group.get_all_groups()
+
+    @_require_config_loaded
+    def get_device(self, name: str) -> Any:
+        """Get a device by its label."""
+        assert self._root_device_group is not None
+        return self._root_device_group.get_device(name)
+
+    @_require_config_loaded
+    def get_group(self, name: str) -> DeviceGroup:
+        """Get a group by its label."""
+        assert self._root_device_group is not None
+        return self._root_device_group.get_group(name)
+
+    @_require_config_loaded
+    def has_device(self, name: str) -> bool:
+        """Check if a device exists."""
+        assert self._root_device_group is not None
+        return self._root_device_group.has_device(name)
+
+    @_require_config_loaded
+    def has_group(self, name: str) -> bool:
+        """Check if a group exists."""
+        assert self._root_device_group is not None
+        return self._root_device_group.has_group(name)
+
+
+if __name__ == "__main__":
+    import coloredlogs
+
+    coloredlogs.install(level=logging.INFO, fmt="%(asctime)s %(levelname)s %(message)s")
+
+    device_manager = DeviceManager()
+    devices = device_manager.discover(num_retries=1)
+    for device_info in sorted(devices.values(), key=lambda d: d.ip):
+        product = device_info.product_name
+        ip = device_info.ip
+        port = device_info.port
+        label = device_info.label
+        logging.info(f"{ip}:\tDiscovered {product}: {label}, {port}")
+    logging.info(f"Total number of devices: {len(devices)}")

--- a/lifxdev/devices/light.py
+++ b/lifxdev/devices/light.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from lifxdev.colors import color
+from lifxdev.devices import device
+from lifxdev.messages import light_messages
+from lifxdev.messages import packet
+
+COLOR_T = tuple[float, float, float, int]
+
+
+class LifxLight(device.LifxDevice):
+    """Light control"""
+
+    def __init__(self, *args, label: str, max_brightness: float = 1.0, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._label = label
+        self.max_brightness = max_brightness
+
+    @property
+    def label(self) -> str:
+        return self._label
+
+    @label.setter
+    def label(self, _: str):
+        raise RuntimeError("Label can only be set on init.")
+
+    @property
+    def max_brightness(self) -> float:
+        return self._max_brightness
+
+    @max_brightness.setter
+    def max_brightness(self, value: float) -> None:
+        if value <= 0:
+            raise ValueError("Max brightness must be greater than zero.")
+        elif value > 1:
+            raise ValueError("Max brightness must be less than or equal to one.")
+        self._max_brightness = float(value)
+
+    def get_color(self) -> color.Hsbk:
+        """Get the color of the device
+
+        Returns:
+            The human-readable HSBK of the light.
+        """
+        response = self.send_recv(light_messages.Get(), res_required=True)
+        assert response is not None
+        return color.Hsbk.from_packet(response.pop().payload["color"])
+
+    def get_power(self) -> bool:
+        """Get the power state of the light.
+
+        Returns:
+            True if the light is powered on. False if off.
+        """
+        response = self.send_recv(light_messages.GetPower(), res_required=True)
+        assert response is not None
+        return response.pop().payload["level"]
+
+    def set_color(
+        self,
+        hsbk: color.Hsbk | COLOR_T,
+        *,
+        duration: float = 0.0,
+        ack_required: bool = False,
+    ) -> packet.LifxResponse | None:
+        """Set the color of the light.
+
+        Args:
+            hsbk: (color.Hsbk) Human-readable HSBK tuple.
+            duration: (float) The time in seconds to make the color transition.
+            ack_required: (bool) True gets an acknowledgement from the light.
+
+        Returns:
+            If ack_required, get an acknowledgement LIFX response tuple.
+        """
+        hsbk = color.Hsbk.from_tuple(hsbk).max_brightness(self.max_brightness)
+        set_color_msg = light_messages.SetColor(
+            color=hsbk.to_packet(),
+            duration=int(duration * 1000),
+        )
+        return self.send_msg(set_color_msg, ack_required=ack_required)
+
+    def set_power(
+        self,
+        state: bool,
+        *,
+        duration: float = 0.0,
+        ack_required: bool = False,
+    ) -> packet.LifxResponse | None:
+        """Set power state on the bulb.
+
+        Args:
+            state: (bool) True powers on the light. False powers it off.
+            duration: (float) The time in seconds to make the color transition.
+            ack_required: (bool) True gets an acknowledgement from the light.
+
+        Returns:
+            If ack_required, get an acknowledgement LIFX response tuple.
+        """
+        power = light_messages.SetPower(level=state, duration=int(duration * 1000))
+        return self.send_msg(power, ack_required=ack_required)
+
+
+class LifxInfraredLight(LifxLight):
+    """Light with IR control"""
+
+    def get_infrared(self) -> float:
+        """Get the current infrared level with 1.0 being the maximum."""
+        response = self.send_recv(light_messages.GetInfrared(), res_required=True)
+        assert response is not None
+        ir_state = response.pop().payload
+        return ir_state["brightness"] / ir_state.get_max("brightness")
+
+    def set_infrared(
+        self, brightness: float, *, ack_required: bool = False
+    ) -> packet.LifxResponse | None:
+        """Set the infrared level on the bulb.
+
+        Args:
+            brightness: (float) IR brightness level. 1.0 is the maximum.
+            ack_required: (bool) True gets an acknowledgement from the light.
+
+        Returns:
+            If ack_required, get an acknowledgement LIFX response tuple.
+        """
+        ir = light_messages.SetInfrared()
+        max_brightness = ir.get_max("brightness")
+        ir["brightness"] = int(brightness * max_brightness)
+        return self.send_msg(ir, ack_required=ack_required)

--- a/lifxdev/devices/multizone.py
+++ b/lifxdev/devices/multizone.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from lifxdev.colors import color
+from lifxdev.devices import light
+from lifxdev.messages import multizone_messages
+from lifxdev.messages import packet
+
+
+class LifxMultiZone(light.LifxLight):
+    """MultiZone device (beam, strip) control"""
+
+    def __init__(self, *args, length: int | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._num_zones: int | None = length
+
+    def get_multizone(self) -> list[color.Hsbk]:
+        """Get a list the colors on the MultiZone.
+
+        Returns:
+            List of human-readable HSBK tuples representing the device.
+        """
+        response = self.send_recv(multizone_messages.GetExtendedColorZones(), res_required=True)
+        assert response is not None
+        payload = response[0].payload
+        self._num_zones = payload["count"]
+        multizone_colors = payload["colors"][: self._num_zones]
+        return [color.Hsbk.from_packet(cc) for cc in multizone_colors]
+
+    def get_num_zones(self) -> int:
+        """Get the number of zones that can be controlled"""
+        if self._num_zones:
+            return self._num_zones
+        else:
+            return len(self.get_multizone())
+
+    def set_multizone(
+        self,
+        multizone_colors: list[color.Hsbk],
+        *,
+        duration: float = 0.0,
+        index: int = 0,
+        ack_required: bool = False,
+    ) -> packet.LifxResponse | None:
+        """Set the MultiZone colors.
+
+        Args:
+            multizone_colors: (list) A list of human-readable HSBK tuples to set.
+            duration: (float) The time in seconds to make the color transition.
+            index: (int) MultiZone starting position of the first element of colors.
+            ack_required: (bool) True gets an acknowledgement from the device.
+        """
+        set_colors = multizone_messages.SetExtendedColorZones()
+        set_colors["apply"] = multizone_messages.ApplicationRequest.APPLY
+        set_colors["duration"] = int(duration * 1000)
+        set_colors["index"] = index
+        set_colors["colors_count"] = len(multizone_colors)
+        for ii, hsbk in enumerate(multizone_colors):
+            set_colors.set_value(
+                "colors",
+                color.Hsbk.from_tuple(hsbk).max_brightness(self.max_brightness).to_packet(),
+                index + ii,
+            )
+        return self.send_msg(set_colors, ack_required=ack_required)

--- a/lifxdev/devices/products.yaml
+++ b/lifxdev/devices/products.yaml
@@ -1,0 +1,1195 @@
+- defaults:
+    buttons: false
+    chain: false
+    color: false
+    extended_multizone: false
+    hev: false
+    infrared: false
+    matrix: false
+    multizone: false
+    relays: false
+    temperature_range: null
+  name: LIFX
+  products:
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX Original 1000
+    pid: 1
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX Color 650
+    pid: 3
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2700
+      - 6500
+    name: LIFX White 800 (Low Voltage)
+    pid: 10
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2700
+      - 6500
+    name: LIFX White 800 (High Voltage)
+    pid: 11
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX Color 1000
+    pid: 15
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX White 900 BR30 (Low Voltage)
+    pid: 18
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX White 900 BR30 (High Voltage)
+    pid: 19
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX Color 1000 BR30
+    pid: 20
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX Color 1000
+    pid: 22
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX A19
+    pid: 27
+    upgrades:
+    - features:
+        temperature_range:
+        - 1500
+        - 9000
+      major: 2
+      minor: 80
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX BR30
+    pid: 28
+    upgrades:
+    - features:
+        temperature_range:
+        - 1500
+        - 9000
+      major: 2
+      minor: 80
+  - features:
+      chain: false
+      color: true
+      infrared: true
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX A19 Night Vision
+    pid: 29
+    upgrades:
+    - features:
+        temperature_range:
+        - 1500
+        - 9000
+      major: 2
+      minor: 80
+  - features:
+      chain: false
+      color: true
+      infrared: true
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX BR30 Night Vision
+    pid: 30
+    upgrades:
+    - features:
+        temperature_range:
+        - 1500
+        - 9000
+      major: 2
+      minor: 80
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: true
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX Z
+    pid: 31
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      min_ext_mz_firmware: 1532997580
+      min_ext_mz_firmware_components:
+      - 2
+      - 77
+      multizone: true
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX Z
+    pid: 32
+    upgrades:
+    - features:
+        extended_multizone: true
+      major: 2
+      minor: 77
+    - features:
+        temperature_range:
+        - 1500
+        - 9000
+      major: 2
+      minor: 80
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX Downlight
+    pid: 36
+    upgrades:
+    - features:
+        temperature_range:
+        - 1500
+        - 9000
+      major: 2
+      minor: 80
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX Downlight
+    pid: 37
+    upgrades:
+    - features:
+        temperature_range:
+        - 1500
+        - 9000
+      major: 2
+      minor: 80
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      min_ext_mz_firmware: 1532997580
+      min_ext_mz_firmware_components:
+      - 2
+      - 77
+      multizone: true
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX Beam
+    pid: 38
+    upgrades:
+    - features:
+        extended_multizone: true
+      major: 2
+      minor: 77
+    - features:
+        temperature_range:
+        - 1500
+        - 9000
+      major: 2
+      minor: 80
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX Downlight White to Warm
+    pid: 39
+    upgrades:
+    - features:
+        temperature_range:
+        - 1500
+        - 9000
+      major: 2
+      minor: 80
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX Downlight
+    pid: 40
+    upgrades:
+    - features:
+        temperature_range:
+        - 1500
+        - 9000
+      major: 2
+      minor: 80
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX A19
+    pid: 43
+    upgrades:
+    - features:
+        temperature_range:
+        - 1500
+        - 9000
+      major: 2
+      minor: 80
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX BR30
+    pid: 44
+    upgrades:
+    - features:
+        temperature_range:
+        - 1500
+        - 9000
+      major: 2
+      minor: 80
+  - features:
+      chain: false
+      color: true
+      infrared: true
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX A19 Night Vision
+    pid: 45
+    upgrades:
+    - features:
+        temperature_range:
+        - 1500
+        - 9000
+      major: 2
+      minor: 80
+  - features:
+      chain: false
+      color: true
+      infrared: true
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX BR30 Night Vision
+    pid: 46
+    upgrades:
+    - features:
+        temperature_range:
+        - 1500
+        - 9000
+      major: 2
+      minor: 80
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Mini Color
+    pid: 49
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 6500
+    name: LIFX Mini White to Warm
+    pid: 50
+    upgrades:
+    - features:
+        temperature_range:
+        - 1500
+        - 9000
+      major: 3
+      minor: 70
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2700
+      - 2700
+    name: LIFX Mini White
+    pid: 51
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX GU10
+    pid: 52
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX GU10
+    pid: 53
+    upgrades: []
+  - features:
+      chain: true
+      color: true
+      infrared: false
+      matrix: true
+      multizone: false
+      temperature_range:
+      - 2500
+      - 9000
+    name: LIFX Tile
+    pid: 55
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: true
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Candle
+    pid: 57
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Mini Color
+    pid: 59
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 6500
+    name: LIFX Mini White to Warm
+    pid: 60
+    upgrades:
+    - features:
+        temperature_range:
+        - 1500
+        - 9000
+      major: 3
+      minor: 70
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2700
+      - 2700
+    name: LIFX Mini White
+    pid: 61
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX A19
+    pid: 62
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX BR30
+    pid: 63
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: true
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX A19 Night Vision
+    pid: 64
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: true
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX BR30 Night Vision
+    pid: 65
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2700
+      - 2700
+    name: LIFX Mini White
+    pid: 66
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: true
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Candle
+    pid: 68
+    upgrades: []
+  - features:
+      buttons: true
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      relays: true
+    name: LIFX Switch
+    pid: 70
+    upgrades: []
+  - features:
+      buttons: true
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      relays: true
+    name: LIFX Switch
+    pid: 71
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2200
+      - 6500
+    name: LIFX Candle White to Warm
+    pid: 81
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2100
+      - 2100
+    name: LIFX Filament Clear
+    pid: 82
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2000
+      - 2000
+    name: LIFX Filament Amber
+    pid: 85
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2700
+      - 2700
+    name: LIFX Mini White
+    pid: 87
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2700
+      - 2700
+    name: LIFX Mini White
+    pid: 88
+    upgrades: []
+  - features:
+      buttons: true
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      relays: true
+    name: LIFX Switch
+    pid: 89
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      hev: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Clean
+    pid: 90
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Color
+    pid: 91
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Color
+    pid: 92
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX A19 US
+    pid: 93
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX BR30
+    pid: 94
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2200
+      - 6500
+    name: LIFX Candle White to Warm
+    pid: 96
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX A19
+    pid: 97
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX BR30
+    pid: 98
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      hev: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Clean
+    pid: 99
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2100
+      - 2100
+    name: LIFX Filament Clear
+    pid: 100
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2000
+      - 2000
+    name: LIFX Filament Amber
+    pid: 101
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: true
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX A19 Night Vision
+    pid: 109
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: true
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX BR30 Night Vision
+    pid: 110
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: true
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX A19 Night Vision
+    pid: 111
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: true
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX BR30 Night Vision Intl
+    pid: 112
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Mini WW US
+    pid: 113
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Mini WW Intl
+    pid: 114
+    upgrades: []
+  - features:
+      buttons: true
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      relays: true
+    name: LIFX Switch
+    pid: 115
+    upgrades: []
+  - features:
+      buttons: true
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      relays: true
+    name: LIFX Switch
+    pid: 116
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      extended_multizone: true
+      infrared: false
+      matrix: false
+      multizone: true
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Z US
+    pid: 117
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      extended_multizone: true
+      infrared: false
+      matrix: false
+      multizone: true
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Z Intl
+    pid: 118
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      extended_multizone: true
+      infrared: false
+      matrix: false
+      multizone: true
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Beam US
+    pid: 119
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      extended_multizone: true
+      infrared: false
+      matrix: false
+      multizone: true
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Beam Intl
+    pid: 120
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Downlight Intl
+    pid: 121
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Downlight US
+    pid: 122
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Color US
+    pid: 123
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Color Intl
+    pid: 124
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX White to Warm US
+    pid: 125
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX White to Warm Intl
+    pid: 126
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2700
+      - 2700
+    name: LIFX White US
+    pid: 127
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2700
+      - 2700
+    name: LIFX White Intl
+    pid: 128
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Color US
+    pid: 129
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Color Intl
+    pid: 130
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX White To Warm US
+    pid: 131
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX White To Warm Intl
+    pid: 132
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2700
+      - 2700
+    name: LIFX White US
+    pid: 133
+    upgrades: []
+  - features:
+      chain: false
+      color: false
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 2700
+      - 2700
+    name: LIFX White Intl
+    pid: 134
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX GU10 Color US
+    pid: 135
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: false
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX GU10 Color Intl
+    pid: 136
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: true
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Candle Color US
+    pid: 137
+    upgrades: []
+  - features:
+      chain: false
+      color: true
+      infrared: false
+      matrix: true
+      multizone: false
+      temperature_range:
+      - 1500
+      - 9000
+    name: LIFX Candle Color Intl
+    pid: 138
+    upgrades: []
+  vid: 1

--- a/lifxdev/devices/tile.py
+++ b/lifxdev/devices/tile.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from matplotlib import colors
+
+from lifxdev.colors import color
+from lifxdev.devices import light
+from lifxdev.messages import tile_messages
+from lifxdev.messages import packet
+
+TILE_WIDTH = 8
+
+
+class LifxTile(light.LifxLight):
+    """Tile device control"""
+
+    def __init__(self, *args, length: int | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._num_tiles: int | None = length
+
+    def get_chain(self) -> packet.LifxResponse:
+        """Get information about the current tile chain"""
+        response = self.send_recv(tile_messages.GetDeviceChain(), res_required=True)
+        assert response is not None
+        response = response.pop()
+        self._num_tiles = response.payload["total_count"]
+        return response
+
+    def get_num_tiles(self) -> int:
+        """Get the number of tiles that can be controlled"""
+        if self._num_tiles:
+            return self._num_tiles
+        else:
+            return self.get_chain().payload["total_count"]
+
+    def get_tile_colors(self, tile_index: int, *, length: int = 1) -> list[list[color.Hsbk]]:
+        """Get the color state for individual tiles.
+
+        Args:
+            tile_index: (int) The tile index in the chain to query.
+            length: (int) The number of tiles to query.
+
+        Returns:
+            List of tile states.
+        """
+        get_request = tile_messages.GetTileState64(width=TILE_WIDTH)
+        get_request["tile_index"] = tile_index
+        get_request["length"] = length
+        responses = self.send_recv(get_request, res_required=True, retry_recv=length > 1)
+        assert responses is not None
+        matrix_list: list[list[color.Hsbk]] = []
+        for state in responses:
+            matrix_list.append([color.Hsbk.from_packet(hsbk) for hsbk in state.payload["colors"]])
+        return matrix_list
+
+    def set_tile_colors(
+        self,
+        tile_index: int,
+        tile_colors: list[color.Hsbk],
+        *,
+        duration: float = 0.0,
+        length: int = 1,
+        ack_required: bool = False,
+    ) -> packet.LifxResponse | None:
+        """Set the tile colors
+
+        Args:
+            tile_index: (int) The tile index in the chain to query.
+            tile_colors: List of colors to set the tile(s) to.
+            duration: (float) The time in seconds to make the color transition.
+            length: (int) The number of tiles to query.
+            ack_required: (bool) True gets an acknowledgement from the device.
+        """
+        set_request = tile_messages.SetTileState64(width=TILE_WIDTH)
+        set_request["tile_index"] = tile_index
+        set_request["length"] = length
+        set_request["duration"] = int(duration * 1000)
+        set_request["colors"] = [
+            hsbk_tuple.max_brightness(self.max_brightness).to_packet()
+            for hsbk_tuple in map(color.Hsbk.from_tuple, tile_colors)
+        ]
+        return self.send_msg(set_request, ack_required=ack_required)

--- a/lifxdev/messages/device_messages.py
+++ b/lifxdev/messages/device_messages.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env pythom3
+
+"""Device messages
+
+https://lan.developer.lifx.com/docs/device-messages
+"""
+
+from __future__ import annotations
+
+from lifxdev.messages import packet
+
+
+@packet.set_message_type(2)
+class GetService(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(3)
+class StateService(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("service", packet.LifxType.u8, 1),
+        ("port", packet.LifxType.u32, 1),
+    ]
+
+
+@packet.set_message_type(12)
+class GetHostInfo(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(13)
+class StateHostInfo(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("signal", packet.LifxType.f32, 1),
+        ("tx", packet.LifxType.u32, 1),
+        ("rx", packet.LifxType.u32, 1),
+        ("reserved", packet.LifxType.s16, 1),
+    ]
+
+
+@packet.set_message_type(14)
+class GetHostFirmware(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(15)
+class StateHostFirmware(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("build", packet.LifxType.u64, 1),
+        ("reserved", packet.LifxType.u64, 1),
+        ("version_minor", packet.LifxType.u16, 1),
+        ("version_major", packet.LifxType.u16, 1),
+    ]
+
+
+@packet.set_message_type(16)
+class GetWifiInfo(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(17)
+class StateWifiInfo(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("signal", packet.LifxType.f32, 1),
+        ("tx", packet.LifxType.u32, 1),
+        ("rx", packet.LifxType.u32, 1),
+        ("reserved", packet.LifxType.s16, 1),
+    ]
+
+
+@packet.set_message_type(18)
+class GetWifiFirmware(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(19)
+class StateWifiFirmware(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("build", packet.LifxType.u64, 1),
+        ("reserved", packet.LifxType.u64, 1),
+        ("version_minor", packet.LifxType.u16, 1),
+        ("version_major", packet.LifxType.u16, 1),
+    ]
+
+
+@packet.set_message_type(20)
+class GetPower(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(21)
+class SetPower(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("level", packet.LifxType.u16, 1),
+        ("duration", packet.LifxType.u32, 1),
+    ]
+
+    def set_value(self, name: str, value: int | bool) -> None:
+        """SetPower level can be either 0 or 65535"""
+        if name.lower() == "level":
+            if isinstance(value, bool):
+                value *= 65535
+            elif isinstance(value, list) and value[0] not in [0, 65535]:
+                raise ValueError("SetPower level must be either 0 or 65535")
+            elif not isinstance(value, list) and value not in [0, 65535]:
+                raise ValueError("SetPower level must be either 0 or 65535")
+        super().set_value(name, value)
+
+
+@packet.set_message_type(22)
+class StatePower(packet.LifxMessage):
+    registers: packet.REGISTER_T = [("level", packet.LifxType.u16, 1)]
+
+    def get_value(self, name: str) -> bool:
+        """Get a register value by name."""
+        value = super().get_value(name)
+        return value > 0
+
+
+@packet.set_message_type(23)
+class GetLabel(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(24)
+class SetLabel(packet.LifxMessage):
+    registers: packet.REGISTER_T = [("label", packet.LifxType.char, 32)]
+
+
+@packet.set_message_type(25)
+class StateLabel(packet.LifxMessage):
+    registers: packet.REGISTER_T = [("label", packet.LifxType.char, 32)]
+
+
+@packet.set_message_type(32)
+class GetVersion(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(33)
+class StateVersion(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("vendor", packet.LifxType.u32, 1),
+        ("product", packet.LifxType.u32, 1),
+        ("version", packet.LifxType.u32, 1),
+    ]
+
+
+@packet.set_message_type(34)
+class GetInfo(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(35)
+class StateInfo(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("time", packet.LifxType.u64, 1),
+        ("uptime", packet.LifxType.u64, 1),
+        ("downtime", packet.LifxType.u64, 1),
+    ]
+
+
+@packet.set_message_type(48)
+class GetLocation(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(49)
+class SetLocation(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("location", packet.LifxType.char, 16),
+        ("label", packet.LifxType.char, 32),
+        ("updated_at", packet.LifxType.u64, 1),
+    ]
+
+
+@packet.set_message_type(50)
+class StateLocation(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("location", packet.LifxType.char, 16),
+        ("label", packet.LifxType.char, 32),
+        ("updated_at", packet.LifxType.u64, 1),
+    ]
+
+
+@packet.set_message_type(51)
+class GetGroup(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(52)
+class SetGroup(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("group", packet.LifxType.char, 16),
+        ("label", packet.LifxType.char, 32),
+        ("updated_at", packet.LifxType.u64, 1),
+    ]
+
+
+@packet.set_message_type(53)
+class StateGroup(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("group", packet.LifxType.char, 16),
+        ("label", packet.LifxType.char, 32),
+        ("updated_at", packet.LifxType.u64, 1),
+    ]
+
+
+@packet.set_message_type(58)
+class EchoRequest(packet.LifxMessage):
+    registers: packet.REGISTER_T = [("payload", packet.LifxType.char, 64)]
+
+
+@packet.set_message_type(59)
+class EchoResponse(packet.LifxMessage):
+    registers: packet.REGISTER_T = [("payload", packet.LifxType.char, 64)]

--- a/lifxdev/messages/firmware_effects.py
+++ b/lifxdev/messages/firmware_effects.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env pythom3
+
+"""Firmware effects
+
+https://lan.developer.lifx.com/docs/firmware-effects
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import Any
+
+from lifxdev.messages import packet
+
+
+class MultiZoneEffectType(enum.Enum):
+    OFF = 0
+    MOVE = 1
+
+
+class TileEffectType(enum.Enum):
+    OFF = 0
+    RESERVED = 1
+    MORPH = 2
+    FLAME = 3
+
+
+@packet.set_message_type(507)
+class GetMultiZoneEffect(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(508)
+class SetMultiZoneEffect(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("instanceid", packet.LifxType.u32, 1),
+        ("type", packet.LifxType.u8, 1),
+        ("reserved_1", packet.LifxType.u16, 1),
+        ("speed", packet.LifxType.u32, 1),
+        ("duration", packet.LifxType.u64, 1),
+        ("reserved_2", packet.LifxType.u32, 1),
+        ("reserved_3", packet.LifxType.u32, 1),
+        ("parameters", packet.LifxType.u32, 8),
+    ]
+
+    def set_value(self, name: str, value: Any):
+        """The apply register must be an ApplicationRequest type"""
+        if name.lower() == "type":
+            if isinstance(value, str):
+                value = MultiZoneEffectType[value].value
+            elif isinstance(value, MultiZoneEffectType):
+                value = value.value
+            elif isinstance(value, int):
+                if value not in [ar.value for ar in MultiZoneEffectType]:
+                    raise ValueError(f"Invalid MultiZoneType: {value}")
+        super().set_value(name, value)
+
+
+@packet.set_message_type(509)
+class StateMultiZoneEffect(SetMultiZoneEffect):
+    pass
+
+
+@packet.set_message_type(718)
+class GetTileEffect(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(719)
+class SetTileEffect(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("reserved_1", packet.LifxType.u8, 1),
+        ("reserved_2", packet.LifxType.u8, 1),
+        ("instanceid", packet.LifxType.u32, 1),
+        ("type", packet.LifxType.u8, 1),
+        ("speed", packet.LifxType.u32, 1),
+        ("duration", packet.LifxType.u64, 1),
+        ("reserved_3", packet.LifxType.u32, 1),
+        ("reserved_4", packet.LifxType.u32, 1),
+        ("parameters", packet.LifxType.u32, 8),
+        ("palette_count", packet.LifxType.u8, 1),
+        ("palette", packet.Hsbk(), 16),
+    ]
+
+    def set_value(self, name: str, value: Any):
+        """The apply register must be an ApplicationRequest type"""
+        if name.lower() == "type":
+            if isinstance(value, str):
+                value = TileEffectType[value].value
+            elif isinstance(value, TileEffectType):
+                value = value.value
+            elif isinstance(value, int):
+                if value not in [ar.value for ar in TileEffectType]:
+                    raise ValueError(f"Invalid TileType: {value}")
+        super().set_value(name, value)
+
+
+@packet.set_message_type(720)
+class StateTileEffect(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("reserved_1", packet.LifxType.u8, 1),
+        ("instanceid", packet.LifxType.u32, 1),
+        ("type", packet.LifxType.u8, 1),
+        ("speed", packet.LifxType.u32, 1),
+        ("duration", packet.LifxType.u64, 1),
+        ("reserved_2", packet.LifxType.u32, 1),
+        ("reserved_3", packet.LifxType.u32, 1),
+        ("parameters", packet.LifxType.u32, 8),
+        ("palette_count", packet.LifxType.u8, 1),
+        ("palette", packet.Hsbk(), 16),
+    ]

--- a/lifxdev/messages/light_messages.py
+++ b/lifxdev/messages/light_messages.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env pythom3
+
+"""Light messages
+
+https://lan.developer.lifx.com/docs/light-messages
+"""
+
+from __future__ import annotations
+
+from lifxdev.messages import packet
+
+
+@packet.set_message_type(101)
+class Get(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(102)
+class SetColor(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("reserved", packet.LifxType.u8, 1),
+        ("color", packet.Hsbk(), 1),
+        ("duration", packet.LifxType.u32, 1),
+    ]
+
+
+@packet.set_message_type(103)
+class SetWaveform(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("reserved", packet.LifxType.u8, 1),
+        ("transient", packet.LifxType.u8, 1),
+        ("color", packet.Hsbk(), 1),
+        ("period", packet.LifxType.u32, 1),
+        ("cycles", packet.LifxType.f32, 1),
+        ("skew_ratio", packet.LifxType.s16, 1),
+        ("waveform", packet.LifxType.u8, 1),
+    ]
+
+
+@packet.set_message_type(107)
+class State(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("color", packet.Hsbk(), 1),
+        ("reserved_1", packet.LifxType.s16, 1),
+        ("power", packet.LifxType.u16, 1),
+        ("label", packet.LifxType.char, 32),
+        ("reserved_2", packet.LifxType.u64, 1),
+    ]
+
+
+@packet.set_message_type(116)
+class GetPower(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(117)
+class SetPower(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("level", packet.LifxType.u16, 1),
+        ("duration", packet.LifxType.u32, 1),
+    ]
+
+    def set_value(self, name: str, value: int | bool) -> None:
+        """SetPower level can be either 0 or 65535"""
+        if name.lower() == "level":
+            if isinstance(value, bool):
+                value *= 65535
+            elif isinstance(value, list) and value[0] not in [0, 65535]:
+                raise ValueError("SetPower level must be either 0 or 65535")
+            elif not isinstance(value, list) and value not in [0, 65535]:
+                raise ValueError("SetPower level must be either 0 or 65535")
+        super().set_value(name, value)
+
+
+@packet.set_message_type(118)
+class StatePower(packet.LifxMessage):
+    registers: packet.REGISTER_T = [("level", packet.LifxType.u16, 1)]
+
+    def get_value(self, name: str) -> bool:
+        """Get a register value by name."""
+        value = super().get_value(name)
+        return value > 0
+
+
+@packet.set_message_type(120)
+class GetInfrared(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(121)
+class StateInfrared(packet.LifxMessage):
+    registers: packet.REGISTER_T = [("brightness", packet.LifxType.u16, 1)]
+
+
+@packet.set_message_type(122)
+class SetInfrared(packet.LifxMessage):
+    registers: packet.REGISTER_T = [("brightness", packet.LifxType.u16, 1)]

--- a/lifxdev/messages/multizone_messages.py
+++ b/lifxdev/messages/multizone_messages.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env pythom3
+
+"""MultiZone messages
+
+https://lan.developer.lifx.com/docs/multizone-messages
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import Any
+
+from lifxdev.messages import packet
+
+
+class ApplicationRequest(enum.Enum):
+    NO_APPLY = 0
+    APPLY = 1
+    APPLY_ONLY = 2
+
+
+@packet.set_message_type(510)
+class SetExtendedColorZones(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("duration", packet.LifxType.u32, 1),
+        ("apply", packet.LifxType.u8, 1),
+        ("index", packet.LifxType.u16, 1),
+        ("colors_count", packet.LifxType.u8, 1),
+        ("colors", packet.Hsbk(), 82),
+    ]
+
+    def set_value(self, name: str, value: Any, index: int | None = None):
+        """The apply register must be an ApplicationRequest type"""
+        if name.lower() == "apply":
+            if isinstance(value, str):
+                value = ApplicationRequest[value].value
+            elif isinstance(value, ApplicationRequest):
+                value = value.value
+            elif isinstance(value, int):
+                if value not in [ar.value for ar in ApplicationRequest]:
+                    raise ValueError(f"Invalid application request: {value}")
+        super().set_value(name, value, index)
+
+
+@packet.set_message_type(511)
+class GetExtendedColorZones(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(512)
+class StateExtendedColorZones(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("count", packet.LifxType.u16, 1),
+        ("index", packet.LifxType.u16, 1),
+        ("colors_count", packet.LifxType.u8, 1),
+        ("colors", packet.Hsbk(), 82),
+    ]
+
+
+# TODO The above API is for the newer firmware. Add support for the older firmware message types

--- a/lifxdev/messages/packet.py
+++ b/lifxdev/messages/packet.py
@@ -1,0 +1,929 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import collections
+import dataclasses
+import enum
+import logging
+import os
+import re
+import selectors
+import socket
+import struct
+import sys
+from collections.abc import Callable
+from typing import cast, Any, Union
+
+BUFFER_SIZE = 65535
+LIFX_PORT = 56700
+TIMEOUT_S = 1
+
+
+class NoResponsesError(Exception):
+    pass
+
+
+class LifxType(enum.Enum):
+    """Type definition:
+
+    0: (int) size in bits
+    1: (char) struct format (None if size % 8 > 0)
+    """
+
+    bool = (1, None)
+    char = (8, "c")
+    f32 = (32, "f")
+    s16 = (16, "h")
+    u2 = (2, None)  # 8 bit int where only 2 bits are used
+    u6 = (6, None)  # 8 bit int where only 6 bits are used
+    u8 = (8, "B")
+    u12 = (12, None)  # 16 bit int where only 12 bits are used
+    u16 = (16, "H")
+    u32 = (32, "I")
+    u64 = (64, "Q")
+
+
+class LifxStruct:
+    """Packed structure for generating byte representations of LIFX bit tables.
+
+    LIFX packets are little endian.
+
+    Register definition:
+        0: (str) name
+        1: (enum) type, if a LifxStruct subclass, use the type instead of a str
+        2: (int) number of items of the type
+    """
+
+    registers: list[tuple[str, Union[LifxType, "LifxStruct"], int]] = []
+
+    def __init__(self, **kwargs):
+        # Set to tuples because they're immutable. _names and _sizes should not be changed.
+        self._names: tuple[str, ...] = tuple([rr[0].lower() for rr in self.registers])
+        for kw in kwargs:
+            if kw not in self._names:
+                name = type(self).__name__
+                if hasattr(self, "name"):
+                    name = getattr(self, "name")
+                raise ValueError(f"Invalid keyword arg for {name}: {kw}")
+
+        self._types = collections.OrderedDict()
+        self._sizes = collections.OrderedDict()
+        self._lens = collections.OrderedDict()
+        self._values = collections.OrderedDict()
+        for name, rr in zip(self._names, self.registers):
+            self._types[name] = rr[1]
+            self._sizes[name] = rr[1].value[0] * rr[2]
+            self._lens[name] = rr[2]
+            if isinstance(self._types[name], LifxType):
+                default = [0] * self._lens[name]
+            else:
+                default = [self._types[name]] * self._lens[name]
+            self._values[name] = default
+            self.set_value(name, kwargs.get(name, default))
+
+    def __str__(self) -> str:
+        segments = [f"{nn}={self.get_value(nn)!r}" for nn in self._names]
+        join = "\n".join(segments)
+        return f"{join}"
+
+    def __repr__(self) -> str:
+        return f"<{type(self).__name__}({id(self)})>\n{self.__str__()}"
+
+    def __eq__(self, other: "LifxStruct") -> bool:
+        if type(self) != type(other):  # noqa: E721
+            return False
+
+        for name in self._names:
+            value_self = self.get_value(name)
+            value_other = other.get_value(name)
+            if value_self != value_other:
+                return False
+        return True
+
+    @classmethod
+    def from_bytes(cls, message_bytes: bytes) -> "LifxStruct":
+        """Create a LifxStruct from bytes
+
+        Anything with irregular bits will have this class overrwitten.
+        """
+        decoded_registers = collections.defaultdict(list)
+
+        offset = 0
+        for reg_info in cls.registers:
+            t_nbytes = 0
+            rname, rtype, rlen = reg_info
+
+            # Easy decoding using struct.unpack for LifxType data
+            if isinstance(rtype, LifxType):
+                if rtype.value[1] is None:
+                    raise RuntimeError(f"Register {rname} cannot be represented as bytes.")
+
+                t_nbytes = rtype.value[0] // 8 * rlen
+                msg_chunk = message_bytes[offset : offset + t_nbytes]
+                value_list = list(struct.unpack("<" + rtype.value[1] * rlen, msg_chunk))
+                decoded_registers[rname] = value_list
+
+            # If bytes are supposed to represent a type, use the from_bytes from that type
+            else:
+                t_nbytes = len(rtype) * rlen
+                msg_chunk = message_bytes[offset : offset + t_nbytes]
+                for _ in range(rlen):
+                    decoded_registers[rname].append(rtype.from_bytes(msg_chunk[: len(rtype)]))
+                    msg_chunk = msg_chunk[len(rtype) :]
+
+            offset += t_nbytes
+
+        return cls(**decoded_registers)
+
+    def get_size_bits(self) -> int:
+        """Get the size in bits of an individual LifxStruct object"""
+        return sum(self._sizes.values())
+
+    def get_size_bytes(self) -> int:
+        """Return the number of bytes in the LifxStruct"""
+        return self.get_size_bits() // 8
+
+    def get_array_size(self, name: str) -> int:
+        name = name.lower()
+        return self._lens[name]
+
+    def get_nbits_per_name(self, name: str) -> int:
+        name = name.lower()
+        return self._sizes[name]
+
+    def get_nbytes_per_name(self, name: str) -> int:
+        return self.get_nbits_per_name(name) // 8
+
+    def get_type(self, name: str) -> Union[LifxType, "LifxStruct"]:
+        name = name.lower()
+        return self._types[name]
+
+    @staticmethod
+    def get_nbits_and_signed(register_type: Union[LifxType, "LifxStruct"]) -> tuple[int, bool]:
+        """Get the number of bits used to represent positive numbers for a type"""
+        n_bits = register_type.value[0]
+        # struct identifiers are lowercase for signed types
+        rtype_value: str | None = register_type.value[1]
+        signed = rtype_value == rtype_value.lower() if rtype_value else False
+        # if signed int, one of the bits is for determining the signed.
+        if signed:
+            n_bits -= 1
+        return n_bits, signed
+
+    def get_max(self, name: str) -> float:
+        """Get the maximum value a member of an integer register can hold"""
+        register_type = self.get_type(name)
+        if register_type.value[1] is None:
+            raise NotImplementedError(f"Maximum undefined for type: {register_type}")
+
+        # Floating point maximum
+        if register_type.value[1] == "f":
+            return sys.float_info.max
+
+        n_bits, _ = self.get_nbits_and_signed(register_type)
+        return (1 << n_bits) - 1
+
+    def get_min(self, name: str) -> float:
+        """Get the minimum value a member of an integer register can hold"""
+        register_type = self.get_type(name)
+        if register_type.value[1] is None:
+            raise NotImplementedError(f"Maximum undefined for type: {register_type}")
+
+        # Floating point minimum
+        if register_type.value[1] == "f":
+            return -sys.float_info.max
+
+        n_bits, signed = self.get_nbits_and_signed(register_type)
+        if signed:
+            return -1 << n_bits
+        else:
+            return 0
+
+    @property
+    def value(self) -> tuple[int, None]:
+        """Mimic the value attribute of the LifxType enum"""
+        return (self.get_size_bits(), None)
+
+    def __len__(self) -> int:
+        return self.len()
+
+    def len(self) -> int:
+        """Return the number of bytes in the LifxStruct"""
+        return self.get_size_bytes()
+
+    def __getitem__(self, name: str) -> Any:
+        return self.get_value(name)
+
+    def get_value(self, name: str) -> Any:
+        """Get a register value by name.
+
+        Returns:
+            A single value if the register length is 1 else return the array of values.
+        """
+        name = name.lower()
+        if name not in self._names:
+            raise KeyError(f"{name!r} not a valid register name")
+
+        register_type = self.get_type(name)
+        value = self._values[name]
+        if register_type.value[1] == "c":
+            value = bytes(value).decode()
+            # strip null bytes
+            idx = value.find(chr(0))
+            if idx >= 0:
+                value = value[:idx]
+        elif len(value) == 1:
+            value = value[0]
+        return value
+
+    def _check_value(self, value: Any, name: str) -> Any:
+        """Validate integer values are within bounds"""
+        # Only integer/floating values can be checked.
+        register_type = self.get_type(name)
+        if not register_type.value[1] or register_type.value[1] == "c":
+            return value
+
+        min_value = self.get_min(name)
+        max_value = self.get_max(name)
+        if value < min_value or value > max_value:
+            raise ValueError(f"value {value} out of bounds for register {name!r}")
+        return value
+
+    def __setitem__(self, name: str, value: Any) -> None:
+        self.set_value(name, value)
+
+    def set_value(self, name: str, value: Any, idx: int | None = None) -> None:
+        """Set a register value by name.
+
+        Args:
+            name: (str) name of the register to write
+            value: Either a singular value or a list of values to write.
+            idx: (int) if a single array item, the position in the array.
+        """
+        name = name.lower()
+        if name not in self._names:
+            raise KeyError(f"{name!r} not a valid register name")
+
+        # Force reserved registers to be null
+        if "reserved" in name:
+            value = [0] * self.get_array_size(name)
+            idx = None
+
+        # Convert strings to bytes and pad them with zeros at the end of they are short
+        n_items = self._lens[name]
+        if isinstance(value, (bytes, str)):
+            if isinstance(value, str):
+                value = value.encode()
+            if len(value) < n_items:
+                margin = n_items - len(value)
+                value += bytes(margin * [0])
+
+        # Store char values as bytes always
+        register_type = self._types[name]
+        if register_type.value[1] == "c" and isinstance(value, (list, tuple)):
+            if all([isinstance(vv, bytes) for vv in value]):
+                value = b"".join(value)
+            elif all([isinstance(vv, int) for vv in value]):
+                value = bytes(value)
+
+        # Validate that if a list was passed, that it matches the register length
+        if isinstance(value, (bytes, list, str, tuple)):
+            if len(value) != n_items:
+                raise ValueError(
+                    f"Value has length {len(value)}, "
+                    f"but register {name} requires length {n_items}"
+                )
+
+        # Force the index to zero if a singular value has been passed in
+        elif n_items == 1:
+            idx = 0
+        elif idx is None:
+            raise ValueError("idx cannot be none for a singular value")
+
+        # Set the value to the internal values dict
+        if isinstance(value, (bytes, str)):
+            self._values[name] = value
+        elif isinstance(value, (list, tuple)):
+            self._values[name] = [self._check_value(vv, name) for vv in value]
+        else:
+            self._values[name][idx] = self._check_value(value, name)
+
+    def to_bytes(self) -> bytes:
+        """Convert the LifxStruct to its bytes representation
+
+        Args:
+            as_ints: (bool) Return the list of ints representing the bytes.
+        """
+        assert len(self._names) == len(self._values)
+        assert len(self._types) == len(self._values)
+        assert len(self._sizes) == len(self._values)
+        assert len(self._lens) == len(self._values)
+
+        message_bytes = b""
+        for reg_info in self.registers:
+            rname, rtype, rlen = reg_info
+
+            # Use struct.path for LifxTypes
+            if isinstance(rtype, LifxType):
+                if rtype.value[1] is None:
+                    raise RuntimeError(f"Register {rname} cannot be represented as bytes.")
+                fmt = "<" + rtype.value[1] * rlen
+                values = self._values[rname]
+                # Convert bytes  to list for struct packing
+                if isinstance(values, bytes):
+                    values = [bytes([vv]) for vv in values]
+                message_bytes += struct.pack(fmt, *values)
+
+            # Use the LifxStruct to_bytes when not a LifxType
+            else:
+                for lstruct in self._values[rname]:
+                    message_bytes += lstruct.to_bytes()
+
+        return message_bytes
+
+
+REGISTER_T = list[tuple[str, LifxType, int]]
+
+
+# Header description: https://lan.developer.lifx.com/docs/header-description
+
+
+class Frame(LifxStruct):
+    registers: REGISTER_T = [
+        ("size", LifxType.u16, 1),
+        ("protocol", LifxType.u12, 1),
+        ("addressable", LifxType.bool, 1),
+        ("tagged", LifxType.bool, 1),
+        ("origin", LifxType.u2, 1),
+        ("source", LifxType.u32, 1),
+    ]
+
+    def set_value(self, name: str, value: int) -> None:
+        """LIFX Frame specification requires certain fields to be constant."""
+        if name.lower() == "protocol":
+            value = 1024
+        elif name.lower() == "addressable":
+            value = True
+        elif name.lower() == "origin":
+            value = 0
+        super().set_value(name, value)
+
+    def to_bytes(self) -> bytes:
+        """Override defaults because of sub-byte packing"""
+        size = self.get_value("size")
+        source = self.get_value("source")
+
+        bit_field = self.get_value("protocol")
+        offset = self.get_nbits_per_name("protocol")
+        bit_field |= self.get_value("addressable") << offset
+        offset += self.get_nbits_per_name("addressable")
+        bit_field |= self.get_value("tagged") << offset
+        offset += self.get_nbits_per_name("tagged")
+        bit_field |= self.get_value("origin") << offset
+
+        return struct.pack("<HHI", size, bit_field, source)
+
+    @classmethod
+    def from_bytes(cls, message_bytes: bytes) -> "Frame":
+        """Override defaults because of sub-byte packing"""
+        size, bit_field, source = struct.unpack("<HHI", message_bytes)
+        frame = cls(size=size, source=source)
+
+        shift = frame.get_nbits_per_name("protocol")
+        frame["protocol"] = bit_field % (1 << shift)
+        bit_field = bit_field >> shift
+
+        shift = frame.get_nbits_per_name("addressable")
+        frame["addressable"] = bool(bit_field % (1 << shift))
+        bit_field = bit_field >> shift
+
+        shift = frame.get_nbits_per_name("tagged")
+        frame["tagged"] = bool(bit_field % (1 << shift))
+        bit_field = bit_field >> shift
+
+        frame["origin"] = bit_field
+        return frame
+
+
+class FrameAddress(LifxStruct):
+    registers: REGISTER_T = [
+        ("target", LifxType.u8, 8),
+        ("reserved_1", LifxType.u8, 6),
+        ("res_required", LifxType.bool, 1),
+        ("ack_required", LifxType.bool, 1),
+        ("reserved_2", LifxType.u6, 1),
+        ("sequence", LifxType.u8, 1),
+    ]
+
+    def set_value(self, name: str, value: int | str | list[int]) -> None:
+        """LIFX Frame Address specification requires certain fields to be constant.
+
+        This also allows for the proper parsing of mac addresses.
+        """
+        name = name.lower()
+        if name == "target":
+            if isinstance(value, str):
+                if is_str_mac(value):
+                    value = mac_str_to_int_list(value)
+
+        super().set_value(name, value)
+
+    def _fmt(self, name: str) -> str:
+        """Create a format string for a register name"""
+        type_value = self.get_type(name).value[1]
+        assert type_value
+        return "<" + type_value * self.get_array_size(name)
+
+    def to_bytes(self) -> bytes:
+        """Override defaults because of sub-byte packing"""
+
+        target_bytes = struct.pack(self._fmt("target"), *self.get_value("target"))
+        res_1_bytes = struct.pack(self._fmt("reserved_1"), *self.get_value("reserved_1"))
+        sequence_bytes = struct.pack(self._fmt("sequence"), self.get_value("sequence"))
+
+        bit_field = int(self.get_value("res_required"))
+        offset = self.get_nbits_per_name("res_required")
+        bit_field |= int(self.get_value("ack_required")) << offset
+        bit_field_bytes = struct.pack("<B", bit_field)
+
+        return target_bytes + res_1_bytes + bit_field_bytes + sequence_bytes
+
+    @classmethod
+    def from_bytes(cls, message_bytes: bytes) -> "FrameAddress":
+        """Override defaults because of sub-byte packing"""
+        frame_address = cls()
+        get_len = frame_address.get_nbytes_per_name
+        get_nbits = frame_address.get_nbits_per_name
+
+        chunk_len = get_len("target")
+        target_bytes = message_bytes[:chunk_len]
+        offset = chunk_len + get_len("reserved_1")
+        chunk_len = get_nbits("res_required") + get_nbits("ack_required") + get_nbits("reserved_2")
+        chunk_len //= 8
+        bit_field_bytes = message_bytes[offset : offset + chunk_len]
+        offset += chunk_len
+
+        chunk_len = get_len("sequence")
+        sequence_bytes = message_bytes[offset : offset + chunk_len]
+
+        frame_address["target"] = list(struct.unpack(frame_address._fmt("target"), target_bytes))
+        frame_address["sequence"] = list(
+            struct.unpack(frame_address._fmt("sequence"), sequence_bytes)
+        )
+        (bit_field,) = struct.unpack("<B", bit_field_bytes)
+        frame_address["res_required"] = bool(bit_field % 2)
+        frame_address["ack_required"] = bool(bit_field // 2)
+
+        return frame_address
+
+
+class ProtocolHeader(LifxStruct):
+    registers: REGISTER_T = [
+        ("reserved_1", LifxType.u64, 1),
+        ("type", LifxType.u16, 1),
+        ("reserved_2", LifxType.u16, 1),
+    ]
+
+
+class Hsbk(LifxStruct):
+    registers: REGISTER_T = [
+        ("hue", LifxType.u16, 1),
+        ("saturation", LifxType.u16, 1),
+        ("brightness", LifxType.u16, 1),
+        ("kelvin", LifxType.u16, 1),
+    ]
+
+    def set_value(self, name: str, value: int | list[int]):
+        """Kelvin must be between 2500 and 9000."""
+        if isinstance(value, list):
+            if len(value) > 1:
+                raise ValueError("HSBK value as list must be length 1")
+            hsbk_value = value[0]
+        else:
+            hsbk_value = value
+
+        # Only value check when setting a non-zero value.
+        # Value checking on the zero would break the default constructor.
+        if name.lower() == "kelvin" and hsbk_value:
+            if hsbk_value < 2500 or hsbk_value > 9000:
+                raise ValueError("Kelvin out of range.")
+
+        super().set_value(name, hsbk_value)
+
+
+#
+# Handle payload messages and responses
+#
+
+
+class LifxMessage(LifxStruct):
+    """LIFX struct used as a message type payload."""
+
+    # integer identifier of for the protocol header of LIFX packets.
+    name: str
+    type: str
+
+    def __repr__(self) -> str:
+        super_str = super().__str__()
+        msg_str = f"<{self.name}({self.type}): {id(self)}>"
+        if super_str:
+            msg_str = f"{msg_str}\n{super_str}"
+        return msg_str
+
+    def __str__(self) -> str:
+        super_str = super().__str__()
+        msg_str = f"<{self.name}({self.type})>"
+        if super_str:
+            msg_str = f"{msg_str}\n{super_str}"
+        return msg_str
+
+    @classmethod
+    def from_bytes(cls, message_bytes: bytes) -> "LifxMessage":
+        return cast(cls, super().from_bytes(message_bytes))
+
+
+@dataclasses.dataclass
+class LifxResponse:
+    addr: tuple[str, int]
+    frame: Frame
+    frame_address: FrameAddress
+    protocol_header: ProtocolHeader
+    payload: LifxMessage
+
+    def __str__(self) -> str:
+        return "\n".join(
+            [
+                f"IP: {self.addr[0]}:{self.addr[1]}",
+                "---",
+                "LifxResponse.frame:",
+                str(self.frame),
+                "---",
+                "LifxResponse.frame_address:",
+                str(self.frame_address),
+                "---",
+                "LifxResponse.protocol_header:",
+                str(self.protocol_header),
+                "---",
+                str(self.payload),
+            ]
+        )
+
+
+# Used for parsing responses from LIFX bulbs
+# This maps the protocol header type to a LifxMessage class to generate using bytes
+_MESSAGE_TYPES: dict[int, type[LifxMessage]] = {}
+
+
+def set_message_type(message_type: int) -> Callable:
+    """Create a LifxMessage class with the message type auto-set.
+
+    Args:
+        message_type: (int) LIFX message type for the protocol header
+    """
+
+    def _msg_type_decorator(cls) -> type:
+        class _LifxMessage(cls):
+            pass
+
+        _LifxMessage.name = cls.__name__
+        _LifxMessage.type = message_type
+        _MESSAGE_TYPES[message_type] = _LifxMessage
+        return _LifxMessage
+
+    return _msg_type_decorator
+
+
+@set_message_type(45)
+class Acknowledgement(LifxMessage):
+    """Acknowledgement message
+
+    Defined here: https://lan.developer.lifx.com/docs/device-messages
+    This is the message type returned when ack_required=True in the frame address.
+    """
+
+    pass
+
+
+#
+# Socket communication
+#
+
+
+@dataclasses.dataclass
+class UdpSender:
+    """Send messages to a single IP/port"""
+
+    # IP address of the LIFX device.
+    ip: str
+
+    # UDP socket for communication
+    comm: socket.socket
+
+    # UDP port on the LIFX device
+    port: int = LIFX_PORT
+
+    # Mac address of the LIFX device
+    mac_addr: str | None = None
+
+    # Buffer size for receiving UDP messages
+    buffer_size: int = BUFFER_SIZE
+
+
+class PacketComm:
+    """Communicate packets with LIFX devices"""
+
+    def __init__(self, comm: UdpSender, verbose: bool = False, timeout: float = TIMEOUT_S):
+        """Create a packet communicator
+
+        Args:
+            comm: (socket) pre-configured UDP socket.
+            verbose: (bool) If true, log to info instead of debug.
+        """
+        self._comm = comm
+        self._comm.comm.setblocking(False)
+        self._log_func = logging.info if verbose else logging.debug
+        self._timeout = timeout
+
+    @property
+    def ip(self) -> str:
+        return self._comm.ip
+
+    @staticmethod
+    def decode_bytes(
+        message_bytes: bytes,
+        message_addr: tuple[str, int],
+        nominal_source: int | None = None,
+        nominal_sequence: int | None = None,
+    ) -> LifxResponse:
+        def _get_nbytes(cls: type[LifxStruct]) -> int:
+            n_bits = 0
+            for _, rtype, rlen in cls.registers:
+                n_bits += rtype.value[0] * rlen
+            return n_bits // 8
+
+        # Decode the Frame information
+        chunk_len = _get_nbytes(Frame)
+        frame = Frame.from_bytes(message_bytes[:chunk_len])
+
+        # Verify the message size matches the expected size
+        size = frame["size"]
+        if len(message_bytes) != size:
+            raise RuntimeError(f"Message size mismatch: R({len(message_bytes)}) != E({size})")
+
+        # Verify the source is the expected source
+        if nominal_source is not None:
+            source = frame["source"]
+            if source != nominal_source:
+                raise RuntimeError(f"Source mismatch: R({source}) != E({nominal_source})")
+
+        # Decode the Frame Address
+        offset = chunk_len
+        chunk_len = _get_nbytes(FrameAddress)
+        frame_address = FrameAddress.from_bytes(message_bytes[offset : offset + chunk_len])
+
+        # Verify the sequence is the expected sequence
+        if nominal_sequence is not None:
+            sequence = frame_address["sequence"]
+            if sequence != nominal_sequence:
+                raise RuntimeError(f"Sequence mismatch: R({sequence}) != E({nominal_sequence})")
+
+        # Decode the payload
+        offset += chunk_len
+        chunk_len = _get_nbytes(ProtocolHeader)
+        protocol_header = cast(
+            ProtocolHeader, ProtocolHeader.from_bytes(message_bytes[offset : offset + chunk_len])
+        )
+
+        offset += chunk_len
+        payload_klass = _MESSAGE_TYPES[protocol_header["type"]]
+        chunk_len = _get_nbytes(payload_klass)
+        payload = payload_klass.from_bytes(message_bytes[offset : offset + chunk_len])
+
+        return LifxResponse(
+            addr=message_addr,
+            frame=frame,
+            frame_address=frame_address,
+            protocol_header=protocol_header,
+            payload=payload,
+        )
+
+    @staticmethod
+    def get_bytes_and_source(
+        *,
+        payload: LifxMessage,
+        mac_addr: str | int | None = None,
+        res_required: bool = False,
+        ack_required: bool = False,
+        sequence: int = 0,
+        source: int | None = None,
+    ) -> tuple[bytes, int]:
+        """Generate LIFX packet bytes.
+
+        Args:
+            payload: (LifxMessage) Payload to encode as bytes.
+            mac_addr: (str) MAC address of the target bulb.
+            res_required: (bool) Require a response from the light.
+            ack_required: (bool) Require an acknowledgement from the light.
+            sequence: (int) Optional identifier to label packets.
+            source: (int) Optional unique identifier to
+
+        Returns:
+            bytes and source identifier
+        """
+        frame = Frame()
+        frame_address = FrameAddress()
+        protocol_header = ProtocolHeader()
+
+        # Set the frame address fields
+        if mac_addr:
+            frame_address["target"] = mac_addr
+        frame_address["res_required"] = res_required
+        frame_address["ack_required"] = ack_required
+        frame_address["sequence"] = sequence
+
+        # Protocol header only requires setting the type.
+        if not payload.type:
+            raise ValueError("Payload has no message type.")
+        protocol_header["type"] = payload.type
+
+        # Generate the frame
+        # tagged must be true when sending a GetService(2)
+        frame["tagged"] = not sum(frame_address["target"]) or payload.type == 2
+        frame["source"] = os.getpid() if source is None else source
+        frame["size"] = len(frame) + len(frame_address) + len(protocol_header) + len(payload)
+
+        # Generate the bytes for the packet
+        packet_bytes = frame.to_bytes()
+        packet_bytes += frame_address.to_bytes()
+        packet_bytes += protocol_header.to_bytes()
+        packet_bytes += payload.to_bytes()
+
+        return packet_bytes, frame["source"]
+
+    def send_recv(
+        self,
+        *,
+        ip: str | None = None,
+        port: int | None = None,
+        mac_addr: str | None = None,
+        comm: socket.socket | None = None,
+        retry_recv: bool = False,
+        verbose: bool = False,
+        **kwargs,
+    ) -> list[LifxResponse]:
+        """Send a packet to a LIFX device or broadcast address and get responses
+
+        Args:
+            ip: (str) Override the IP address.
+            port: (int) Override the UDP port.
+            mac_addr: (str) Override the MAC address.
+            comm: (socket) Override the UDP socket.
+            retry_recv: (bool) Re-run recv_from until there are no more packets.
+            verbose: (bool) Use logging.info for messages.
+            kwargs: Keyword arguments for for get_bytes_and_source.
+
+        Returns:
+            If a response or acknowledgement requested, return them.
+        """
+        addr = (ip or self._comm.ip, port or self._comm.port)
+        comm = comm or self._comm.comm
+        payload_name = kwargs["payload"].name
+
+        source = self.send(
+            ip=ip,
+            port=port,
+            mac_addr=mac_addr,
+            comm=comm,
+            verbose=verbose,
+            **kwargs,
+        )
+        kwargs.pop("source", None)
+
+        responses = []
+        if kwargs.get("ack_required", False) or kwargs.get("res_required", False):
+            selector = selectors.DefaultSelector()
+            selector.register(comm, selectors.EVENT_READ)
+            while True:
+                new_responses = self.recv(
+                    comm=comm,
+                    selector=selector,
+                    source=source,
+                    verbose=verbose,
+                    **kwargs,
+                )
+                responses.extend(new_responses)
+                if not (new_responses and retry_recv):
+                    break
+
+            if not responses:
+                raise NoResponsesError(
+                    f"Did not get a response from {addr[0]} with message: {payload_name}"
+                )
+        return responses
+
+    def send(
+        self,
+        *,
+        ip: str | None = None,
+        port: int | None = None,
+        mac_addr: str | None = None,
+        comm: socket.socket | None = None,
+        verbose: bool = False,
+        **kwargs,
+    ) -> int:
+        """Send a packet to a LIFX device or broadcast address and get responses
+
+        Args:
+            ip: (str) Override the IP address.
+            port: (int) Override the UDP port.
+            mac_addr: (str) Override the MAC address.
+            comm: (socket) Override the UDP socket.
+            verbose: (bool) Use logging.info for messages.
+            kwargs: Keyword arguments for for get_bytes_and_source.
+
+        Returns:
+            Source identifier of the packet for responses
+        """
+        log_func = logging.info if verbose else self._log_func
+        addr = (ip or self._comm.ip, port or self._comm.port)
+        comm = comm or self._comm.comm
+        kwargs["mac_addr"] = mac_addr or self._comm.mac_addr
+
+        packet_bytes, source = self.get_bytes_and_source(**kwargs)
+        payload_name = kwargs["payload"].name
+        log_func(f"Sending {payload_name} message to {addr[0]}:{addr[1]}")
+        comm.sendto(packet_bytes, addr)
+        return source
+
+    def recv(
+        self,
+        *,
+        comm: socket.socket | None = None,
+        selector: selectors.BaseSelector | None = None,
+        source: int | None = None,
+        verbose: bool = False,
+        **kwargs,
+    ) -> list[LifxResponse]:
+        log_func = logging.info if verbose else self._log_func
+        comm = comm or self._comm.comm
+        payload_name = kwargs["payload"].name
+
+        if not selector:
+            selector = selectors.DefaultSelector()
+            selector.register(comm, selectors.EVENT_READ)
+        responses = []
+        events = selector.select(timeout=self._timeout)
+        for key, event in events:
+            assert event & selectors.EVENT_READ
+            assert key.fileobj == self._comm.comm
+            recv_bytes, recv_addr = comm.recvfrom(self._comm.buffer_size)
+            response = self.decode_bytes(recv_bytes, recv_addr, source, kwargs.get("sequence", 0))
+            responses.append(response)
+            payload_name = response.payload.name
+            log_func(f"Received {payload_name} message from {recv_addr[0]}:{recv_addr[1]}")
+
+        return responses
+
+
+def is_str_ipaddr(ipaddr: str) -> bool:
+    """Check of a string is an IP address"""
+    if re.match(r"(\d+)\.(\d+)\.(\d+)\.(\d+)", ipaddr) is None:
+        return False
+
+    try:
+        ip_nums = map(int, ipaddr.split("."))
+        nums_valid = [0 <= n <= 255 for n in ip_nums]
+    except ValueError:
+        return False
+
+    return all(nums_valid)
+
+
+def is_str_mac(mac: str) -> bool:
+    """Check if a string is a MAC address"""
+    if re.match(r"(\S\S):" * 5 + r"(\S\S)", mac) is None:
+        return False
+
+    try:
+        mac_nums = [int("0x" + ch, 16) for ch in mac.split(":")]
+        nums_valid = [0 <= n <= 255 for n in mac_nums]
+    except ValueError:
+        return False
+
+    return all(nums_valid)
+
+
+def _mac_str_to_int(mac_str: str) -> int:
+    # Swap endianness, then convert to an integer
+    hex_str = "0x" + "".join(reversed(mac_str.split(":")))
+    return int(hex_str, 16)
+
+
+def mac_str_to_int_list(mac_str: str) -> list[int]:
+    mac_int = _mac_str_to_int(mac_str)
+    int_list: list[int] = []
+    for _ in range(8):
+        int_list.append(mac_int % (1 << 8))
+        mac_int = mac_int >> 8
+    return int_list

--- a/lifxdev/messages/test_utils.py
+++ b/lifxdev/messages/test_utils.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+
+"""Create a mock socket that can be used for testing/simulating"""
+
+from __future__ import annotations
+
+import enum
+import socket
+
+from lifxdev.messages import packet
+
+# These are needed to populate the packet internal responses
+from lifxdev.messages import device_messages  # noqa: F401
+from lifxdev.messages import light_messages  # noqa: F401
+from lifxdev.messages import multizone_messages  # noqa: F401
+from lifxdev.messages import tile_messages  # noqa: F401
+from lifxdev.messages import firmware_effects  # noqa: F401
+
+# Number of read attempts on the read socket
+_N_READS = 16
+
+
+# Take from the product info page:
+# https://lan.developer.lifx.com/v2.0/docs/lifx-products
+class Product(enum.Enum):
+    NONE = 0
+    LIGHT = 27
+    IR = 29
+    MZ = 38
+    TILE = 55
+
+
+class MockSocket:
+    """Mock the socket send/recv functions"""
+
+    def __init__(
+        self,
+        *args,
+        label: str = "LIFX mock",
+        mac_addr: str | None = None,
+        product: Product = Product.NONE,
+        **kwargs,
+    ):
+        self._label = label
+        self._mac_addr = mac_addr
+        self._response_bytes = b""
+        self._last_addr = ("", 0)
+        self._sequence = 0
+        self._first_response_query = False
+        self._responses: dict[str, bytes] = {}
+        self._wsock, self._rsock = socket.socketpair(type=socket.SOCK_DGRAM)
+        self._wsock.setblocking(False)
+        self._rsock.setblocking(False)
+        for msg_num in sorted(packet._MESSAGE_TYPES.keys()):
+            message = packet._MESSAGE_TYPES[msg_num]()
+            name = message.name
+
+            # Set up some defaults
+            if name in ["State", "StateLabel"]:
+                message["label"] = self._label
+            elif name == "StateDeviceChain":
+                message["total_count"] = 5
+                for ii, tile in enumerate(message["tile_devices"]):
+                    tile = message["tile_devices"][ii]
+                    tile["width"] = 8
+                    tile["height"] = 8
+                    message["tile_devices"][ii] = tile
+            elif name == "StateExtendedColorZones":
+                message["count"] = 32
+                message["colors_count"] = 32
+            elif name == "StateService":
+                message["service"] = 1
+                message["port"] = packet.LIFX_PORT
+            elif name == "StateVersion":
+                message["vendor"] = 1
+                message["product"] = product.value
+
+            self._responses[name], self._source = packet.PacketComm.get_bytes_and_source(
+                payload=message,
+                mac_addr=self._mac_addr,
+                res_required=True,
+            )
+
+    def fileno(self) -> int:
+        return self._rsock.fileno()
+
+    def set_label(self, label: str, addr: tuple[str, int] = ("127.0.0.1", packet.LIFX_PORT)):
+        """Set the label returned in messages"""
+        self.update_payload("State", addr, label=label)
+        self.update_payload("StateLabel", addr, label=label)
+
+    def set_product(
+        self, product: Product, addr: tuple[str, int] = ("127.0.0.1", packet.LIFX_PORT)
+    ):
+        """Set the product returned in messages"""
+        self.update_payload("StateVersion", addr, product=product.value)
+
+    def update_payload(self, register_name: str, addr: tuple[str, int], **kwargs):
+        """Update a payload's bytes registers"""
+        payload = packet.PacketComm.decode_bytes(self._responses[register_name], addr).payload
+        for key, value in kwargs.items():
+            payload[key] = value
+        self._responses[register_name], self._source = packet.PacketComm.get_bytes_and_source(
+            payload=payload,
+            mac_addr=self._mac_addr,
+            source=self._source,
+            sequence=self._sequence,
+        )
+
+    def setsockopt(self, *args, **kwargs):
+        """Ignore setsockopt calls"""
+        pass
+
+    def getblocking(self) -> bool:
+        """Return the blocking status"""
+        return False
+
+    def gettimeout(self) -> float | None:
+        """Return the timeout"""
+        return None
+
+    def setblocking(self, flag: bool):
+        """Set the blocking flag"""
+        pass
+
+    def settimeout(self, timeout: float | None):
+        """Set the timeout"""
+        pass
+
+    def sendto(self, message_bytes: bytes, addr: tuple[str, int]):
+        """Mock sendto by spoofing the bytes to be returned on the next recvfrom"""
+        self._last_addr = addr
+
+        full_packet = packet.PacketComm.decode_bytes(message_bytes, addr)
+        payload = full_packet.payload
+        self._source = full_packet.frame["source"]
+        self._sequence = full_packet.frame_address["sequence"]
+
+        # usually, replacing get/set with state, but there are exceptions
+        response_name = payload.name.replace("Get", "State").replace("Set", "State")
+        if payload.name in ["GetColor", "SetColor", "SetWaveform"]:
+            response_name = "State"
+        elif payload.name == "EchoRequest":
+            response_name = "EchoResponse"
+
+        # Update the color message when setting the power level
+        if payload.name == "SetPower":
+            self.update_payload("State", addr, power=payload["level"])
+
+        # Craft a response when setting light state.
+        if payload.name.startswith("Set") or payload.name == "EchoRequest":
+            response_payload = packet.PacketComm.decode_bytes(
+                self._responses[response_name], addr
+            ).payload
+            payload_registers = set([rr[0] for rr in payload.registers])
+            response_registers = set([rr[0] for rr in response_payload.registers])
+            intersection = response_registers & payload_registers
+            for name in intersection:
+                response_payload[name] = payload[name]
+            if response_name == "StateExtendedColorZones":
+                response_payload["count"] = response_payload["colors_count"]
+            self._responses[response_name], self._source = packet.PacketComm.get_bytes_and_source(
+                payload=response_payload,
+                mac_addr=self._mac_addr,
+                source=self._source,
+                sequence=self._sequence,
+            )
+
+        # Set the response. If an acknowledgement as been requested, use those bytes.
+        if full_packet.frame_address["ack_required"]:
+            self._response_bytes = self._responses["Acknowledgement"]
+        else:
+            self._response_bytes = self._responses[response_name]
+        self._first_response_query = True
+        self._wsock.send(bytes())
+        return len(message_bytes)
+
+    def recvfrom(self, buffer_size: int) -> tuple[bytes, tuple[str, int]]:
+        """Get the latest response bytes"""
+        for _ in range(_N_READS):
+            try:
+                self._rsock.recv(1)
+            except BlockingIOError:
+                break
+        if self._first_response_query:
+            self._first_response_query = False
+            return (self._response_bytes, self._last_addr)
+        else:
+            raise BlockingIOError
+
+
+if __name__ == "__main__":
+    import coloredlogs
+    import logging
+    from typing import cast
+
+    coloredlogs.install(level=logging.INFO)
+
+    udp_sender = packet.UdpSender(ip="127.0.0.1", comm=cast(socket.socket, MockSocket()))
+    packet_comm = packet.PacketComm(udp_sender, verbose=True)
+    set_color = light_messages.SetColor(
+        color=packet.Hsbk(
+            hue=16384,
+            saturation=65535,
+            brightness=65535,
+            kelvin=5500,
+        )
+    )
+
+    logging.info(
+        packet_comm.send_recv(payload=light_messages.SetPower(level=65535), res_required=True)
+    )
+    logging.info(packet_comm.send_recv(payload=set_color, res_required=True))
+    logging.info(packet_comm.send_recv(payload=light_messages.SetPower(), ack_required=True))
+    logging.info(packet_comm.send_recv(payload=light_messages.Get(), res_required=True))

--- a/lifxdev/messages/tile_messages.py
+++ b/lifxdev/messages/tile_messages.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env pythom3
+
+"""Tile messages
+
+https://lan.developer.lifx.com/docs/tile-messages
+"""
+
+from __future__ import annotations
+
+from lifxdev.messages import packet
+
+
+class Tile(packet.LifxStruct):
+    registers: packet.REGISTER_T = [
+        ("accel_meas_x", packet.LifxType.s16, 1),
+        ("accel_meas_y", packet.LifxType.s16, 1),
+        ("accel_meas_z", packet.LifxType.s16, 1),
+        ("reserved_1", packet.LifxType.s16, 1),
+        ("user_x", packet.LifxType.f32, 1),
+        ("user_y", packet.LifxType.f32, 1),
+        ("width", packet.LifxType.u8, 1),
+        ("height", packet.LifxType.u8, 1),
+        ("reserved_2", packet.LifxType.u8, 1),
+        ("device_version_vendor", packet.LifxType.u32, 1),
+        ("device_version_product", packet.LifxType.u32, 1),
+        ("device_version_version", packet.LifxType.u32, 1),
+        ("firmware_build", packet.LifxType.u64, 1),
+        ("reserved_3", packet.LifxType.u64, 1),
+        ("firmware_version_minor", packet.LifxType.u16, 1),
+        ("firmware_version_major", packet.LifxType.u16, 1),
+        ("reserved_4", packet.LifxType.u32, 1),
+    ]
+
+
+@packet.set_message_type(701)
+class GetDeviceChain(packet.LifxMessage):
+    pass
+
+
+@packet.set_message_type(702)
+class StateDeviceChain(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("start_index", packet.LifxType.u8, 1),
+        ("tile_devices", Tile(), 16),
+        ("total_count", packet.LifxType.u8, 1),
+    ]
+
+
+@packet.set_message_type(703)
+class SetUserPosition(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("tile_index", packet.LifxType.u8, 1),
+        ("reserved", packet.LifxType.u16, 1),
+        ("user_x", packet.LifxType.f32, 1),
+        ("user_y", packet.LifxType.f32, 1),
+    ]
+
+
+@packet.set_message_type(707)
+class GetTileState64(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("tile_index", packet.LifxType.u8, 1),
+        ("length", packet.LifxType.u8, 1),
+        ("reserved", packet.LifxType.u8, 1),
+        ("x", packet.LifxType.u8, 1),
+        ("y", packet.LifxType.u8, 1),
+        ("width", packet.LifxType.u8, 1),
+    ]
+
+
+@packet.set_message_type(711)
+class StateTileState64(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("tile_index", packet.LifxType.u8, 1),
+        ("reserved", packet.LifxType.u8, 1),
+        ("x", packet.LifxType.u8, 1),
+        ("y", packet.LifxType.u8, 1),
+        ("width", packet.LifxType.u8, 1),
+        ("colors", packet.Hsbk(), 64),
+    ]
+
+
+@packet.set_message_type(715)
+class SetTileState64(packet.LifxMessage):
+    registers: packet.REGISTER_T = [
+        ("tile_index", packet.LifxType.u8, 1),
+        ("length", packet.LifxType.u8, 1),
+        ("reserved", packet.LifxType.u8, 1),
+        ("x", packet.LifxType.u8, 1),
+        ("y", packet.LifxType.u8, 1),
+        ("width", packet.LifxType.u8, 1),
+        ("duration", packet.LifxType.u32, 1),
+        ("colors", packet.Hsbk(), 64),
+    ]


### PR DESCRIPTION
This is the first pass support adding LIFX UDP protocol to LedFx.
Supports single bulbs and z strips, other lifx products not tested.
Bulbs must be added by IP with correct number of zones/leds.
Includes pared down copy of lifxdev library (https://github.com/domagalski/lifxdev) not currently available in pip, removed dependency to matplotlib.

Todo:
- Trim excess Lifx library code overhead
- Refactor color handling of lifx packet code
- Possibly figure out how to use aiolifx or photon library instead (async based)
- Use autodiscovery built into protocol instead of manually adding bulbs/specifying led count
- Automatically make virtual devices based on lifx groups