### PR TITLE
Update publish-release-pypi.yml workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y \
-          gcc libatlas3-base portaudio19-dev libsamplerate-dev
+          gcc libatlas3-base portaudio19-dev
       - name: Setup Python ${{ matrix.python }}
         id: python
         uses: actions/setup-python@v5

--- a/.github/workflows/publish-release-pypi.yml
+++ b/.github/workflows/publish-release-pypi.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           ledfx --ci-smoke-test -vv
   publish:
-    name: Publish Python distributions to PyPI
+    name: Publish
     needs: [install-from-wheel, install-from-sdist]
     runs-on: ubuntu-latest
     steps:
@@ -93,32 +93,23 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: LedFx-wheel
+          path: dist/
       - name: Get the source tarball from the previous job
         uses: actions/download-artifact@v4
         with:
           name: LedFx-sdist
-      - name: Move the wheel and source tarball to the root directory
-        run: |
-          mv ledfx-*.whl /dist/ledfx-*.whl
-          mv ledfx-*.tar.gz /dist/ledfx-*.tar.gz
-      - name: Publish distribution to Test PyPI
+          path: dist/
+      - name: Publish to Test PyPI
         if: github.event_name == 'workflow_dispatch'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TEST_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
-      - name: Publish distribution to PyPI
+
+      - name: Publish to PyPI
         if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-      # - name: Trigger HomeAssistant Add-on
-      #   uses: benc-uk/workflow-dispatch@v1
-      #   with:
-      #     workflow: Builder
-      #     repo: YeonV/home-assistant-addons
-      #     ref: refs/heads/master
-      #     token: ${{ secrets.LEDFX_HOMEASSISTANT_ADDON }}
-      #     inputs: '{ "version": "${{ github.ref_name }}" }'

--- a/.github/workflows/publish-release-pypi.yml
+++ b/.github/workflows/publish-release-pypi.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-test-wheel-and-sdist]
     steps:
-      - name: Get the wheel from the previous job
+      - name: Get the wheel
         uses: actions/download-artifact@v4
         with:
           name: LedFx-wheel
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-test-wheel-and-sdist]
     steps:
-      - name: Get the wheel from the previous job
+      - name: Get the sdist
         uses: actions/download-artifact@v4
         with:
           name: LedFx-sdist
@@ -89,12 +89,12 @@ jobs:
     needs: [install-from-wheel, install-from-sdist]
     runs-on: ubuntu-latest
     steps:
-      - name: Get the wheel from the previous job
+      - name: Get the wheel
         uses: actions/download-artifact@v4
         with:
           name: LedFx-wheel
           path: dist/
-      - name: Get the source tarball from the previous job
+      - name: Get the sdist
         uses: actions/download-artifact@v4
         with:
           name: LedFx-sdist

--- a/.github/workflows/publish-release-pypi.yml
+++ b/.github/workflows/publish-release-pypi.yml
@@ -4,18 +4,15 @@ on:
   release:
     types:
       - published
-  # push:
-  #   paths-ignore:
-  #     - 'docs/**'
-  #     - '.*/**'
+
   workflow_dispatch:
 
 env:
   DEFAULT_PYTHON: 3.12
 
 jobs:
-  build-n-publish:
-    name: Build and publish Python distributions to PyPI
+  build-test-wheel-and-sdist:
+    name: Build LedFx wheel/sdist
     runs-on: ubuntu-latest
     steps:
       - name: Check out code from GitHub
@@ -33,6 +30,71 @@ jobs:
       - name: Build a binary wheel and source tarball
         run: |
           poetry build
+      - name: Package the wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: LedFx-wheel
+          path: dist/ledfx-*.whl
+      - name: Package the sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: LedFx-sdist
+          path: dist/ledfx-*.tar.gz
+  install-from-wheel:
+    name: Install the LedFx wheel
+    runs-on: ubuntu-latest
+    needs: [build-test-wheel-and-sdist]
+    steps:
+      - name: Get the wheel from the previous job
+        uses: actions/download-artifact@v4
+        with:
+          name: LedFx-wheel
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Install the wheel
+        run: |
+          pip install ledfx-*.whl
+      - name: Run LedFx
+        run: |
+          ledfx --ci-smoke-test -vv
+  install-from-sdist:
+    name: Install the LedFx sdist
+    runs-on: ubuntu-latest
+    needs: [build-test-wheel-and-sdist]
+    steps:
+      - name: Get the wheel from the previous job
+        uses: actions/download-artifact@v4
+        with:
+          name: LedFx-sdist
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Install the wheel
+        run: |
+          pip install ledfx-*.tar.gz
+      - name: Run LedFx
+        run: |
+          ledfx --ci-smoke-test -vv
+  publish:
+    name: Publish Python distributions to PyPI
+    needs: [install-from-wheel, install-from-sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the wheel from the previous job
+        uses: actions/download-artifact@v4
+        with:
+          name: LedFx-wheel
+      - name: Get the source tarball from the previous job
+        uses: actions/download-artifact@v4
+        with:
+          name: LedFx-sdist
+      - name: Move the wheel and source tarball to the root directory
+        run: |
+          mv ledfx-*.whl /dist/ledfx-*.whl
+          mv ledfx-*.tar.gz /dist/ledfx-*.tar.gz
       - name: Publish distribution to Test PyPI
         if: github.event_name == 'workflow_dispatch'
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-release-pypi.yml
+++ b/.github/workflows/publish-release-pypi.yml
@@ -53,6 +53,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Install portaudio
+        run: |
+         sudo apt-get update && sudo apt-get install -y portaudio19-dev
       - name: Install the wheel
         run: |
           pip install ledfx-*.whl
@@ -72,7 +75,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
-      - name: Install the wheel
+      - name: Install portaudio
+        run: |
+         sudo apt-get update && sudo apt-get install -y portaudio19-dev
+      - name: Install the sdist
         run: |
           pip install ledfx-*.tar.gz
       - name: Run LedFx


### PR DESCRIPTION
This pull request updates the publish-release-pypi.yml workflow. 

This is now a 3 step process - build, install the build wheel/sdist, and then package.

Should pickup any strange errors before we get to publishing to pypi, which is impossible to publish the same version to if we ever upload a broken version.
![image](https://github.com/LedFx/LedFx/assets/21007065/fa25c310-c858-42ef-84eb-b98d46f38ff2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CI build workflow by removing an unnecessary dependency.
- **Refactor**
	- Renamed and restructured the PyPI publishing workflow to improve clarity and efficiency. Added separate jobs for building, packaging, and installing, and introduced conditional publishing to Test PyPI and PyPI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->