### PR TITLE
Update schema validator to reject "colour" as a schema key

### DIFF
--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -797,12 +797,14 @@ class BaseRegistry(ABC):
                 if not is_snake_case(actual_key):
                     # Raise an error if the key is not snake_case - this is to prevent
                     # development of new effects/devices that have keys that are not snake_case
-                    _LOGGER.critical(
-                        f"Invalid key '{actual_key}' in {self.__name__}. Keys must use snake_case."
-                    )
-                    raise ValueError(
-                        f"Invalid key '{actual_key}' in {self.__name__}. Keys must use snake_case."
-                    )
+                    error_msg = f"Invalid key '{actual_key}' in {self.__name__}. Keys must use snake_case."
+                    _LOGGER.critical(error_msg)
+                    raise ValueError(error_msg)
+                # We search if the key contains the word "colour" and raise an error if it does, since we want to standardise on color
+                if "colour" in actual_key:
+                    error_msg = f"Invalid key '{actual_key}' in {self.__name__}. Keys must use 'color' instead of 'colour'."
+                    _LOGGER.critical(error_msg)
+                    raise ValueError(error_msg)
 
         return schema
 

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -782,7 +782,21 @@ class BaseRegistry(ABC):
                     schema = schema.extend(c_schema.fget().schema)
                 else:
                     schema = schema.extend(c_schema.schema)
+        self.validate_schema_keys(schema)
 
+        return schema
+
+    @classmethod
+    def validate_schema_keys(self, schema):
+        """
+        Validates the keys in the given schema.
+
+        Args:
+            schema (vol.Schema): The schema to validate.
+
+        Raises:
+            ValueError: If any key in the schema do not match our naming conventions.
+        """
         # Check if all keys in the schema use snake_case
         for key in schema.schema.keys():
             # If key is a vol.Required or vol.Optional, get the schema from the key
@@ -805,8 +819,6 @@ class BaseRegistry(ABC):
                     error_msg = f"Invalid key '{actual_key}' in {self.__name__}. Keys must use 'color' instead of 'colour'."
                     _LOGGER.critical(error_msg)
                     raise ValueError(error_msg)
-
-        return schema
 
     @classmethod
     def registry(self):


### PR DESCRIPTION
This pull request updates the schema validator to reject the use of "colour" as a schema key. Instead, the key "color" should be used to maintain consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced key naming convention checks within settings to enforce snake_case and standardize the term "color."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->