### PR TITLE
Add background mixing option to effects

### DIFF
--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -464,7 +464,7 @@ class Effect(BaseRegistry):
                     if config["background_mixing"] == "additive":
                         pixels += self.bg_color_array
                     elif config["background_mixing"] == "replace":
-                        # We use >= 1 here because we want to replace any pixels that are
+                        # We use >= 2 here because we want to replace any pixels that are
                         # very close to black, but not exactly black, with the background color
                         # This is because the blur effect can leave some pixels that are very
                         # close to black, but not exactly black.

--- a/ledfx/effects/metro.py
+++ b/ledfx/effects/metro.py
@@ -18,7 +18,12 @@ from ledfx.utils import Graph, bokeh_available
 class MetroEffect(AudioReactiveEffect):
     NAME = "Metro"
     CATEGORY = "Diagnostic"
-    HIDDEN_KEYS = ["background_brightness", "blur", "mirror"]
+    HIDDEN_KEYS = [
+        "background_brightness",
+        "blur",
+        "mirror",
+        "background_mixing",
+    ]
     if not bokeh_available:
         HIDDEN_KEYS.append("capture")
 

--- a/ledfx/effects/pixels.py
+++ b/ledfx/effects/pixels.py
@@ -18,7 +18,13 @@ _LOGGER = logging.getLogger(__name__)
 class PixelsEffect(TemporalEffect):
     NAME = "Pixels"
     CATEGORY = "Diagnostic"
-    HIDDEN_KEYS = ["speed", "background_brightness", "blur", "mirror"]
+    HIDDEN_KEYS = [
+        "speed",
+        "background_brightness",
+        "blur",
+        "mirror",
+        "background_mixing",
+    ]
 
     start_time = timeit.default_timer()
 

--- a/ledfx/effects/plasma2d.py
+++ b/ledfx/effects/plasma2d.py
@@ -15,7 +15,11 @@ _LOGGER = logging.getLogger(__name__)
 class Plasma2d(Twod, GradientEffect):
     NAME = "Plasma2d"
     CATEGORY = "Matrix"
-    HIDDEN_KEYS = Twod.HIDDEN_KEYS + ["background_color", "gradient_roll"]
+    HIDDEN_KEYS = Twod.HIDDEN_KEYS + [
+        "background_color",
+        "gradient_roll",
+        "background_mixing",
+    ]
     ADVANCED_KEYS = Twod.ADVANCED_KEYS + []
 
     CONFIG_SCHEMA = vol.Schema(

--- a/ledfx/effects/twod.py
+++ b/ledfx/effects/twod.py
@@ -21,6 +21,7 @@ class Twod(AudioReactiveEffect):
         "test",
         "flip horizontal",
         "flip vertical",
+        "background_mixing",
     ]
 
     CONFIG_SCHEMA = vol.Schema(


### PR DESCRIPTION
This pull request adds a new configuration option called "background_mixing" to the effects. This option allows users to choose how the background color is mixed with the effect pixels. 

The available options are "additive" and "replace".  Default is additive, which is old behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `background_mixing` option to enhance effect configurations.
  
- **Refactor**
  - Refined the handling of `background_color` and `brightness` settings for more consistent effect rendering.
  
- **Style**
  - Improved blur effect application for a smoother visual experience.
  
- **Bug Fixes**
  - Adjusted visibility of the `background_mixing` parameter across various effects to ensure a cleaner user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->