### PR TITLE
make ledfx restart on visualisation_maxlen change

### DIFF
--- a/ledfx/api/config.py
+++ b/ledfx/api/config.py
@@ -249,7 +249,10 @@ class ConfigEndpoint(RestEndpoint):
                         "scan_on_startup",
                         "user_presets",
                         "transmission_mode",
-                        "visualisation_maxlen",
+                        # ToDo:
+                        # temporary let ledfx restart when visualisation_maxlen is changed
+                        # until backend can change the length of the pixel data sent via websocket
+                        # "visualisation_maxlen",
                     ]
                 )
                 and len(core_config) == 1


### PR DESCRIPTION
temporary let ledfx restart when visualisation_maxlen is changed
until backend can change the length of the pixel data sent via websocket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Temporarily disabled the "visualisation_maxlen" parameter to ensure stability during configuration changes. A restart of LEDFx is recommended when altering related settings until further updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->