### PR TITLE
protect from small matrix for entity injection

### DIFF
--- a/ledfx/effects/game_of_life.py
+++ b/ledfx/effects/game_of_life.py
@@ -143,7 +143,7 @@ class GameOfLifeVisualiser(Twod):
             height=self.r_height, width=self.r_width, depth=self.history
         )
         if self.r_height <= 4 or self.r_width <= 4:
-            _LOGGER.info(f"Board too small at {self.game.board_size} disabling beat injection of entitiers")
+            _LOGGER.info(f"Board too small at {self.game.board_size} disabling beat injection of entities")
             self.inject = False
 
     def audio_data_updated(self, data):

--- a/ledfx/effects/game_of_life.py
+++ b/ledfx/effects/game_of_life.py
@@ -142,6 +142,9 @@ class GameOfLifeVisualiser(Twod):
         self.game = GameOfLife(
             height=self.r_height, width=self.r_width, depth=self.history
         )
+        if self.r_height <= 4 or self.r_width <= 4:
+            _LOGGER.info(f"Board too small at {self.game.board_size} disabling beat injection of entitiers")
+            self.inject = False
 
     def audio_data_updated(self, data):
         if self.inject and data.volume_beat_now():


### PR DESCRIPTION
as per 

https://github.com/LedFx/LedFx/issues/700

Tested on 1d strip for pretection, needs bounds testing on 3,3 4,4 5,5

[INFO    ] ledfx.effects.game_of_life     : Board too small at [1, 356] disabling beat injection of entities

[INFO    ] ledfx.effects.game_of_life     : Board too small at [4, 4] disabling beat injection of entities

Seen working at 5 x 5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability for the Game of Life effect by disabling beat injection on small boards, enhancing user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->