### PR TITLE
fix reversing bands when band pixel counts are not equal

### DIFF
--- a/ledfx/effects/bands_matrix.py
+++ b/ledfx/effects/bands_matrix.py
@@ -66,7 +66,7 @@ class BandsMatrixAudioEffect(AudioReactiveEffect, GradientEffect):
                 out_split[i] = np.flip(out_split[i], axis=0)
 
         if self.flip_horizontal:
-            out_split = np.flip(out_split, axis=0)
+            out_split.reverse()
 
         self.pixels = np.vstack(out_split)
         self.roll_gradient()


### PR DESCRIPTION
see https://discord.com/channels/469985374052286474/1194000444079481015

User crashing ledfx with bands matrix flip horizontal switch

np.flip requires equal array lengths and will crash if pixel count % bands is not equal to zero

Just use list reverse instead of np function.

It all gets mapped into np.array in the next step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the efficiency of the output flipping logic in the visual effects module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->