### PR TITLE
Migrate to AsyncZeroconf

### DIFF
--- a/ledfx/api/find_devices.py
+++ b/ledfx/api/find_devices.py
@@ -28,7 +28,7 @@ class FindDevicesEndpoint(RestEndpoint):
             exc = future.exception()
 
         async_fire_and_forget(
-            self._ledfx.devices.find_wled_devices(),
+            self._ledfx.zeroconf.discover_wled_devices(),
             loop=self._ledfx.loop,
             exc_handler=handle_exception,
         )

--- a/ledfx/api/find_devices.py
+++ b/ledfx/api/find_devices.py
@@ -35,3 +35,19 @@ class FindDevicesEndpoint(RestEndpoint):
 
         response = {"status": "success"}
         return web.json_response(data=response, status=200)
+
+    async def get(self) -> web.Response:
+        """Handle HTTP GET requests"""
+
+        def handle_exception(future):
+            # Ignore exceptions, these will be raised when a device is found that already exists
+            exc = future.exception()
+
+        async_fire_and_forget(
+            self._ledfx.zeroconf.discover_wled_devices(),
+            loop=self._ledfx.loop,
+            exc_handler=handle_exception,
+        )
+
+        response = {"status": "success"}
+        return web.json_response(data=response, status=200)

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -38,6 +38,7 @@ from ledfx.utils import (
     currently_frozen,
 )
 from ledfx.virtuals import Virtuals
+from ledfx.zeroconf import ZeroConfRunner
 
 _LOGGER = logging.getLogger(__name__)
 if currently_frozen():
@@ -259,17 +260,14 @@ class LedFxCore:
         self.devices.create_from_config(self.config["devices"])
         await self.devices.async_initialize_devices()
 
-        # sync_mode = WLED_CONFIG_SCHEMA(self.config["wled_preferences"])[
-        #     "wled_preferred_mode"
-        # ]
-        # if sync_mode:
-        #     await self.devices.set_wleds_sync_mode(sync_mode)
-
+        self.zeroconf = ZeroConfRunner(ledfx=self)
         self.virtuals.create_from_config(self.config["virtuals"])
         self.integrations.create_from_config(self.config["integrations"])
 
         if self.config["scan_on_startup"]:
