### PR TITLE
Remove pywin32

### DIFF
--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -202,17 +202,6 @@ class LedFxCore:
     def start(self, open_ui=False):
         async_fire_and_forget(self.async_start(open_ui=open_ui), self.loop)
 
-        # Windows does not seem to handle Ctrl+C well so as a workaround
-        # register a handler and manually stop the app
-        if sys.platform == "win32":
-            import win32api
-
-            def handle_win32_interrupt(sig, func=None):
-                self.stop(exit_code=2)
-                return True
-
-            win32api.SetConsoleCtrlHandler(handle_win32_interrupt, 1)
-
         try:
             self.loop.run_forever()
         except KeyboardInterrupt:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1396,29 +1396,6 @@ files = [
 six = ">=1.10.0"
 
 [[package]]
-name = "pywin32"
-version = "306"
-description = "Python for Window Extensions"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pywin32-306-cp310-cp310-win32.whl", hash = "sha256:06d3420a5155ba65f0b72f2699b5bacf3109f36acbe8923765c22938a69dfc8d"},
-    {file = "pywin32-306-cp310-cp310-win_amd64.whl", hash = "sha256:84f4471dbca1887ea3803d8848a1616429ac94a4a8d05f4bc9c5dcfd42ca99c8"},
-    {file = "pywin32-306-cp311-cp311-win32.whl", hash = "sha256:e65028133d15b64d2ed8f06dd9fbc268352478d4f9289e69c190ecd6818b6407"},
-    {file = "pywin32-306-cp311-cp311-win_amd64.whl", hash = "sha256:a7639f51c184c0272e93f244eb24dafca9b1855707d94c192d4a0b4c01e1100e"},
-    {file = "pywin32-306-cp311-cp311-win_arm64.whl", hash = "sha256:70dba0c913d19f942a2db25217d9a1b726c278f483a919f1abfed79c9cf64d3a"},
-    {file = "pywin32-306-cp312-cp312-win32.whl", hash = "sha256:383229d515657f4e3ed1343da8be101000562bf514591ff383ae940cad65458b"},
-    {file = "pywin32-306-cp312-cp312-win_amd64.whl", hash = "sha256:37257794c1ad39ee9be652da0462dc2e394c8159dfd913a8a4e8eb6fd346da0e"},
-    {file = "pywin32-306-cp312-cp312-win_arm64.whl", hash = "sha256:5821ec52f6d321aa59e2db7e0a35b997de60c201943557d108af9d4ae1ec7040"},
-    {file = "pywin32-306-cp37-cp37m-win32.whl", hash = "sha256:1c73ea9a0d2283d889001998059f5eaaba3b6238f767c9cf2833b13e6a685f65"},
-    {file = "pywin32-306-cp37-cp37m-win_amd64.whl", hash = "sha256:72c5f621542d7bdd4fdb716227be0dd3f8565c11b280be6315b06ace35487d36"},
-    {file = "pywin32-306-cp38-cp38-win32.whl", hash = "sha256:e4c092e2589b5cf0d365849e73e02c391c1349958c5ac3e9d5ccb9a28e017b3a"},
-    {file = "pywin32-306-cp38-cp38-win_amd64.whl", hash = "sha256:e8ac1ae3601bee6ca9f7cb4b5363bf1c0badb935ef243c4733ff9a393b1690c0"},
-    {file = "pywin32-306-cp39-cp39-win32.whl", hash = "sha256:e25fd5b485b55ac9c057f67d94bc203f3f6595078d1fb3b458c9c28b7153a802"},
-    {file = "pywin32-306-cp39-cp39-win_amd64.whl", hash = "sha256:39b61c15272833b5c329a2989999dcae836b1eed650252ab1b7bfbe1d59f30f4"},
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
@@ -1938,4 +1915,4 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "c4eb9bdb226127b3c7dbb346cedfa8635b43744eb92713a249d1fcd8f6b2957b"
+content-hash = "7f58292afe04c3f5eb644af788810fa7c79de7461b3a513d48b414c1a581c5e5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ python-osc = ">=1.8.3"
 pybase64 = "~=1.3.1"
 mss = "~=9.0.1"
 setuptools = "~=69.0.3"
-pywin32 = {version = ">=306", platform = "win32"}
 uvloop = {version = ">=0.16.0", markers = "sys_platform != 'win32'"}
 rpi-ws281x = {version = ">=4.3.0", platform = "linux"}
 python-mbedtls = {version = "^2.8.0", markers = "(sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'armv7l') or sys_platform == 'win32' or sys_platform == 'darwin'"}


### PR DESCRIPTION
Now we're on python 3.9 or above we don't need to worry about hacky win32api calls for Control-C.

Works over here, but could do with some testing.