### PR TITLE
Fix NaN values in melbank array

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -925,4 +925,13 @@ class AudioReactiveEffect(Effect):
         mel_length = len(melbank)
         splits = tuple(map(lambda i: int(i * mel_length), [0.2, 0.5]))
 
+        # Check for NaN values in the melbank array
+        # Difficult to determine why this happens, but it seems to be related to
+        # the audio input device. If NaNs are present, replace them with 0
+        # TODO: Investigate why NaNs are present in the melbank array for some people/devices
+        if np.isnan(melbank).any():
+            print("NaNs!")
+            # Replace NaN values with 0
+            melbank = np.nan_to_num(melbank)
+
         return np.split(melbank, splits)

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -930,8 +930,7 @@ class AudioReactiveEffect(Effect):
         # the audio input device. If NaNs are present, replace them with 0
         # TODO: Investigate why NaNs are present in the melbank array for some people/devices
         if np.isnan(melbank).any():
-            print("NaNs!")
+            _LOGGER.warning("NaN values detected in the melbank array and replaced with 0.")
             # Replace NaN values with 0
             melbank = np.nan_to_num(melbank)
-
         return np.split(melbank, splits)

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -930,7 +930,9 @@ class AudioReactiveEffect(Effect):
         # the audio input device. If NaNs are present, replace them with 0
         # TODO: Investigate why NaNs are present in the melbank array for some people/devices
         if np.isnan(melbank).any():
-            _LOGGER.warning("NaN values detected in the melbank array and replaced with 0.")
+            _LOGGER.warning(
+                "NaN values detected in the melbank array and replaced with 0."
+            )
             # Replace NaN values with 0
             melbank = np.nan_to_num(melbank)
         return np.split(melbank, splits)


### PR DESCRIPTION
This pull request fixes an issue where NaN values were present in the melbank array. 

The NaN values seem to be related to the audio input device. 

To address this, the code now checks for NaN values and replaces them with 0.

I can't reproduce but a test binary with this change was sent to a user and confirmed to be working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved audio effect stability by handling NaN values in audio processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->