### PR TITLE
Add try-catch blocks to statements with logging to statements that currently cause a crash

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -444,7 +444,7 @@ Query and manage virtuals connected to LedFx
 Get configuration of all virtuals
 
 .. rubric:: PUT
-   
+
 Pause/Unpause all virtuals
 
 .. rubric:: POST

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -443,6 +443,10 @@ Query and manage virtuals connected to LedFx
 
 Get configuration of all virtuals
 
+.. rubric:: PUT
+   
+Pause/Unpause all virtuals
+
 .. rubric:: POST
 
 Adds a new virtual to LedFx based on the provided JSON configuration

--- a/ledfx/effects/clone.py
+++ b/ledfx/effects/clone.py
@@ -84,7 +84,10 @@ class Clone(Twod):
                     "mon": self.screen,
                 }
             except Exception as e:
-                _LOGGER.error("Caught exception trying to grab screenclip in draw() of clone.py", exc_info=True)
+                _LOGGER.error(
+                    "Caught exception trying to grab screenclip in draw() of clone.py",
+                    exc_info=True,
+                )
                 super.super.virtual.clear_effect()
                 return
 
@@ -92,7 +95,10 @@ class Clone(Twod):
         try:
             frame = self.sct.grab(self.grab)
         except Exception as e:
-            _LOGGER.error("Intercepted crash as a result of clone effect - screengrab failed", exc_info=True)
+            _LOGGER.error(
+                "Intercepted crash as a result of clone effect - screengrab failed",
+                exc_info=True,
+            )
             self.deactivate()
             return
         grab = timeit.default_timer()

--- a/ledfx/effects/clone.py
+++ b/ledfx/effects/clone.py
@@ -74,17 +74,27 @@ class Clone(Twod):
 
         if self.grab is None:
             # grab a screen clip from screen x at x,y of width, height
-            mon = self.sct.monitors[self.screen]
-            self.grab = {
-                "top": mon["top"] + self.x,
-                "left": mon["left"] + self.y,
-                "width": self.width,
-                "height": self.height,
-                "mon": self.screen,
-            }
+            try:
+                mon = self.sct.monitors[self.screen]
+                self.grab = {
+                    "top": mon["top"] + self.x,
+                    "left": mon["left"] + self.y,
+                    "width": self.width,
+                    "height": self.height,
+                    "mon": self.screen,
+                }
+            except Exception as e:
+                _LOGGER.error("Caught exception trying to grab screenclip in draw() of clone.py", exc_info=True)
+                super.super.virtual.clear_effect()
+                return
 
         pre = timeit.default_timer()
-        frame = self.sct.grab(self.grab)
+        try:
+            frame = self.sct.grab(self.grab)
+        except Exception as e:
+            _LOGGER.error("Intercepted crash as a result of clone effect - screengrab failed", exc_info=True)
+            self.deactivate()
+            return
         grab = timeit.default_timer()
 
         rgb_image = Image.frombytes(

--- a/ledfx/effects/twod.py
+++ b/ledfx/effects/twod.py
@@ -159,7 +159,7 @@ class Twod(AudioReactiveEffect):
         try:
             copy_length = min(self.pixels.shape[0], rgb_array.shape[0])
             self.pixels[:copy_length, :] = rgb_array[:copy_length, :]
-        except: 
+        except:
             _LOGGER.error("Failed to copy image to matrix!", exc_info=True)
 
     def log_sec(self):

--- a/ledfx/effects/twod.py
+++ b/ledfx/effects/twod.py
@@ -156,8 +156,11 @@ class Twod(AudioReactiveEffect):
         rgb_array = rgb_array.astype(np.float32)
         rgb_array = rgb_array.reshape(int(rgb_array.shape[0] / 3), 3)
 
-        copy_length = min(self.pixels.shape[0], rgb_array.shape[0])
-        self.pixels[:copy_length, :] = rgb_array[:copy_length, :]
+        try:
+            copy_length = min(self.pixels.shape[0], rgb_array.shape[0])
+            self.pixels[:copy_length, :] = rgb_array[:copy_length, :]
+        except: 
+            _LOGGER.error("Failed to copy image to matrix!", exc_info=True)
 
     def log_sec(self):
         result = False


### PR DESCRIPTION
This is an interim solution, as I'm not familiar enough with the codebase to find and patch the root cause. 

Currently, if LEDFx isn't able to get a screengrab the entire program crashes into a state that's difficult to recover from - since the last used effect (that caused it to crash) will be re-started again on startup. (See issue 614 )

I added try-catch statements around the statements that were causing crashes on my machine, and turn the virtual off to prevent issues - this way, something is evidently wrong and the user knows to check. Some kind of alert in the UI would be better, but tbh i'm not sure how to do that and this at least lets the user keep using it without having to get out their terminal. 

Thanks for your work guys, this program rocks.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability to pause and unpause all virtual devices from the API documentation.

- **Bug Fixes**
	- Improved stability of the clone effect by handling exceptions during screen capture.
	- Enhanced error handling in the 2D effect to prevent crashes when processing images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->