### PR TITLE
Fix glitch on gif first frame resize

### DIFF
--- a/ledfx/effects/keybeat2d.py
+++ b/ledfx/effects/keybeat2d.py
@@ -146,7 +146,7 @@ class Keybeat2d(Twod, GifBase):
             self.orig_frames = []
 
             for frame in iterator:
-                self.orig_frames.append(frame.copy())
+                self.orig_frames.append(frame.copy().convert("RGB"))
             self.gif.close()
 
         self.last_gif = self.image_location

--- a/ledfx/effects/keybeat2d.py
+++ b/ledfx/effects/keybeat2d.py
@@ -146,7 +146,7 @@ class Keybeat2d(Twod, GifBase):
             self.orig_frames = []
 
             for frame in iterator:
-                self.orig_frames.append(frame.copy().convert("RGB"))
+                self.orig_frames.append(frame.convert("RGB"))
             self.gif.close()
 
         self.last_gif = self.image_location


### PR DESCRIPTION
First extracted frame from a GIF is always coming in as P

following frames are defaulted to RGB

Pillow will only use nearest on P for resize

Force ALL frames to RGB on extraction

Now resize method will be obeyed

Tested glitch is gone on gif that was easy to see impact
Tested all other presets still work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the handling of frame data in the Keybeat2D effect to ensure proper configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->