### PR TITLE
Rainbow x3 speed again

### DIFF
--- a/ledfx/color.py
+++ b/ledfx/color.py
@@ -2,6 +2,7 @@ import logging
 from collections import namedtuple
 
 import numpy as np
+from numpy.typing import NDArray
 from PIL import ImageColor
 
 _LOGGER = logging.getLogger(__name__)
@@ -70,54 +71,48 @@ class Gradient:
         self.angle = angle
 
 
-def hsv_to_rgb(h, s, v):
+def hsv_to_rgb(hue: NDArray, saturation: float, value: float) -> NDArray:
     """
-    Converts an array of HSV (Hue, Saturation, Value) values to RGB (Red, Green, Blue).
-
-    This function implements the algorithm for converting color representations from
-    HSV to RGB. It is designed to work on arrays of HSV values, efficiently converting
-    them to their RGB counterparts.
+    Converts an array of Hues using provided saturation and value properties to an RGB array.
 
     Args:
-        h (numpy.ndarray): Array of hue values (0 to 1).
-        s (numpy.ndarray): Array of saturation values (0 to 1).
-        v (numpy.ndarray): Array of value/brightness values (0 to 1).
+        hue (numpy.ndarray): Array of hue values (0 to 1).
+        saturation (float between 0 and 1): The saturation ("brightness") of the color.
+        value (float between 0 and 1): The value ("colorfulness") of the color.
 
     Returns:
         numpy.ndarray: An array of RGB values where each RGB value is in the range
                        0 to 255.
 
-    Note:
-        The function assumes that h, s, and v are numpy arrays of the same shape.
     """
 
     # The hue value is scaled by 6 to map it to one of the six sections of the
     # RGB color wheel.
-    h_i = h * 6
+    hue_i = hue * 6
 
     # The integer part of h_i determines the section of the color wheel the hue
     # belongs to.
-    i = np.floor(h_i).astype(int)
+    i = np.floor(hue_i).astype(int)
 
     # The fractional part of h_i.
-    f = h_i - i
+    f = hue_i - i
 
     # Intermediate values for the RGB conversion process.
-    p = v * (1 - s)
-    q = v * (1 - s * f)
-    t = v * (1 - s * (1 - f))
+    p = value * (1 - saturation)
+    q = value * (1 - saturation * f)
+    t = value * (1 - saturation * (1 - f))
 
     # Ensure that i values are within the range [0, 5].
     i = i % 6
 
     # Preparing an array for RGB values.
-    rgb = np.zeros((h.shape[0], 3))
+    rgb = np.zeros((hue.shape[0], 3))
 
     # Assigning the red, green, and blue components based on the section of the
     # color wheel. 'np.choose' is used to efficiently select values for each pixel.
-    rgb[:, 0] = np.choose(i, [v, q, p, p, t, v], mode="wrap")
-    rgb[:, 1] = np.choose(i, [t, v, v, q, p, p], mode="wrap")
-    rgb[:, 2] = np.choose(i, [p, p, t, v, v, q], mode="wrap")
+    rgb[:, 0] = np.choose(i, [value, q, p, p, t, value], mode="wrap")
+    rgb[:, 1] = np.choose(i, [t, value, value, q, p, p], mode="wrap")
+    rgb[:, 2] = np.choose(i, [p, p, t, value, value, q], mode="wrap")
 
     # Scale the RGB values to the 0-255 range
     return rgb * 255

--- a/ledfx/color.py
+++ b/ledfx/color.py
@@ -69,80 +69,57 @@ class Gradient:
         self.mode = mode
         self.angle = angle
 