-            async_fire_and_forget(self.devices.find_wled_devices(), self.loop)
+            async_fire_and_forget(
+                self.zeroconf.discover_wled_devices(), self.loop
+            )
 
         async_fire_and_forget(
             self.integrations.activate_integrations(), self.loop
@@ -310,7 +308,7 @@ class LedFxCore:
         # Fire a shutdown event and flush the loop
         self.events.fire_event(LedFxShutdownEvent())
         await asyncio.sleep(0)
-
+        await self.zeroconf.async_close()
         _LOGGER.info("Stopping HttpServer...")
         await self.http.stop()
 

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -8,7 +8,6 @@ from functools import cached_property
 
 import numpy as np
 import voluptuous as vol
-import zeroconf
 
 from ledfx.color import parse_color
 from ledfx.effects import DummyEffect
@@ -940,7 +939,6 @@ class Virtuals:
 
         self._ledfx = ledfx
         self._ledfx.events.add_listener(cleanup_effects, Event.LEDFX_SHUTDOWN)
-        self._zeroconf = zeroconf.Zeroconf()
         self._virtuals = {}
 
     def create_from_config(self, config):

--- a/ledfx/zeroconf.py
+++ b/ledfx/zeroconf.py
@@ -137,7 +137,9 @@ class ZeroConfRunner:
         """
         Asynchronous function for closing zeroconf listener.
         """
-        _LOGGER.info("Closing zeroconf listener.")
-        await self.aiobrowser.async_cancel()
-        await self.aiozc.async_close()
-        _LOGGER.info("Zeroconf closed.")
+        # If aiobrowser exists, then aiozc must also exist.
+        if self.aiobrowser:
+            _LOGGER.info("Closing zeroconf listener.")
+            await self.aiobrowser.async_cancel()
+            await self.aiozc.async_close()
+            _LOGGER.info("Zeroconf closed.")

--- a/ledfx/zeroconf.py
+++ b/ledfx/zeroconf.py
@@ -137,8 +137,6 @@ class ZeroConfRunner:
         """
         Asynchronous function for closing zeroconf listener.
         """
-        assert self.aiozc is not None
-        assert self.aiobrowser is not None
         _LOGGER.info("Closing zeroconf listener.")
         await self.aiobrowser.async_cancel()
         await self.aiozc.async_close()

--- a/ledfx/zeroconf.py
+++ b/ledfx/zeroconf.py
@@ -1,0 +1,70 @@
+
+import asyncio
+
+from typing import Any, Optional, cast
+import logging
+from zeroconf import  ServiceStateChange, Zeroconf
+from zeroconf.asyncio import (
+    AsyncServiceBrowser,
+    AsyncServiceInfo,
+    AsyncZeroconf,
+    
+)
+from ledfx.utils import async_fire_and_forget
+_LOGGER = logging.getLogger(__name__)
+
+class WLEDResponder:
+
+    def async_on_service_state_change(
+        zeroconf: Zeroconf, service_type: str, name: str, state_change: ServiceStateChange
+    ) -> None:
+        print(f"Service {name} of type {service_type} state changed: {state_change}")
+        if state_change is not ServiceStateChange.Added:
+            return
+        async_fire_and_forget(WLEDResponder.async_display_service_info(zeroconf, service_type, name))
+
+
+    async def async_display_service_info(zeroconf: Zeroconf, service_type: str, name: str) -> None:
+        info = AsyncServiceInfo(service_type, name)
+        await info.async_request(zeroconf, 3000)
+        print("Info from zeroconf.get_service_info: %r" % (info))
+        if info:
+            addresses = ["%s:%d" % (addr, cast(int, info.port)) for addr in info.parsed_scoped_addresses()]
+            print("  Name: %s" % name)
+            print("  Addresses: %s" % ", ".join(addresses))
+            print("  Weight: %d, priority: %d" % (info.weight, info.priority))
+            print(f"  Server: {info.server}")
+            if info.properties:
+                print("  Properties are:")
+                for key, value in info.properties.items():
+                    print(f"    {key!r}: {value!r}")
+            else:
+                print("  No properties")
+        else:
+            print("  No info")
+        print('\n')
+
+
+class ZeroConfRunner:
+
+    def __init__(self, args: Any) -> None:
+        self.args = args
+        self.aiobrowser: Optional[AsyncServiceBrowser] = None
+        self.aiozc: Optional[AsyncZeroconf] = None
+
+    async def async_run(self) -> None:
+        self.aiozc = AsyncZeroconf()
+
+        services = ["_wled._tcp.local."]
+
+        print("\nBrowsing %s service(s), press Ctrl-C to exit...\n" % services)
+        self.aiobrowser = AsyncServiceBrowser(
+            self.aiozc.zeroconf, services, handlers=[WLEDResponder.async_on_service_state_change]
+        )
+
+
+    async def async_close(self) -> None:
+        assert self.aiozc is not None
+        assert self.aiobrowser is not None
+        await self.aiobrowser.async_cancel()
+        await self.aiozc.async_close()

--- a/ledfx/zeroconf.py
+++ b/ledfx/zeroconf.py
@@ -17,8 +17,8 @@ class ZeroConfRunner:
     Class responsible for handling zeroconf, WLED discovery and WLED device registration.
 
     Attributes:
-        aiobrowser (Optional[AsyncServiceBrowser]): The async service browser for zeroconf.
-        aiozc (Optional[AsyncZeroconf]): The async zeroconf instance.
+        aiobrowser: The async service browser for zeroconf.
+        aiozc: The async zeroconf instance.
         _ledfx: The ledfx instance.
 
     Methods:

--- a/ledfx/zeroconf.py
+++ b/ledfx/zeroconf.py
@@ -92,7 +92,9 @@ class ZeroConfRunner:
         self, zeroconf: Zeroconf, service_type: str, name: str
     ) -> None:
         """
-        Asynchronous function for
+        Asynchronous function for feeding discovered WLED devices to add_new_device.
+
+        Duplicate detection is handled within add_new_device.
 
         Args:
             zeroconf (Zeroconf): The zeroconf instance.


### PR DESCRIPTION
This is a biggish change to core Zeroconf functionality.

Tore out the blocking stuff and refactored all zeroconf into one file.

~~Also reeenabled the scan on startup that has been commented out.~~

Tested with my WLED devices and all seems fine.

If we want to keep the listener alive and have newly discovered devices automatically added that's doable, but I think for now on startup and on demand is likely enough.

Should fix the annoying zeroconf warning on shutdown and make the shutdown process faster.