### PR TITLE
Correct call to HTTPMethodNotAllowed

### DIFF
--- a/ledfx/api/__init__.py
+++ b/ledfx/api/__init__.py
@@ -36,7 +36,8 @@ class RestEndpoint(BaseRegistry):
 
         method = getattr(self, request.method.lower(), None)
         if not method:
-            raise web.HTTPMethodNotAllowed("")
+            allowed_methods = [meth.upper() for meth in ['get', 'post', 'put', 'delete'] if hasattr(self, meth)]
+            raise web.HTTPMethodNotAllowed("", allowed_methods=allowed_methods)
 
         wanted_args = list(inspect.signature(method).parameters.keys())
         available_args = request.match_info.copy()

--- a/ledfx/api/__init__.py
+++ b/ledfx/api/__init__.py
@@ -36,7 +36,11 @@ class RestEndpoint(BaseRegistry):
 
         method = getattr(self, request.method.lower(), None)
         if not method:
-            allowed_methods = [meth.upper() for meth in ['get', 'post', 'put', 'delete'] if hasattr(self, meth)]
+            allowed_methods = [
+                meth.upper()
+                for meth in ["get", "post", "put", "delete"]
+                if hasattr(self, meth)
+            ]
             raise web.HTTPMethodNotAllowed("", allowed_methods=allowed_methods)
 
         wanted_args = list(inspect.signature(method).parameters.keys())


### PR DESCRIPTION
Fix crash in bad call 

Previously caused 

500 Internal Server Error

Tested with injection of unsupported method calls changed to GET where only POST is supported

Now returns 

405: Method Not Allowed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for unsupported HTTP methods by dynamically specifying allowed methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->