-
-def hsv_to_rgb(hsv):
+def hsv_to_rgb(h, s, v):
     """
-    Vectorized conversion of an entire pixel array from hsv colorspace to rgb colorspace.
-    Approx 3x faster than using colorsys.hsv_to_rgb on a single pixel, and performance improvement is exponential with the number of pixels.
+    Converts an array of HSV (Hue, Saturation, Value) values to RGB (Red, Green, Blue).
 
-    Algorithm from https://en.wikipedia.org/wiki/HSL_and_HSV#HSV_to_RGB
+    This function implements the algorithm for converting color representations from
+    HSV to RGB. It is designed to work on arrays of HSV values, efficiently converting
+    them to their RGB counterparts.
 
-    Parameters:
-    - hsv: numpy array of shape (n, 3) representing the HSV values of pixels
+    Args:
+        h (numpy.ndarray): Array of hue values (0 to 1).
+        s (numpy.ndarray): Array of saturation values (0 to 1).
+        v (numpy.ndarray): Array of value/brightness values (0 to 1).
 
     Returns:
-    - rgb: numpy array of shape (n, 3) representing the RGB values of pixels
+        numpy.ndarray: An array of RGB values where each RGB value is in the range
+                       0 to 255.
+
+    Note:
+        The function assumes that h, s, and v are numpy arrays of the same shape.
     """
-    # Extract the hue, saturation, and value components from the HSV color space
-    hue, saturation, value = hsv[:, 0], hsv[:, 1], hsv[:, 2]
 
-    # Compute the chroma, which is the colorfulness relative to the brightness of another color that appears white under similar viewing conditions
-    chroma = value * saturation
+    # The hue value is scaled by 6 to map it to one of the six sections of the
+    # RGB color wheel.
+    h_i = h * 6
 
-    # Multiply the hue by 6 to map it to a sector number, as per the HSV to RGB conversion algorithm
-    # These six hue sectors represent the six transitions between primary and secondary colors on the color wheel
-    # The hue value is an angle between 0 and 360 degrees, so we need to multiply it by 6 to map it to a sector number
-    hue *= 6
+    # The integer part of h_i determines the section of the color wheel the hue
+    # belongs to.
+    i = np.floor(h_i).astype(int)
 
-    # Compute the intermediate value used in the RGB conversion
-    intermediate_value = chroma * (1 - np.abs(hue % 2 - 1))
+    # The fractional part of h_i.
+    f = h_i - i
 
-    # Initialize the RGB values array with zeros, having the same shape as the HSV input
-    rgb_values = np.zeros(hsv.shape)
+    # Intermediate values for the RGB conversion process.
+    p = v * (1 - s)
+    q = v * (1 - s * f)
+    t = v * (1 - s * (1 - f))
 
-    # For each sector of the hue, calculate the corresponding RGB values
-    # The RGB conversion algorithm is different for each sector of the hue
+    # Ensure that i values are within the range [0, 5].
+    i = i % 6
 
-    # Sector 0 to 1 (red to yellow)
-    mask = (0 <= hue) & (hue <= 1)
-    rgb_values[mask, 0] = chroma[mask]  # Red is dominant
-    rgb_values[mask, 1] = intermediate_value[mask]  # Green is increasing
+    # Preparing an array for RGB values.
+    rgb = np.zeros((h.shape[0], 3))
 
-    # Sector 1 to 2 (yellow to green)
-    mask = (1 < hue) & (hue <= 2)
-    rgb_values[mask, 0] = intermediate_value[mask]  # Red is decreasing
-    rgb_values[mask, 1] = chroma[mask]  # Green is dominant
+    # Assigning the red, green, and blue components based on the section of the
+    # color wheel. 'np.choose' is used to efficiently select values for each pixel.
+    rgb[:, 0] = np.choose(i, [v, q, p, p, t, v], mode='wrap')
+    rgb[:, 1] = np.choose(i, [t, v, v, q, p, p], mode='wrap')
+    rgb[:, 2] = np.choose(i, [p, p, t, v, v, q], mode='wrap')
 
