### PR TITLE
virtuals_tools effect copy implementation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -648,7 +648,7 @@ Extensible support for general tools towards a specified virtual
 
 .. rubric:: PUT
 
-Supports tool instances of force_color, calibration, highlight and oneshot others may be added in the future
+Supports tool instances of force_color, calibration, highlight, oneshot and copy, others may be added in the future
 
 **force_color**
 
@@ -792,6 +792,33 @@ The virtual must be active or an error will be returned
         "status": "failed",
         "reason": "virtual falcon1 is not active"
     }
+
+
+**copy**
+
+| Copy the active effect config of <virtual_id> to a list of other virtuals
+
+| target: A list of virtual ids to copy the active effect config to
+
+.. code-block:: json
+
+    {
+        "tool":"copy",
+        "target":["my_virtual1","my_virtual2","my_virtual3"]
+    }
+
+returns
+
+.. code-block:: json
+
+    {
+        "status": "success",
+        "tool": "copy"
+    }
+
+| The virtual must have an active or an error will be returned
+| target must be a list of virtual ids or an error will be returned
+| At least one virtual effect copy must be successful or an error will be returned
 
 /api/effects/<effect_id>/presets
 ===================================

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -66,6 +66,7 @@ Linux
 
     This assumes an apt based system such as ubuntu.
     If your system uses another package manager you should be able use it to get the required packages.
+
 #. Install poetry:
 
    .. code:: console

--- a/docs/directing_audio.rst
+++ b/docs/directing_audio.rst
@@ -113,7 +113,7 @@ Windows have output devices and input devices. LedFx works processing an input d
 
 
 Webaudio
-=======
+========
 .. warning::
 
    This feature is still in alpha.

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -89,9 +89,9 @@ To install on macOS (Apple Silicon) first ensure you have at least Python 3.9 in
 
     .. code:: console
 
-    $ pip uninstall numpy aubio
-    $ pip install numpy --no-cache-dir
-    $ pip install aubio --no-cache-dir
+        $ pip uninstall numpy aubio
+        $ pip install numpy --no-cache-dir
+        $ pip install aubio --no-cache-dir
 
 #. Launch LedFx with the ``open-ui`` option to launch the browser:
 

--- a/ledfx/api/virtual_effects.py
+++ b/ledfx/api/virtual_effects.py
@@ -7,6 +7,7 @@ from aiohttp import web
 
 from ledfx.api import RestEndpoint
 from ledfx.config import save_config
+from ledfx.utils import update_effect_config
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,37 +41,6 @@ class EffectsEndpoint(RestEndpoint):
             effect_response["type"] = virtual.active_effect.type
             response = {"effect": effect_response}
         return await self.bare_request_success(response)
