### PR TITLE
feat: HyperHDR support

### DIFF
--- a/ledfx/devices/packets.py
+++ b/ledfx/devices/packets.py
@@ -58,6 +58,7 @@ def build_drgb_packet(data: np.ndarray, timeout: int):
     packet.extend(byteData.flatten().tobytes())
     return packet
 
+
 def build_rgb_packet(data: np.ndarray):
     """
     Generic RGB packet encoding (used by HyperHDR's "UDP raw receiver")

--- a/ledfx/devices/packets.py
+++ b/ledfx/devices/packets.py
@@ -58,6 +58,22 @@ def build_drgb_packet(data: np.ndarray, timeout: int):
     packet.extend(byteData.flatten().tobytes())
     return packet
 
+def build_rgb_packet(data: np.ndarray):
+    """
+    Generic RGB packet encoding (used by HyperHDR's "UDP raw receiver")
+    Max LEDs: 500
+
+    Header: none
+    Byte 	Description
+    0 + n*3 	Red Value
+    1 + n*3 	Green Value
+    2 + n*3 	Blue Value
+
+    """
+    byteData = data.astype(np.dtype("B"))
+    packet = byteData.flatten().tobytes()
+    return packet
+
 
 def build_drgbw_packet(data: np.ndarray, timeout: int):
     """

--- a/ledfx/devices/udp.py
+++ b/ledfx/devices/udp.py
@@ -9,7 +9,14 @@ from ledfx.devices import UDPDevice, packets
 _LOGGER = logging.getLogger(__name__)
 
 RGB_HYPERHDR_PACKET = "RGB (HyperHDR)"
-SUPPORTED_PACKETS = ["DRGB", "WARLS", "DRGBW", "DNRGB", "adaptive_smallest", RGB_HYPERHDR_PACKET]
+SUPPORTED_PACKETS = [
+    "DRGB",
+    "WARLS",
+    "DRGBW",
+    "DNRGB",
+    "adaptive_smallest",
+    RGB_HYPERHDR_PACKET,
+]
 
 
 class UDPRealtimeDevice(UDPDevice):
@@ -112,8 +119,11 @@ class UDPRealtimeDevice(UDPDevice):
             else:
                 udpData = packets.build_drgb_packet(data, timeout)
                 self.transmit_packet(udpData, frame_is_equal_to_last)
-        
-        elif self._config["udp_packet_type"] == RGB_HYPERHDR_PACKET and frame_size <= 500:
+
+        elif (
+            self._config["udp_packet_type"] == RGB_HYPERHDR_PACKET
+            and frame_size <= 500
+        ):
             udpData = packets.build_rgb_packet(data)
             self.transmit_packet(udpData, frame_is_equal_to_last)
 

--- a/ledfx/devices/udp.py
+++ b/ledfx/devices/udp.py
@@ -8,7 +8,8 @@ from ledfx.devices import UDPDevice, packets
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORTED_PACKETS = ["DRGB", "WARLS", "DRGBW", "DNRGB", "adaptive_smallest"]
+RGB_HYPERHDR_PACKET = "RGB (HyperHDR)"
+SUPPORTED_PACKETS = ["DRGB", "WARLS", "DRGBW", "DNRGB", "adaptive_smallest", RGB_HYPERHDR_PACKET]
 
 
 class UDPRealtimeDevice(UDPDevice):
@@ -111,6 +112,10 @@ class UDPRealtimeDevice(UDPDevice):
             else:
                 udpData = packets.build_drgb_packet(data, timeout)
                 self.transmit_packet(udpData, frame_is_equal_to_last)
+        
+        elif self._config["udp_packet_type"] == RGB_HYPERHDR_PACKET and frame_size <= 500:
+            udpData = packets.build_rgb_packet(data)
+            self.transmit_packet(udpData, frame_is_equal_to_last)
 
         else:  # fallback
             _LOGGER.warning(


### PR DESCRIPTION
Add support for [HyperHDR](https://github.com/awawa-dev/HyperHDR) ambient lights. HyperHDR uses a UDP protocol that is similar to `DRGB`, without the header (and thus, without a timeout parameter) (see [source](https://github.com/awawa-dev/HyperHDR/blob/8656c107169a7af3be5f2d0d840e220988270f77/sources/base/RawUdpServer.cpp#L118-L146)).

In order to use HyperHDR as a device, the "UDP raw receiver" needs to be enabled under Menu > "Advanced" > "Network Services". In LedFx, create a UDP device with the new "RGB (HyperHDR)" mode. The pixel count needs to be exactly the same as configured in HyperHDR, otherwise HyperHDR discards the UDP packets.

I tested this on my local installation and it works perfectly :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for HyperHDR's "UDP raw receiver" through a new RGB packet encoding functionality, enhancing compatibility with diverse lighting setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->