### PR TITLE
Cancel duplicate CI jobs

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,6 +3,10 @@ name: CI Build LedFx
 on:
   push:
   pull_request:
+    
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-ledfx-linux:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,7 +3,7 @@ name: CI Build LedFx
 on:
   push:
   pull_request:
-    
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ on:
   schedule:
     - cron: '0 8,20 * * *'
   workflow_dispatch:
-    
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,10 @@ on:
   schedule:
     - cron: '0 8,20 * * *'
   workflow_dispatch:
+    
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CACHE_VERSION: 1


### PR DESCRIPTION
Should save some time/energy when we multiple PRs/commits at the same time.