-    # Sector 2 to 3 (green to cyan)
-    mask = (2 < hue) & (hue <= 3)
-    rgb_values[mask, 1] = chroma[mask]  # Green is dominant
-    rgb_values[mask, 2] = intermediate_value[mask]  # Blue is increasing
-
-    # Sector 3 to 4 (cyan to blue)
-    mask = (3 < hue) & (hue <= 4)
-    rgb_values[mask, 1] = intermediate_value[mask]  # Green is decreasing
-    rgb_values[mask, 2] = chroma[mask]  # Blue is dominant
-
-    # Sector 4 to 5 (blue to magenta)
-    mask = (4 < hue) & (hue <= 5)
-    rgb_values[mask, 0] = intermediate_value[mask]  # Red is increasing
-    rgb_values[mask, 2] = chroma[mask]  # Blue is dominant
-
-    # Sector 5 to 6 (magenta to red)
-    mask = (5 < hue) & (hue <= 6)
-    rgb_values[mask, 0] = chroma[mask]  # Red is dominant
-    rgb_values[mask, 2] = intermediate_value[mask]  # Blue is decreasing
-
-    # Compute the match value to match the RGB values with the original value
-    match_value = value - chroma
-
-    # Add the match value to each RGB component to align it with the original value
-    rgb_values[:, 0] += match_value
-    rgb_values[:, 1] += match_value
-    rgb_values[:, 2] += match_value
-
-    # Return the RGB values, scaled to the range 0-255 as per the standard RGB color space
-    return rgb_values * 255
+    # Scale the RGB values to the 0-255 range
+    return rgb * 255
 
 
 def parse_color(color: (str, list, tuple)) -> RGB:

--- a/ledfx/color.py
+++ b/ledfx/color.py
@@ -69,6 +69,7 @@ class Gradient:
         self.mode = mode
         self.angle = angle
 
+
 def hsv_to_rgb(h, s, v):
     """
     Converts an array of HSV (Hue, Saturation, Value) values to RGB (Red, Green, Blue).
@@ -114,9 +115,9 @@ def hsv_to_rgb(h, s, v):
 
     # Assigning the red, green, and blue components based on the section of the
     # color wheel. 'np.choose' is used to efficiently select values for each pixel.
-    rgb[:, 0] = np.choose(i, [v, q, p, p, t, v], mode='wrap')
-    rgb[:, 1] = np.choose(i, [t, v, v, q, p, p], mode='wrap')
-    rgb[:, 2] = np.choose(i, [p, p, t, v, v, q], mode='wrap')
+    rgb[:, 0] = np.choose(i, [v, q, p, p, t, v], mode="wrap")
+    rgb[:, 1] = np.choose(i, [t, v, v, q, p, p], mode="wrap")
+    rgb[:, 2] = np.choose(i, [p, p, t, v, v, q], mode="wrap")
 
     # Scale the RGB values to the 0-255 range
     return rgb * 255

--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -87,24 +87,15 @@ def fill_rainbow(pixels, initial_hue, delta_hue):
     sat = 0.95
     val = 1.0
 
-    # Create a range of initial hues for each pixel
-    initial_hues = np.linspace(
-        initial_hue, initial_hue + delta_hue * (len(pixels) - 1), len(pixels)
-    )
+    # Create an array of hue values starting from 'initial_hue' and increasing
+    # by 'delta_hue' for each pixel. The array length is initially set to be longer
+    # than the number of pixels.
+    hues = np.arange(initial_hue, initial_hue + len(pixels) * delta_hue, delta_hue)
 
-    # Add delta_hue to the initial hues for each pixel and wrap around any values that exceed 1.0
-    hues = (initial_hues + delta_hue) % 1.0
+    # ensure each pixel has a corresponding hue value.
+    hues = hues[: len(pixels)]
 
-    # Create 2D arrays for saturation and value
-    saturation = np.full_like(hues, sat)
-    value = np.full_like(hues, val)
-
-    # Stack the hues, saturation, and value arrays along the second axis
-    hsv_array = np.stack((hues, saturation, value), axis=-1)
-
-    # Convert the HSV array to RGB and return it
-    return hsv_to_rgb(hsv_array)
-
+    return hsv_to_rgb(hues, sat, val)
 
 def blur_pixels(pixels, sigma):
     """

--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -90,12 +90,15 @@ def fill_rainbow(pixels, initial_hue, delta_hue):
     # Create an array of hue values starting from 'initial_hue' and increasing
     # by 'delta_hue' for each pixel. The array length is initially set to be longer
     # than the number of pixels.
