### PR TITLE
fix clip value function for keybeat

### DIFF
--- a/ledfx/effects/keybeat2d.py
+++ b/ledfx/effects/keybeat2d.py
@@ -11,7 +11,7 @@ from ledfx.utils import (
     extract_positive_integers,
     get_mono_font,
     open_gif,
-    remove_values_above_limit,
+    clip_at_limit,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -154,11 +154,11 @@ class Keybeat2d(Twod, GifBase):
         self.f_beat = 0.0  # fake beat oscillator
 
         self.framecount = len(self.orig_frames)
-        self.beat_frames = remove_values_above_limit(
+        self.beat_frames = clip_at_limit(
             sorted(extract_positive_integers(self._config["beat frames"])),
             len(self.orig_frames),
         )
-        self.skip_frames = remove_values_above_limit(
+        self.skip_frames = clip_at_limit(
             sorted(extract_positive_integers(self._config["skip frames"])),
             len(self.orig_frames),
         )

--- a/ledfx/effects/keybeat2d.py
+++ b/ledfx/effects/keybeat2d.py
@@ -8,10 +8,10 @@ from ledfx.consts import LEDFX_ASSETS_PATH
 from ledfx.effects.gifbase import GifBase
 from ledfx.effects.twod import Twod
 from ledfx.utils import (
+    clip_at_limit,
     extract_positive_integers,
     get_mono_font,
     open_gif,
-    clip_at_limit,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -1216,9 +1216,9 @@ def extract_positive_integers(s):
     return [int(num) for num in numbers if int(num) >= 0]
 
 
-def remove_values_above_limit(numbers, limit):
-    # Keep only values that are less than or equal to the limit
-    return [num for num in numbers if num <= limit]
+def clip_at_limit(numbers, limit):
+    # Keep only values that are less than the limit
+    return [num for num in numbers if num < limit]
 
 
 def open_gif(gif_path):


### PR DESCRIPTION
Preferred fix for erroneous <= test instead of <

Even function name was bad :-(

tested with reproduction of reported crash and then proven hardening.

What could be reasonably written as an in line list comprehension was put in a function as the overall manipulation going on was already complex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved handling of beat and skip frames in the 2D keybeat effect for enhanced performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->