### PR TITLE
Autoheal hard coded presets and custom presets

### DIFF
--- a/ledfx/api/presets.py
+++ b/ledfx/api/presets.py
@@ -5,7 +5,7 @@ from aiohttp import web
 
 from ledfx.api import RestEndpoint
 from ledfx.config import save_config
-from ledfx.utils import generate_defaults
+from ledfx.utils import generate_defaults, inject_missing_default_keys
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,6 +53,8 @@ class PresetsEndpoint(RestEndpoint):
             custom = self._ledfx.config["user_presets"][effect_id]
         else:
             custom = {}
+
+        custom = inject_missing_default_keys(custom, default)
 
         response = {
             "status": "success",

--- a/ledfx/api/virtual_presets.py
+++ b/ledfx/api/virtual_presets.py
@@ -5,7 +5,12 @@ from aiohttp import web
 
 from ledfx.api import RestEndpoint
 from ledfx.config import save_config
-from ledfx.utils import generate_default_config, generate_defaults, generate_id, inject_missing_default_keys
+from ledfx.utils import (
+    generate_default_config,
+    generate_defaults,
+    generate_id,
+    inject_missing_default_keys,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/ledfx/api/virtual_presets.py
+++ b/ledfx/api/virtual_presets.py
@@ -5,7 +5,7 @@ from aiohttp import web
 
 from ledfx.api import RestEndpoint
 from ledfx.config import save_config
-from ledfx.utils import generate_default_config, generate_defaults, generate_id
+from ledfx.utils import generate_default_config, generate_defaults, generate_id, inject_missing_default_keys
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,6 +43,8 @@ class VirtualPresetsEndpoint(RestEndpoint):
             custom = self._ledfx.config["user_presets"][effect_id]
         else:
             custom = {}
+
+        custom = inject_missing_default_keys(custom, default)
 
         response = {
             "status": "success",

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -1298,6 +1298,7 @@ def get_font(font_list, size):
 def generate_default_config(ledfx_effects, effect_id):
     return ledfx_effects.get_class(effect_id).get_combined_default_schema()
 
+
 def inject_missing_default_keys(presets, defaults):
     """Inject missing keys from defaults into presets
     This happens when static or user presets are defined and there are
@@ -1314,6 +1315,7 @@ def inject_missing_default_keys(presets, defaults):
             if key not in preset["config"]:
                 preset["config"][key] = value
     return presets
+
 
 def generate_defaults(ledfx_presets, ledfx_effects, effect_id):
     """Generate default presets for an effect.
@@ -1345,4 +1347,3 @@ def generate_defaults(ledfx_presets, ledfx_effects, effect_id):
 
     default.update(presets)
     return default
-

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -1298,6 +1298,22 @@ def get_font(font_list, size):
 def generate_default_config(ledfx_effects, effect_id):
     return ledfx_effects.get_class(effect_id).get_combined_default_schema()
 
+def inject_missing_default_keys(presets, defaults):
+    """Inject missing keys from defaults into presets
+    This happens when static or user presets are defined and there are
+    new keys added to the effect config schema later
+    Args:
+        presets (dict): The current presets.
+        defaults (dict): The current defaults.
+    Returns:
+        dict: The updated presets.
+    """
+    for preset in presets.values():
+        default_preset = defaults["reset"]["config"]
+        for key, value in default_preset.items():
+            if key not in preset["config"]:
+                preset["config"][key] = value
+    return presets
 
 def generate_defaults(ledfx_presets, ledfx_effects, effect_id):
     """Generate default presets for an effect.
@@ -1324,5 +1340,9 @@ def generate_defaults(ledfx_presets, ledfx_effects, effect_id):
             "name": "reset",
         }
     }
+
+    presets = inject_missing_default_keys(presets, default)
+
     default.update(presets)
     return default
+


### PR DESCRIPTION
Use the schema default values to auto heal hard coded presets and user custom presets with default values for missing keys.

Allows rotted presets to highlight blue in UX. No change to default behavior as missing keys would just fall to default in normal flow.

Testing done.

Rotted keybeat presets now seen to highlight blue on selection and exit / enter of effect view if active. Prior they could be selected, but indication that active was missing.

Same for custom preset with missing fields

These presets would otherwise still work as the effect config if selected would inject defaults where keys are missing.

Also code single stepped in debug to validate intent, and see keys indentified and injected as required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced presets handling to ensure default settings are automatically included when custom presets are created or retrieved.
- **Improvements**
	- Updated utility functions to support more robust presets generation and management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->