### PR TITLE
Update serial device error handling

### DIFF
--- a/ledfx/devices/adalight.py
+++ b/ledfx/devices/adalight.py
@@ -51,3 +51,4 @@ class AdalightDevice(SerialDevice):
             _LOGGER.critical(
                 "Serial Connection Interrupted. Please check connections and ensure your device is functioning correctly."
             )
+            self.deactivate()


### PR DESCRIPTION
This pull request fixes a bug where the serial connection could be interrupted and any erroring devices would not be deactivated - they simply spam the error log on every call to flush.

The `flush` function has been updated to include a call to the `deactivate` method when a serial connection interruption occurs.