### PR TITLE
Refactor audio_devices.py to use bare_request_success() method

### DIFF
--- a/ledfx/api/audio_devices.py
+++ b/ledfx/api/audio_devices.py
@@ -33,7 +33,7 @@ class AudioDevicesEndpoint(RestEndpoint):
         response[
             "devices"
         ] = AudioInputSource.input_devices()  # dict(enumerate(input_devices))
-        return await self.request_success(response)
+        return await self.bare_request_success(response)
 
     async def put(self, request: web.Request) -> web.Response:
         """


### PR DESCRIPTION
This pull request refactors the audio_devices.py file to use the bare_request_success() method instead of the request_success() method.

The audio devices were not part of the response when using the request_success method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Modified the response handling for audio device queries to enhance API efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->