### PR TITLE
"Fix" audio input source deactivation bug

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -132,7 +132,6 @@ class AudioInputSource:
     def __init__(self, ledfx, config):
         self._ledfx = ledfx
         self.update_config(config)
-        self.pending_deactivation = False
 
         def deactivate(e):
             self.deactivate()
@@ -320,7 +319,6 @@ class AudioInputSource:
         self._callbacks.append(callback)
 
         if len(self._callbacks) > 0 and not self._is_activated:
-            self.pending_deactivation = False
             self.activate()
 
     def unsubscribe(self, callback):


### PR DESCRIPTION
~~Ugly, dirty, poor~~ Elegant, nuanced solution to drive around what appears to be a portaudio bug.

Leaves audio device open and analysis running for 5 seconds when no effects areusing it and then checks and closes at the end of the timer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
	- Improved audio effect subscription management.
- **Bug Fixes**
	- Addressed an issue with audio device handling on unsubscribe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->