-    hues = np.arange(initial_hue, initial_hue + len(pixels) * delta_hue, delta_hue)
+    hues = np.arange(
+        initial_hue, initial_hue + len(pixels) * delta_hue, delta_hue
+    )
 
     # ensure each pixel has a corresponding hue value.
     hues = hues[: len(pixels)]
 
     return hsv_to_rgb(hues, sat, val)
+
 
 def blur_pixels(pixels, sigma):
     """

--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -6,6 +6,7 @@ from functools import lru_cache
 
 import numpy as np
 import voluptuous as vol
+from numpy.typing import NDArray
 
 from ledfx.color import hsv_to_rgb, parse_color, validate_color
 from ledfx.utils import BaseRegistry, RegistryLoader
@@ -46,7 +47,7 @@ class DummyEffect:
         pass
 
 
-def mix_colors(color_1, color_2, ratio):
+def mix_colors(color_1: tuple, color_2: tuple, ratio: float) -> tuple:
     """
     Mixes two colors based on a given ratio.
 
@@ -72,7 +73,9 @@ def mix_colors(color_1, color_2, ratio):
         )
 
 
-def fill_rainbow(pixels, initial_hue, delta_hue):
+def fill_rainbow(
+    pixels: NDArray, initial_hue: float, delta_hue: float
+) -> NDArray:
     """
     Fills the given pixels with a rainbow effect.
 
@@ -100,7 +103,7 @@ def fill_rainbow(pixels, initial_hue, delta_hue):
     return hsv_to_rgb(hues, sat, val)
 
 
-def blur_pixels(pixels, sigma):
+def blur_pixels(pixels: NDArray, sigma: float) -> NDArray:
     """
     Applies a blur effect to the given pixels.
 
@@ -119,7 +122,7 @@ def blur_pixels(pixels, sigma):
 
 
 @lru_cache(maxsize=1024)
-def _gaussian_kernel1d(sigma, order, array_len):
+def _gaussian_kernel1d(sigma: float, order: int, array_len: int) -> NDArray:
     """
     Produces a 1D Gaussian or Gaussian-derivative filter kernel as a numpy array.
 
@@ -164,7 +167,7 @@ def _gaussian_kernel1d(sigma, order, array_len):
     return phi_x
 
 
-def fast_blur_pixels(pixels, sigma):
+def fast_blur_pixels(pixels: NDArray, sigma: float) -> NDArray:
     """
     Applies a fast blur effect to the given pixels using a Gaussian kernel.
 
@@ -187,7 +190,7 @@ def fast_blur_pixels(pixels, sigma):
     return pixels
 
 
-def fast_blur_array(array, sigma):
+def fast_blur_array(array: NDArray, sigma: float) -> NDArray:
     """
     Apply fast Gaussian blur to a 1-dimensional array.
 

--- a/ledfx/effects/rainbow.py
+++ b/ledfx/effects/rainbow.py
@@ -11,10 +11,15 @@ class RainbowEffect(TemporalEffect):
     CONFIG_SCHEMA = vol.Schema(
         {
             vol.Optional(
+                "speed",
+                description="Speed of the effect",
+                default=1.0,
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.1, max=20)),
+            vol.Optional(
                 "frequency",
                 description="Frequency of the effect curve",
                 default=1.0,
-            ): vol.All(vol.Coerce(float), vol.Range(min=0.1, max=10)),
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.1, max=64)),
         }
     )
 


### PR DESCRIPTION
Tortured chatgpt to refactor against original rainbow implementation

updated to reflect the new function home in color.py

Render time per frame performance on 16K physical panel has been seen to drop across generations from aprrox

10 milli sec -> 1,5 milli sec -> 500 micro sec

So ~20x

Tested with multiple rainbow running across matrix 128x128, 32x16 and 1d at  356, 506, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the color conversion efficiency from HSV to RGB.
	- Simplified the rainbow effect generation for better performance and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->