### PR TITLE
New sentry implementation

### DIFF
--- a/ledfx/sentry_config.py
+++ b/ledfx/sentry_config.py
@@ -1,29 +1,17 @@
 import logging
+import os
 
 from ledfx.consts import DEV, PROJECT_VERSION
 
 _LOGGER = logging.getLogger(__name__)
 
-# overall logic
+# if you want your own sentry backend for development then replace the first one
+# only
 
-# default is no sentry dsn
-# sentry_dsn can be overridden by build scripts or a developer
-# if a dev sets DEV to 1 or higher in const.py, sentry is turned on
-# if they have overridden dsn it is used, else we put in a dev dsn
+env = os.getenv("ENVIRONMENT", "dev")
 
-# Place your key between the quotes if you have a sentry.io account and wish to use it.
-
-# the following is modified by some build scripts during release process
-sentry_dsn = "DSN"
-sample_rate = 0
-release = f"ledfx@{PROJECT_VERSION}"
-
-# a developer can decide to turn on sentry tracking to a specific backend,
-# along with transaction measurements if they wish to by bumping up DEV value in
-# consts.py to 1 or higher
-if DEV > 0:
-    if sentry_dsn == "DSN":
-        sentry_dsn = "https://de9ea3e00f334954b2f1478b90936d55@o482797.ingest.sentry.io/5886499"
+if env == "dev":
+    sentry_dsn = "https://b192934eebd517c86bf7e9c512b3888a@o482797.ingest.sentry.io/4506350241841152"
     sample_rate = 1
 
     from subprocess import PIPE, Popen
@@ -33,20 +21,21 @@ if DEV > 0:
     commit_hash = commit_hash[:7].decode("utf-8")
     exit_code = process.wait()
     release = f"ledfx@{PROJECT_VERSION}-{commit_hash}"
-
-
-if sentry_dsn != "DSN":
-    import sentry_sdk
-    from sentry_sdk.integrations.aiohttp import AioHttpIntegration
-
-    _LOGGER.info(
-        f"Sentry config\ndsn first ten: {sentry_dsn[8:18]}\nsample_rate: {sample_rate}\nrelease: {release}"
-    )
-    sentry_sdk.init(
-        sentry_dsn,
-        traces_sample_rate=sample_rate,
-        integrations=[AioHttpIntegration()],
-        release=release,
-    )
 else:
-    _LOGGER.info("Sentry not configured")
+    # production / release behaviour due to injection of "prod" into
+    sentry_dsn = "https://dc6070345a8dfa1f2f24433d16f7a133@o482797.ingest.sentry.io/4506350233321472"
+    sample_rate = 0
+    release = f"ledfx@{PROJECT_VERSION}"
+
+import sentry_sdk
+from sentry_sdk.integrations.aiohttp import AioHttpIntegration
+
+_LOGGER.info(
+    f"Sentry config\ndsn first ten: {sentry_dsn[8:18]}\nsample_rate: {sample_rate}\nrelease: {release}"
+)
+sentry_sdk.init(
+    sentry_dsn,
+    traces_sample_rate=sample_rate,
+    integrations=[AioHttpIntegration()],
+    release=release,
+)

--- a/ledfx/sentry_config.py
+++ b/ledfx/sentry_config.py
@@ -1,7 +1,9 @@
 import logging
 import os
+import sentry_sdk
 
-from ledfx.consts import DEV, PROJECT_VERSION
+from sentry_sdk.integrations.aiohttp import AioHttpIntegration
+from ledfx.consts import PROJECT_VERSION
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,9 +28,6 @@ else:
     sentry_dsn = "https://dc6070345a8dfa1f2f24433d16f7a133@o482797.ingest.sentry.io/4506350233321472"
     sample_rate = 0
     release = f"ledfx@{PROJECT_VERSION}"
-
-import sentry_sdk
-from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 
 _LOGGER.info(
     f"Sentry config\ndsn first ten: {sentry_dsn[8:18]}\nsample_rate: {sample_rate}\nrelease: {release}"

--- a/ledfx/sentry_config.py
+++ b/ledfx/sentry_config.py
@@ -7,8 +7,6 @@ from ledfx.consts import PROJECT_VERSION
 
 _LOGGER = logging.getLogger(__name__)
 
-# if you want your own sentry backend for development then replace the first one
-# only
 
 env = os.getenv("ENVIRONMENT", "dev")
 
@@ -24,7 +22,7 @@ if env == "dev":
     exit_code = process.wait()
     release = f"ledfx@{PROJECT_VERSION}-{commit_hash}"
 else:
-    # production / release behaviour due to injection of "prod" into
+    # production / release behaviour due to injection of "prod" or anything really into ENVIRONMENT env variable
     sentry_dsn = "https://dc6070345a8dfa1f2f24433d16f7a133@o482797.ingest.sentry.io/4506350233321472"
     sample_rate = 0
     release = f"ledfx@{PROJECT_VERSION}"


### PR DESCRIPTION
Hard coded sentry DSNs into sentry_config.py

Move to brand new key, in this case ledfx-v2-dev where intention is

If environment variable ENVIRONMENT is set to any other value than empty or "dev" the release DSN will be used.

ledfx-v2-rel
client key / DSN
https://dc6070345a8dfa1f2f24433d16f7a133@o482797.ingest.sentry.io/4506350233321472

Default is to assume "dev" DSN

ledfx-v2-dev
client key / DSN
https://b192934eebd517c86bf7e9c512b3888a@o482797.ingest.sentry.io/4506350241841152

Tested with --offline
Tested with forced crash using --sentry-crash-test

Tested for no ENVIRONMENT variable = dev key
Tested with ENVIRONMENT = "rel" = rel key

Crash traces seen in back end in correct db's
