### PR TITLE
game of life

### DIFF
--- a/ledfx/effects/game_of_life.py
+++ b/ledfx/effects/game_of_life.py
@@ -305,8 +305,9 @@ class GameOfLife:
         Clears the board history.
         """
         _LOGGER.info("Erasing history of the universe")
-        self.board_history = [np.zeros(self.board_size, dtype=bool) for _ in
-                              range(self.depth)]
+        self.board_history = [
+            np.zeros(self.board_size, dtype=bool) for _ in range(self.depth)
+        ]
 
     def add_glider(self):
         """

--- a/ledfx/effects/game_of_life.py
+++ b/ledfx/effects/game_of_life.py
@@ -187,6 +187,11 @@ class GameOfLifeVisualiser(Twod, GradientEffect):
             img_array[alive_mask] = self.live_colors[duration]
 
         for duration in range(len(self.dead_colors)):
+            # where pixel is long dead, don't draw black, allows any image
+            # behind to show through, and well as faster for all non plots
+            if duration == 5:
+                continue
+
             dead_mask = np.logical_and(
                 ~current_board, dead_durations == duration
             )
@@ -300,9 +305,8 @@ class GameOfLife:
         Clears the board history.
         """
         _LOGGER.info("Erasing history of the universe")
-        self.board_history = [
-            np.zeros(self.board_size, dtype=bool) for _ in range(self.depth)
-        ]
+        self.board_history = [np.zeros(self.board_size, dtype=bool) for _ in
+                              range(self.depth)]
 
     def add_glider(self):
         """


### PR DESCRIPTION
Don't plot black

Save time by not plotting truly dead cells, also allows game of life to run over the top of existing content

Could be used to load an image as background

Tested using test option to draw rectangle under game of life
Also hacked in image for fun, though not in this PR
Also messed with colors for live / dead to check full range being used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the efficiency of the Game of Life effect by adding a conditional skip for specific durations.
	- Enhanced code readability in the Game of Life effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->