### PR TITLE
Protect against no git for senty

### DIFF
--- a/ledfx/effects/twod.py
+++ b/ledfx/effects/twod.py
@@ -15,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 class Twod(AudioReactiveEffect):
     EFFECT_START_TIME = timeit.default_timer()
     HIDDEN_KEYS = ["background_brightness", "mirror", "flip", "blur"]
-    ADVANCED_KEYS = ["dump", "diag", "test"]
+    ADVANCED_KEYS = ["dump", "diag", "test", "flip horizontal", "flip vertical"]
 
     CONFIG_SCHEMA = vol.Schema(
         {

--- a/ledfx/sentry_config.py
+++ b/ledfx/sentry_config.py
@@ -22,6 +22,7 @@ if is_release == "false":
         (commit_hash, err) = process.communicate()
         commit_hash = commit_hash[:7].decode("utf-8")
         exit_code = process.wait()
+    # TODO: trap explicit exceptions if it becomes clear what they are
     except Exception as e:
         commit_hash = "unknown"
         _LOGGER.warning(f"Failed to get git commit hash: {e}")

--- a/ledfx/sentry_config.py
+++ b/ledfx/sentry_config.py
@@ -15,12 +15,16 @@ if is_release == "false":
     sentry_dsn = "https://b192934eebd517c86bf7e9c512b3888a@o482797.ingest.sentry.io/4506350241841152"
     sample_rate = 1
 
-    from subprocess import PIPE, Popen
+    try:
+        from subprocess import PIPE, Popen
 
-    process = Popen(["git", "rev-parse", "HEAD"], stdout=PIPE)
-    (commit_hash, err) = process.communicate()
-    commit_hash = commit_hash[:7].decode("utf-8")
-    exit_code = process.wait()
+        process = Popen(["git", "rev-parse", "HEAD"], stdout=PIPE)
+        (commit_hash, err) = process.communicate()
+        commit_hash = commit_hash[:7].decode("utf-8")
+        exit_code = process.wait()
+    except Exception as e:
+        commit_hash = "unknown"
+        _LOGGER.warning(f"Failed to get git commit hash: {e}")
     release = f"ledfx@{PROJECT_VERSION}-{commit_hash}"
 else:
     # production / release behaviour due to injection of "prod" or anything really into ENVIRONMENT env variable


### PR DESCRIPTION
protect sentry git enquiry in dev mode from failing to find git for commit extraction

Tested by breaking git by changing the name called. Generated error warning and continued with "unknown"

Caused https://discord.com/channels/469985374052286474/1194713190609735751


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced horizontal and vertical flip options for two-dimensional effects.

- **Bug Fixes**
	- Improved error handling for version tracking to enhance application stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->