### PR TITLE
⚠️⚠️⚠️ Breaking: Update Presets/Virtuals API ⚠️⚠️⚠️

### DIFF
--- a/ledfx/api/presets.py
+++ b/ledfx/api/presets.py
@@ -27,20 +27,20 @@ class PresetsEndpoint(RestEndpoint):
             return web.json_response(data=response, status=400)
 
         if effect_id in self._ledfx.config["ledfx_presets"].keys():
-            default = self._ledfx.config["ledfx_presets"][effect_id]
+            ledfx_presets = self._ledfx.config["ledfx_presets"][effect_id]
         else:
-            default = {}
+            ledfx_presets = {}
 
         if effect_id in self._ledfx.config["user_presets"].keys():
-            custom = self._ledfx.config["user_presets"][effect_id]
+            user_presets = self._ledfx.config["user_presets"][effect_id]
         else:
-            custom = {}
+            user_presets = {}
 
         response = {
             "status": "success",
             "effect": effect_id,
-            "default_presets": default,
-            "custom_presets": custom,
+            "ledfx_presets": ledfx_presets,
+            "user_presets": user_presets,
         }
         return web.json_response(data=response, status=200)
 
@@ -69,9 +69,7 @@ class PresetsEndpoint(RestEndpoint):
         if category not in ["ledfx_presets", "user_presets"]:
             response = {
                 "status": "failed",
-                "reason": 'Category {} is not "ledfx_presets" or "user_presets"'.format(
-                    category
-                ),
+                "reason": f'Category {category} is not "ledfx_presets" or "user_presets"',
             }
             return web.json_response(data=response, status=400)
 
@@ -85,9 +83,7 @@ class PresetsEndpoint(RestEndpoint):
         if effect_id not in self._ledfx.config[category].keys():
             response = {
                 "status": "failed",
-                "reason": "Effect {} does not exist in category {}".format(
-                    effect_id, category
-                ),
+                "reason": f"Effect {effect_id} does not exist in category {category}",
             }
             return web.json_response(data=response, status=400)
 
@@ -110,9 +106,7 @@ class PresetsEndpoint(RestEndpoint):
         if preset_id not in self._ledfx.config[category][effect_id].keys():
             response = {
                 "status": "failed",
-                "reason": "Preset {} does not exist for effect {} in category {}".format(
-                    preset_id, effect_id, category
-                ),
+                "reason": f"Preset {preset_id} does not exist for effect {effect_id} in category {category}",
             }
             return web.json_response(data=response, status=400)
 
@@ -156,9 +150,7 @@ class PresetsEndpoint(RestEndpoint):
         if category not in ["ledfx_presets", "user_presets"]:
             response = {
                 "status": "failed",
-                "reason": 'Category {} is not "ledfx_presets" or "user_presets"'.format(
-                    category
-                ),
+                "reason": f'Category {category} is not "ledfx_presets" or "user_presets"',
             }
             return web.json_response(data=response, status=400)
 
@@ -181,9 +173,7 @@ class PresetsEndpoint(RestEndpoint):
         if effect_id not in self._ledfx.config[category].keys():
             response = {
                 "status": "failed",
-                "reason": "Effect {} does not exist in category {}".format(
-                    effect_id, category
-                ),
+                "reason": f"Effect {effect_id} does not exist in category {category}",
             }
             return web.json_response(data=response, status=400)
 
@@ -197,9 +187,7 @@ class PresetsEndpoint(RestEndpoint):
         if preset_id not in self._ledfx.config[category][effect_id].keys():
             response = {
                 "status": "failed",
-                "reason": "Preset {} does not exist for effect {} in category {}".format(
-                    preset_id, effect_id, category
-                ),
+                "reason": f"Preset {preset_id} does not exist for effect {effect_id} in category {category}",
             }
             return web.json_response(data=response, status=400)
 

--- a/ledfx/api/virtual_presets.py
+++ b/ledfx/api/virtual_presets.py
@@ -23,7 +23,7 @@ class VirtualPresetsEndpoint(RestEndpoint):
                 "status": "failed",
                 "reason": f"Virtual with ID {virtual_id} not found",
             }
-            return web.json_response(data=response, status=404)
+            return web.json_response(data=response, status=400)
 
         if not virtual.active_effect:
             response = {
@@ -48,8 +48,8 @@ class VirtualPresetsEndpoint(RestEndpoint):
             "status": "success",
             "virtual": virtual_id,
             "effect": effect_id,
-            "default_presets": default,
-            "custom_presets": custom,
+            "ledfx_presets": default,
+            "user_presets": custom,
         }
 
         return web.json_response(data=response, status=200)
@@ -83,7 +83,7 @@ class VirtualPresetsEndpoint(RestEndpoint):
                 "status": "failed",
                 "reason": f"Virtual with ID {virtual_id} not found",
             }
-            return web.json_response(data=response, status=404)
+            return web.json_response(data=response, status=400)
 
         try:
             data = await request.json()
@@ -104,17 +104,12 @@ class VirtualPresetsEndpoint(RestEndpoint):
             }
             return web.json_response(data=response, status=400)
 
-        if category not in ["default_presets", "custom_presets"]:
+        if category not in ["ledfx_presets", "user_presets"]:
             response = {
                 "status": "failed",
                 "reason": f'Category {category} is not "ledfx_presets" or "user_presets"',
             }
             return web.json_response(data=response, status=400)
-
-        if category == "default_presets":
-            category = "ledfx_presets"
-        else:
-            category = "user_presets"
 
         if effect_id is None:
             response = {
@@ -140,9 +135,7 @@ class VirtualPresetsEndpoint(RestEndpoint):
         if preset_id not in self._ledfx.config[category][effect_id].keys():
             response = {
                 "status": "failed",
-                "reason": "Preset {} does not exist for effect {} in category {}".format(
-                    preset_id, effect_id, category
-                ),
+                "reason": f"Preset {preset_id} does not exist for effect {effect_id} in category {category}",
             }
             return web.json_response(data=response, status=400)
 
@@ -185,14 +178,14 @@ class VirtualPresetsEndpoint(RestEndpoint):
                 "status": "failed",
                 "reason": f"Virtual with ID {virtual_id} not found",
             }
-            return web.json_response(data=response, status=404)
+            return web.json_response(data=response, status=400)
 
         if not virtual.active_effect:
             response = {
                 "status": "failed",
                 "reason": f"Virtual {virtual_id} has no active effect",
             }
-            return web.json_response(data=response, status=404)
+            return web.json_response(data=response, status=400)
 
         try:
             data = await request.json()
@@ -249,7 +242,7 @@ class VirtualPresetsEndpoint(RestEndpoint):
                 "status": "failed",
                 "reason": f"Virtual with ID {virtual_id} not found",
             }
-            return web.json_response(data=response, status=404)
+            return web.json_response(data=response, status=400)
 
         # Clear the effect
         virtual.clear_effect()


### PR DESCRIPTION
This removes the last instances of `default_presets` and `custom_presets` that are leftover from a long time ago.

This breaks the frontend and any other clients using the HTTP API, but should simplify things moving forward (not having to remap from old name to new name forever etc)

This doesn't actually fix the bug that I was looking at/for [discord thread](https://discord.com/channels/469985374052286474/1173289949483761787)  - that's caused by the frontend incorrectly sending default_presets as the category for user presets.

I'll have a look at the frontend and see if I can learn enough to do a PR to it.