### PR TITLE
Catch invalid schemas in Effect class

### DIFF
--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -293,7 +293,13 @@ class Effect(BaseRegistry):
 
     def update_config(self, config):
         self.lock.acquire()
-        validated_config = type(self).schema()(config)
+        try:
+            validated_config = type(self).schema()(config)
+        except vol.Invalid as err:
+            _LOGGER.warning(f"Error updating effect {self.NAME} config: {err}")
+            self.lock.release()
+            return
+
         prior_config = self._config
 
         if self._config != {}:


### PR DESCRIPTION
This pull request fixes an issue where invalid schemas were not being caught in the Effect class.

 Now, when updating the effect configuration, if an invalid schema is detected, a warning message is logged and the update is aborted.