### PR TITLE
Suggested fix to prevent crashing when numbers entered in skip frames or beat frames do not account for 0-indexing.

### DIFF
--- a/ledfx/effects/keybeat2d.py
+++ b/ledfx/effects/keybeat2d.py
@@ -156,11 +156,11 @@ class Keybeat2d(Twod, GifBase):
         self.framecount = len(self.orig_frames)
         self.beat_frames = remove_values_above_limit(
             sorted(extract_positive_integers(self._config["beat frames"])),
-            len(self.orig_frames)-1,
+            len(self.orig_frames) - 1,
         )
         self.skip_frames = remove_values_above_limit(
             sorted(extract_positive_integers(self._config["skip frames"])),
-            len(self.orig_frames)-1,
+            len(self.orig_frames) - 1,
         )
 
         if self.diag:

--- a/ledfx/effects/keybeat2d.py
+++ b/ledfx/effects/keybeat2d.py
@@ -156,11 +156,11 @@ class Keybeat2d(Twod, GifBase):
         self.framecount = len(self.orig_frames)
         self.beat_frames = remove_values_above_limit(
             sorted(extract_positive_integers(self._config["beat frames"])),
-            len(self.orig_frames),
+            len(self.orig_frames)-1,
         )
         self.skip_frames = remove_values_above_limit(
             sorted(extract_positive_integers(self._config["skip frames"])),
-            len(self.orig_frames),
+            len(self.orig_frames)-1,
         )
 
         if self.diag:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the timing accuracy in the Keybeat2D effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->