-
-    def update_effect_config(self, virtual_id, effect):
-        """
-        Update the configuration of a virtual effect.
-
-        Args:
-            virtual_id (str): The ID of the virtual effect.
-            effect (Effect): The effect object containing the updated configuration.
-
-        Returns:
-            None
-        """
-        # Store as both the active effect to protect existing code, and one of effects
-        virtual = next(
-            (
-                item
-                for item in self._ledfx.config["virtuals"]
-                if item["id"] == virtual_id
-            ),
-            None,
-        )
-        if virtual:
-            if not ("effects" in virtual):
-                virtual["effects"] = {}
-            virtual["effects"][effect.type] = {}
-            virtual["effects"][effect.type]["type"] = effect.type
-            virtual["effects"][effect.type]["config"] = effect.config
-            if not ("effect" in virtual):
-                virtual["effect"] = {}
-            virtual["effect"]["type"] = effect.type
-            virtual["effect"]["config"] = effect.config
 
     async def put(self, virtual_id, request) -> web.Response:
         """
@@ -180,7 +150,7 @@ class EffectsEndpoint(RestEndpoint):
             _LOGGER.warning(error_message)
             return await self.internal_error("warning", error_message)
 
-        self.update_effect_config(virtual_id, effect)
+        update_effect_config(self._ledfx.config, virtual_id, effect)
 
         save_config(
             config=self._ledfx.config,
@@ -289,7 +259,7 @@ class EffectsEndpoint(RestEndpoint):
             _LOGGER.warning(error_message)
             return await self.internal_error("error", error_message)
 
-        self.update_effect_config(virtual_id, effect)
+        update_effect_config(self._ledfx.config, virtual_id, effect)
 
         save_config(
             config=self._ledfx.config,

--- a/ledfx/api/virtual_effects.py
+++ b/ledfx/api/virtual_effects.py
@@ -7,7 +7,7 @@ from aiohttp import web
 
 from ledfx.api import RestEndpoint
 from ledfx.config import save_config
-from ledfx.utils import update_effect_config
+from ledfx.virtuals import update_effect_config
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/ledfx/api/virtual_presets.py
+++ b/ledfx/api/virtual_presets.py
@@ -10,8 +10,8 @@ from ledfx.utils import (
     generate_defaults,
     generate_id,
     inject_missing_default_keys,
-    update_effect_config,
 )
+from ledfx.virtuals import update_effect_config
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/ledfx/api/virtuals_tools.py
+++ b/ledfx/api/virtuals_tools.py
@@ -125,18 +125,27 @@ class VirtualsToolsEndpoint(RestEndpoint):
         if tool == "copy":
             # copy the config of the specified virtual instance to all virtuals listed in the target payload
             target = data.get("target")
+            # test if target is none or not a list
+
             if target is None:
                 return await self.invalid_request(
                     "Required attribute for copy, target was not provided"
                 )
+            if type(target) is not list:
+                return await self.invalid_request(
+                    "Required attribute for copy, target must be a list"
+                )
             updated = 0
+            if virtual.active_effect is None:
+                return await self.invalid_request(
+                    "Virtual copy failed, no active effect on source virtual"
+                )
+            effect = virtual.active_effect
             for dest_virtual in target:
                 dest_virtual = self._ledfx.virtuals.get(dest_virtual)
                 if dest_virtual is None:
                     continue
-                # only copy the effect type and effect config
-                dest_virtual.config["effect_type"] = virtual.config["effect_type"]
-                dest_virtual.config["effect_config"] = virtual.config["effect_config"]
+                dest_virtual.set_effect(effect)
                 updated += 1
             
             if updated > 0:

--- a/ledfx/api/virtuals_tools.py
+++ b/ledfx/api/virtuals_tools.py
@@ -2,10 +2,10 @@ import logging
 from json import JSONDecodeError
 
 from aiohttp import web
-from ledfx.config import save_config
 
 from ledfx.api import RestEndpoint
 from ledfx.color import parse_color, validate_color
+from ledfx.config import save_config
 from ledfx.utils import update_effect_config
 
 _LOGGER = logging.getLogger(__name__)
@@ -149,26 +149,29 @@ class VirtualsToolsEndpoint(RestEndpoint):
 
                 try:
                     effect = self._ledfx.effects.create(
-                        ledfx=self._ledfx, type=virtual.active_effect.type,
-                        config=virtual.active_effect.config
+                        ledfx=self._ledfx,
+                        type=virtual.active_effect.type,
+                        config=virtual.active_effect.config,
                     )
 
                     dest_virtual.set_effect(effect)
                 except (ValueError, RuntimeError) as msg:
                     continue
 
-                update_effect_config(self._ledfx.config,
-                                     dest_virtual_id,
-                                     effect)
+                update_effect_config(
+                    self._ledfx.config, dest_virtual_id, effect
+                )
                 updated += 1
-            
+
             if updated > 0:
                 save_config(
                     config=self._ledfx.config,
                     config_dir=self._ledfx.config_dir,
                 )
             else:
-                return await self.invalid_request("Virtual copy failed, no valid targets")
+                return await self.invalid_request(
+                    "Virtual copy failed, no valid targets"
+                )
 
         effect_response = {}
         effect_response["tool"] = tool

--- a/ledfx/api/virtuals_tools.py
+++ b/ledfx/api/virtuals_tools.py
@@ -6,7 +6,7 @@ from aiohttp import web
 from ledfx.api import RestEndpoint
 from ledfx.color import parse_color, validate_color
 from ledfx.config import save_config
-from ledfx.utils import update_effect_config
+from ledfx.virtuals import update_effect_config
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -1498,35 +1498,3 @@ class PerformanceAnalysis:
                     f"{percent_faster}%",
                 ]
             )
-
-
-def update_effect_config(config, virtual_id, effect):
-    """
-    Update the configuration of a virtual effect.
-
-    This function is important for maintaining both the active effect and adding
-    to the collection of effects configs on the virtual
-
-    Args:
-        config (dict): The current config structure
-        virtual_id (str): The ID of the virtual effect.
-        effect (Effect): The effect object containing the updated configuration.
-
-    Returns:
-        None
-    """
-    # Store as both the active effect to protect existing code, and one of effects
-    virtual = next(
-        (item for item in config["virtuals"] if item["id"] == virtual_id),
-        None,
-    )
-    if virtual:
-        if not ("effects" in virtual):
-            virtual["effects"] = {}
-        virtual["effects"][effect.type] = {}
-        virtual["effects"][effect.type]["type"] = effect.type
-        virtual["effects"][effect.type]["config"] = effect.config
-        if not ("effect" in virtual):
-            virtual["effect"] = {}
-        virtual["effect"]["type"] = effect.type
-        virtual["effect"]["config"] = effect.config

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -1517,11 +1517,7 @@ def update_effect_config(config, virtual_id, effect):
     """
     # Store as both the active effect to protect existing code, and one of effects
     virtual = next(
-        (
-            item
-            for item in config["virtuals"]
-            if item["id"] == virtual_id
-        ),
+        (item for item in config["virtuals"] if item["id"] == virtual_id),
         None,
     )
     if virtual:

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -1498,3 +1498,39 @@ class PerformanceAnalysis:
                     f"{percent_faster}%",
                 ]
             )
