### PR TITLE
Add breadcrumb suppression mechanic for sentry

### DIFF
--- a/ledfx/sentry_config.py
+++ b/ledfx/sentry_config.py
@@ -1,11 +1,11 @@
 import logging
 import os
 import sys
+from contextlib import contextmanager
 
 import sentry_sdk
 from dotenv import load_dotenv
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
-from contextlib import contextmanager
 
 from ledfx.consts import PROJECT_VERSION
 from ledfx.utils import currently_frozen
@@ -29,9 +29,9 @@ def suppress_sentry_breadcrumb():
 
     # Set a flag in the current scope
     with sentry_sdk.configure_scope() as scope:
-        scope.set_tag('suppress_breadcrumb', True)
+        scope.set_tag("suppress_breadcrumb", True)
         yield
-        scope.remove_tag('suppress_breadcrumb')
+        scope.remove_tag("suppress_breadcrumb")
 
 
 def before_breadcrumb(crumb, hint):
@@ -43,7 +43,9 @@ def before_breadcrumb(crumb, hint):
     """
 
     # Check if the breadcrumb should be suppressed
-    if crumb['category'] == 'http' and sentry_sdk.get_current_scope().tags.get('suppress_breadcrumb'):
+    if crumb["category"] == "http" and sentry_sdk.get_current_scope().tags.get(
+        "suppress_breadcrumb"
+    ):
         return None  # Skip this breadcrumb
 
     return crumb


### PR DESCRIPTION
THIS HYPOTHESIS WAS INCORRECT, sentry does not send breadcrumbs for the TCP control of Nanoleaf, I was mistaking the diagnostic for HTTP send for nanoleaf with -vv option as sentry packets

This is being added specifically for nanolead http send breadcrumb suppression

Presently if sentry is active with http traffic breadcrumbs ( as per in dev mode ) we are spamming sentry with the breadcrumb for the frame data send at FPS rate

Once this is tested, we can go look at any other device that is using TCP / HTTP at the frame level

NEEDS TESTING. Will be placed in draft


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for Nanoleaf devices to prevent reporting of non-critical issues.
- **Refactor**
	- Enhanced Sentry integration for better filtering and management of error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->