### PR TITLE
Restore default server:port behavior in find_openrgb api

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -222,21 +222,30 @@ if no device is found will return an error
         "error": "Failed to find launchpad"
     }
 
-/api/find_openrgb/?server=1.2.3.4&port=5678
+/api/find_openrgb
 ===========================================
-
-.. rubric:: GET
-
-Optional Query parameters are supported as follows:
-
-'**server**' (optional): IP address of openRGB server, a default value of loacl host will be used
-'**port**' (optional): Port to be used for openRGB server. a default value of 6742 will be used
-
-In most cases these do not need to be defined as defaults of localhost and 6742 are used
 
 Returns all found openRGB devices registered with the openRGB server
 
-example:
+.. rubric:: GET
+
+The GET call uses default values of 127.0.0.1:6742 for the openRGB server
+
+.. rubric:: POST
+
+JSON parameters are supported as follows:
+
+| '**server**' (optional): IP address of openRGB server, a default value of 127.0.0.1 will be used
+| '**port**' (optional): Port to be used for openRGB server, a default value of 6742 will be used
+
+.. code-block:: json
+
+    {
+      "server": "1.2.3.4",
+      "port": 1234
+    }
+
+example reponse:
 
 .. code-block:: json
 

--- a/ledfx/api/__init__.py
+++ b/ledfx/api/__init__.py
@@ -8,6 +8,8 @@ from ledfx.utils import BaseRegistry, RegistryLoader
 
 _LOGGER = logging.getLogger(__name__)
 
+SNACKBAR_OPTIONS = ["success", "info", "warning", "error"]
+
 
 @BaseRegistry.no_registration
 class RestEndpoint(BaseRegistry):
@@ -73,6 +75,10 @@ class RestEndpoint(BaseRegistry):
         Returns:
             A web response with a JSON payload containing the error and a 500 status.
         """
+        if type not in SNACKBAR_OPTIONS:
+            raise ValueError(
+                "Snackbar type must be one of 'success', 'info', 'warning', 'error'."
+            )
         response = {
             "status": "failed",
             "payload": {"type": type, "reason": message},
@@ -87,12 +93,16 @@ class RestEndpoint(BaseRegistry):
 
         Args:
             reason (str): The reason for the invalid request. Defaults to 'Invalid request'.
-            type (str): The type of error. Defaults to 'error'. Options 'default','error', 'success', 'warning','info'.
+            type (str): The type of error. Defaults to 'error'.
             resp_code (int): The response code to be returned. Defaults to 200 so that snackbar works.
 
         Returns:
             web.Response: A JSON response with the status and reason for the invalid request.
         """