+
+
+def update_effect_config(config, virtual_id, effect):
+    """
+    Update the configuration of a virtual effect.
+
+    This function is important for maintaining both the active effect and adding
+    to the collection of effects configs on the virtual
+
+    Args:
+        config (dict): The current config structure
+        virtual_id (str): The ID of the virtual effect.
+        effect (Effect): The effect object containing the updated configuration.
+
+    Returns:
+        None
+    """
+    # Store as both the active effect to protect existing code, and one of effects
+    virtual = next(
+        (
+            item
+            for item in config["virtuals"]
+            if item["id"] == virtual_id
+        ),
+        None,
+    )
+    if virtual:
+        if not ("effects" in virtual):
+            virtual["effects"] = {}
+        virtual["effects"][effect.type] = {}
+        virtual["effects"][effect.type]["type"] = effect.type
+        virtual["effects"][effect.type]["config"] = effect.config
+        if not ("effect" in virtual):
+            virtual["effect"] = {}
+        virtual["effect"]["type"] = effect.type
+        virtual["effect"]["config"] = effect.config

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -1043,3 +1043,35 @@ class Virtuals:
 
     def get(self, *args):
         return self._virtuals.get(*args)
+
+
+def update_effect_config(config, virtual_id, effect):
+    """
+    Update the configuration of a virtual effect.
+
+    This function is important for maintaining both the active effect and adding
+    to the collection of effects configs on the virtual
+
+    Args:
+        config (dict): The current config structure
+        virtual_id (str): The ID of the virtual effect.
+        effect (Effect): The effect object containing the updated configuration.
+
+    Returns:
+        None
+    """
+    # Store as both the active effect to protect existing code, and one of effects
+    virtual = next(
+        (item for item in config["virtuals"] if item["id"] == virtual_id),
+        None,
+    )
+    if virtual:
+        if not ("effects" in virtual):
+            virtual["effects"] = {}
+        virtual["effects"][effect.type] = {}
+        virtual["effects"][effect.type]["type"] = effect.type
+        virtual["effects"][effect.type]["config"] = effect.config
+        if not ("effect" in virtual):
+            virtual["effect"] = {}
+        virtual["effect"]["type"] = effect.type
+        virtual["effect"]["config"] = effect.config


### PR DESCRIPTION
Docs updated, see copy under 

https://ledfx--638.org.readthedocs.build/en/638/api.html#api-virtuals-tools-virtual-id

Tested via postman for virtual copy to 4 other virtuals, with various original configurations
Transitions are good, so confirmed we are setting at the right level
Ensured that effects list is updated

Fixed some pre existing docs errors / warnings

Refactored code that updates the overall config with an activated effect and stores that effect in the virtuals effects list storage, as it was already in two places ( from me prior ) and I was adding a third, so time to put that in utils

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced "copy" tool for duplicating effect configurations across virtual instances.

- **Documentation**
	- Updated API documentation to reflect the new "copy" tool functionality.
	- Revised developer installation instructions with alternative package manager options.
	- Modified audio direction documentation, including a warning for the alpha stage "Webaudio" feature.
	- Improved code block formatting in installation guide.

- **Bug Fixes**
	- Streamlined effect configuration updates by centralizing the logic in a utility function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->