### PR TITLE
More defensive clone implementation

### DIFF
--- a/ledfx/effects/clone.py
+++ b/ledfx/effects/clone.py
@@ -1,4 +1,5 @@
 import logging
+
 import mss
 import voluptuous as vol
 from PIL import Image

--- a/ledfx/effects/clone.py
+++ b/ledfx/effects/clone.py
@@ -1,6 +1,4 @@
 import logging
-import timeit
-
 import mss
 import voluptuous as vol
 from PIL import Image


### PR DESCRIPTION
Avoid any sniffing into mss.

If we have an except then return to protect the system, and try to create the mss again on the next frame
If we have 5 failure frames in a row give up
If we give up just return every frame. Don't spam debug past the decision to give up
A change to effect config will restart the fail count and clear the giveup flag

Tested for normal runtime behavior
Tested by forcing divide by zero errors in both excepts
Tested for 1 hour + against two endpoints on seperate virtuals through to physical matrix 16x32 and 128x128 on windows
Tested on windows by second user
Main issues are on Mac, but this implementation should be very platform independent whereas old protection was very bad for that!

It is not possible to just recreate the mss object every frame as we get some form of resource exhaustion in some unknown amount of time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability of effect processing by introducing a retry limit upon consecutive failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->