### PR TITLE
Use LedFx_shutdown event in Zeroconf implementation

### DIFF
--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -308,7 +308,6 @@ class LedFxCore:
         # Fire a shutdown event and flush the loop
         self.events.fire_event(LedFxShutdownEvent())
         await asyncio.sleep(0)
-        await self.zeroconf.async_close()
         _LOGGER.info("Stopping HttpServer...")
         await self.http.stop()
 

--- a/ledfx/mdns_manager.py
+++ b/ledfx/mdns_manager.py
@@ -7,6 +7,7 @@ from zeroconf.asyncio import (
     AsyncZeroconf,
 )
 
+from ledfx.events import Event
 from ledfx.utils import async_fire_and_forget
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,6 +34,11 @@ class ZeroConfRunner:
         self.aiobrowser = None
         self.aiozc = None
         self._ledfx = ledfx
+
+        def on_shutdown(e):
+            async_fire_and_forget(self.async_close(), self._ledfx.loop)
+
+        self._ledfx.events.add_listener(on_shutdown, Event.LEDFX_SHUTDOWN)
 
     def on_service_state_change(
         self,


### PR DESCRIPTION
This pull request removes the zeroconf.async_close() method from the core and replaces it with a shutdown event listener. 

