### PR TITLE
add brightness image adjustment for keybeat

### DIFF
--- a/ledfx/effects/keybeat2d.py
+++ b/ledfx/effects/keybeat2d.py
@@ -1,8 +1,8 @@
 import logging
 import os
 
-import PIL.ImageSequence as ImageSequence
 import PIL.ImageEnhance as ImageEnhance
+import PIL.ImageSequence as ImageSequence
 import voluptuous as vol
 
 from ledfx.consts import LEDFX_ASSETS_PATH
@@ -189,7 +189,8 @@ class Keybeat2d(Twod, GifBase):
         self.post_frames = [img for img in self.post_frames if img is not None]
         self.post_frames = [
             ImageEnhance.Brightness(frame).enhance(
-                self._config["image_brightness"])
+                self._config["image_brightness"]
+            )
             for frame in self.post_frames
         ]
 

--- a/ledfx/effects/keybeat2d.py
+++ b/ledfx/effects/keybeat2d.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 import PIL.ImageSequence as ImageSequence
+import PIL.ImageEnhance as ImageEnhance
 import voluptuous as vol
 
 from ledfx.consts import LEDFX_ASSETS_PATH
@@ -28,6 +29,7 @@ class Keybeat2d(Twod, GifBase):
         "fake_beat",
         "pp_skip",
         "resize_method",
+        "image_brightness",
     ]
 
     CONFIG_SCHEMA = vol.Schema(
@@ -102,6 +104,11 @@ class Keybeat2d(Twod, GifBase):
                 description="half the beat input impulse, slow things down",
                 default=False,
             ): bool,
+            vol.Optional(
+                "image_brightness",
+                description="Image brightness",
+                default=1.0,
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.1, max=3.0)),
         }
     )
 
@@ -180,6 +187,11 @@ class Keybeat2d(Twod, GifBase):
 
         # strip out None frames
         self.post_frames = [img for img in self.post_frames if img is not None]
+        self.post_frames = [
+            ImageEnhance.Brightness(frame).enhance(
+                self._config["image_brightness"])
+            for frame in self.post_frames
+        ]
 
         if self.diag:
             _LOGGER.info(


### PR DESCRIPTION
slider from 0.1 to 3

Defaults to 1.0 which = no adjustment

Very useful on video gif images to boost them up

Tried color balance, contrast and sharpness, but not worth the clutter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `image_brightness` parameter for effects, enhancing image brightness customization with a range from 0.1 to 3.0.
- **Enhancements**
	- Improved image processing with brightness adjustments to offer more dynamic visual effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->