+        if type not in SNACKBAR_OPTIONS:
+            raise ValueError(
+                "Snackbar type must be one of 'success', 'info', 'warning', 'error'."
+            )
         response = {
             "status": "failed",
             "payload": {
@@ -121,6 +131,10 @@ class RestEndpoint(BaseRegistry):
             "status": "success",
         }
         if type and message is not None:
+            if type not in SNACKBAR_OPTIONS:
+                raise ValueError(
+                    "Snackbar type must be one of 'success', 'info', 'warning', 'error'"
+                )
             response["payload"] = {
                 "type": type,
                 "reason": message,
@@ -140,7 +154,7 @@ class RestEndpoint(BaseRegistry):
         """
         if payload is None:
             raise ValueError(
-                "Payload must be provided to the bare request_success method"
+                "Payload must be provided to the bare request_success method."
             )
         return web.json_response(data=payload, status=200)
 

--- a/ledfx/api/find_openrgb.py
+++ b/ledfx/api/find_openrgb.py
@@ -28,29 +28,24 @@ class FindOpenRGBDevicesEndpoint(RestEndpoint):
         try:
             data = await request.json()
         except JSONDecodeError:
-            return await self.json_decode_error()
+            data = {}
 
-        if "server" in data.keys():
-            server = data["server"]
-        else:
-            server = "127.0.0.1"
+        server = data.get("server", "127.0.0.1")
+        port = data.get("port", "6742")
 
-        if "port" in data.keys():
-            try:
-                port = int(data["port"])
-            except ValueError:
-                error_message = f"Unable to convert {data['port']} to int."
-                _LOGGER.warning(error_message)
-                return await self.invalid_request(error_message)
-        else:
-            port = 6742
+        try:
+            port = int(port)
+        except ValueError:
+            error_message = f"Unable to convert {port} to int."
+            _LOGGER.warning(error_message)
+            return await self.invalid_request(error_message)
 
         try:
             client = OpenRGBClient(address=server, port=port)
         except Exception as e:
             _LOGGER.error(f"Failed to connect to OpenRGB server: {e}")
             return await self.request_success(
-                "info", "No OpenRGB server found at {server}:{port}"
+                "info", f"No OpenRGB server found at {server}:{port}"
             )
 
         devices = []

--- a/ledfx/api/find_openrgb.py
+++ b/ledfx/api/find_openrgb.py
@@ -10,24 +10,61 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class FindOpenRGBDevicesEndpoint(RestEndpoint):
-    """REST end-point for detecting and reporting OpenRGB devices
-    optional params for server and port"""
+    """
+    REST end-point for detecting and reporting OpenRGB devices.
+    """
 
     ENDPOINT_PATH = "/api/find_openrgb"
 
-    async def get(self, request: web.Request) -> web.Response:
+    async def get(self) -> web.Response:
         """
-        Check for an openRGB server and report devices
+        Check for an OpenRGB server at localhost on the default port and report devices if found.
+
+        Returns:
+            web.Response: The HTTP response object containing either an error, or a dict of OpenRGB devices at localhost:6742.
+        """
+
+        try:
+            client = OpenRGBClient(address="127.0.0.1", port=6742)
+        except Exception as e:
+            error_message = (
+                f"Unable to connect to OpenRGB server at localhost:6742, {e}."
+            )
+            _LOGGER.error(error_message)
+            return await self.request_success(
+                "warning",
+                error_message,
+            )
+
+        devices = []
+        for device in client.devices:
+            devices.append(
+                {
+                    "name": device.name,
+                    "type": device.type,
+                    "id": device.id,
+                    "leds": len(device.leds),
+                }
+            )
+        response = {"status": "success", "devices": devices}
+        return await self.bare_request_success(response)
+
+    async def post(self, request: web.Request) -> web.Response:
+        """
+        Check for an OpenRGB server at and report devices if found.
 
         Args:
             request (web.Request): The incoming request object that contains the `server` (str) and `port` (str or int). Defaults to 127.0.0.1 and 6742 if not provided.
 
         Returns:
-            web.Response: The HTTP response object.
+            web.Response: The HTTP response object containing either an error, or a dict of OpenRGB devices on the given server.
         """
         try:
             data = await request.json()
         except JSONDecodeError:
+            _LOGGER.warning(
+                "Unable to decode JSON from OpenRGB request, using default localhost:6742."
+            )
             data = {}
 
         server = data.get("server", "127.0.0.1")
@@ -43,11 +80,14 @@ class FindOpenRGBDevicesEndpoint(RestEndpoint):
         try:
             client = OpenRGBClient(address=server, port=port)
         except Exception as e:
-            _LOGGER.error(f"Failed to connect to OpenRGB server: {e}")
-            return await self.request_success(
-                "info", f"No OpenRGB server found at {server}:{port}"
+            error_message = (
+                f"Unable to connect to OpenRGB server at {server}:{port}, {e}."
             )
-
+            _LOGGER.error(error_message)
+            return await self.request_success(
+                "warning",
+                error_message,
+            )
         devices = []
         for device in client.devices:
             devices.append(


### PR DESCRIPTION
Refactored to GET and POST versions

https://ledfx--661.org.readthedocs.build/en/661/api.html#api-find-openrgb

Fix missing f-string on error

Seen by user after trying to use the bare api call to test openrgb server access

http://localhost:8888/api/find_openrgb

Should default to 127.0.0.1:6742

Tested against running openRGB server with postman for both GET and POST versions

This was a regression from 

https://github.com/LedFx/LedFx/commit/451e2cb5a9166bbefe8d42550217898b8ed45ec9#diff-c1980e608a5c75d824465c069eb626a300143e236a96f8d7a32362c58ef05dd1R28



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a list of options for snack bar types.
	- Modified the `get` method in the `FindOpenRGBDevicesEndpoint` class to handle server and port data.
	- Updated the `/api/find_openrgb` endpoint to use default values for openRGB server and port, and updated optional query parameters.
	- Added a response example to the documentation for the `/api/find_openrgb` endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->