### PR TITLE
x13 vectorization improvement of game of life

### DIFF
--- a/ledfx/effects/game_of_life.py
+++ b/ledfx/effects/game_of_life.py
@@ -178,8 +178,8 @@ class GameOfLifeVisualiser(Twod, GradientEffect):
         )
 
         # Calculate alive and dead durations using vectorization
-        alive_durations = np.sum(history_stack[:, :, :] == True, axis=0)
-        dead_durations = np.sum(history_stack[:, :, :] == False, axis=0)
+        alive_durations = np.sum(history_stack, axis=0)
+        dead_durations = np.sum(~history_stack, axis=0)
 
         # Map durations to colors using vectorized operations
         for duration in range(len(self.live_colors)):

--- a/ledfx/effects/game_of_life.py
+++ b/ledfx/effects/game_of_life.py
@@ -1,14 +1,13 @@
 import logging
 import random
-
 from enum import Enum
 
 import numpy as np
 import voluptuous as vol
+from PIL import Image
 
 from ledfx.effects.gradient import GradientEffect
 from ledfx.effects.twod import Twod
-from PIL import Image
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,23 +47,29 @@ class GameOfLifeVisualiser(Twod, GradientEffect):
     history = 5
     # need history plus one colors
 
-    dead_colors = np.array([
-        [180, 0, 0],
-        [120, 0, 0],
-        [60, 0, 0],
-        [30, 0, 0],
-        [15, 0, 0],
-        [0, 0, 0],
-    ], dtype=np.uint8)
+    dead_colors = np.array(
+        [
+            [180, 0, 0],
+            [120, 0, 0],
+            [60, 0, 0],
+            [30, 0, 0],
+            [15, 0, 0],
+            [0, 0, 0],
+        ],
+        dtype=np.uint8,
+    )
 
-    live_colors = np.array([
-        [0, 180, 0],
-        [0, 255, 0],
-        [255, 255, 255],
-        [200, 200, 200],
-        [150, 150, 150],
-        [100, 100, 100],
-    ], dtype=np.uint8)
+    live_colors = np.array(
+        [
+            [0, 180, 0],
+            [0, 255, 0],
+            [255, 255, 255],
+            [200, 200, 200],
+            [150, 150, 150],
+            [100, 100, 100],
+        ],
+        dtype=np.uint8,
+    )
 
     CONFIG_SCHEMA = vol.Schema(
         {
@@ -169,7 +174,8 @@ class GameOfLifeVisualiser(Twod, GradientEffect):
         # Convert game board and history to NumPy arrays
         current_board = np.array(self.game.board)
         history_stack = np.array(
-            [np.array(hist) for hist in self.game.board_history])
+            [np.array(hist) for hist in self.game.board_history]
+        )
 
         # Calculate alive and dead durations using vectorization
         alive_durations = np.sum(history_stack[:, :, :] == True, axis=0)
@@ -177,17 +183,20 @@ class GameOfLifeVisualiser(Twod, GradientEffect):
 
         # Map durations to colors using vectorized operations
         for duration in range(len(self.live_colors)):
-            alive_mask = np.logical_and(current_board,
-                                        alive_durations == duration)
+            alive_mask = np.logical_and(
+                current_board, alive_durations == duration
+            )
             img_array[alive_mask] = self.live_colors[duration]
 
         for duration in range(len(self.dead_colors)):
-            dead_mask = np.logical_and(~current_board,
-                                       dead_durations == duration)
+            dead_mask = np.logical_and(
+                ~current_board, dead_durations == duration
+            )
             img_array[dead_mask] = self.dead_colors[duration]
 
         # Convert the NumPy array back to PIL Image and update self.matrix
         self.matrix = Image.fromarray(img_array)
+
 
 class GameOfLife:
     """

--- a/ledfx/effects/game_of_life.py
+++ b/ledfx/effects/game_of_life.py
@@ -171,11 +171,9 @@ class GameOfLifeVisualiser(Twod, GradientEffect):
         # Convert PIL image to NumPy array for processing
         img_array = np.array(self.matrix)
 
-        # Convert game board and history to NumPy arrays
-        current_board = np.array(self.game.board)
-        history_stack = np.array(
-            [np.array(hist) for hist in self.game.board_history]
-        )
+        # Use game board and history directly
+        current_board = self.game.board
+        history_stack = np.array(self.game.board_history)
 
         # Calculate alive and dead durations using vectorization
         alive_durations = np.sum(history_stack, axis=0)
@@ -223,7 +221,6 @@ class GameOfLife:
     """
 
     def __init__(self, height, width, depth):
-        self.board_history = []
         self.depth = depth
         self.board_size = [height, width]
         self.board = self.random_board()
@@ -238,14 +235,14 @@ class GameOfLife:
             numpy.ndarray: The random game board.
         """
         _LOGGER.info("Evolving life")
-        return np.random.choice([True, False], self.board_size)
+        return np.random.choice([True, False], size=self.board_size)
 
     def step_board(self):
         """
         Performs one step of the game simulation.
         """
-        # _LOGGER.debug("Stepping board")
-        self.board_history.append(self.board)
+        # Update board_history
+        self.board_history.append(np.copy(self.board))
         if len(self.board_history) > self.depth:
             self.board_history.pop(0)
 
@@ -303,9 +300,8 @@ class GameOfLife:
         Clears the board history.
         """
         _LOGGER.info("Erasing history of the universe")
-        self.empty_board = np.zeros(self.board_size, dtype=bool)
-        # append self.depth empty boards
-        self.board_history = [self.empty_board] * self.depth
+        self.board_history = [np.zeros(self.board_size, dtype=bool) for _ in
+                              range(self.depth)]
 
     def add_glider(self):
         """

--- a/ledfx/effects/game_of_life.py
+++ b/ledfx/effects/game_of_life.py
@@ -300,8 +300,9 @@ class GameOfLife:
         Clears the board history.
         """
         _LOGGER.info("Erasing history of the universe")
-        self.board_history = [np.zeros(self.board_size, dtype=bool) for _ in
-                              range(self.depth)]
+        self.board_history = [
+            np.zeros(self.board_size, dtype=bool) for _ in range(self.depth)
+        ]
 
     def add_glider(self):
         """


### PR DESCRIPTION
Threw some chatgpt at it

purely refactors the update_image_with_board()
~x13 speed at 128 x 128
10ms per frame -> 0.75 ms per frame

I will want to go over color mappings with a fine toothcomb later, but it looks good right now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Optimized the Game of Life effect for better performance and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->