### PR TITLE
Rows protect

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -780,6 +780,10 @@ class AudioReactiveEffect(Effect):
         "High": "high_power",
     }
 
+    def __init__(self, ledfx, config):
+        super().__init__(ledfx, config)
+        self.audio = None
+
     def activate(self, channel):
         _LOGGER.info("Activating AudioReactiveEffect.")
         super().activate(channel)

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -780,10 +780,6 @@ class AudioReactiveEffect(Effect):
         "High": "high_power",
     }
 
-    def __init__(self, ledfx, config):
-        super().__init__(ledfx, config)
-        self.audio = None
-
     def activate(self, channel):
         _LOGGER.info("Activating AudioReactiveEffect.")
         super().activate(channel)

--- a/ledfx/effects/twod.py
+++ b/ledfx/effects/twod.py
@@ -77,7 +77,7 @@ class Twod(AudioReactiveEffect):
         self.current_pixel = 0
         self.last_cycle_time = 20
         self.bar = 0
-        self.t_height = self._virtual.config["rows"]
+        self.t_height = max(1, self._virtual.config["rows"])
         self.t_width = self.pixel_count // self.t_height
         # initialise here so inherited can assume it exists
         self.current_time = timeit.default_timer()
@@ -123,7 +123,7 @@ class Twod(AudioReactiveEffect):
         # also triggered by config change in parent virtual
         # presently only on row change
 
-        self.t_height = self._virtual.config["rows"]
+        self.t_height = max(1, self._virtual.config["rows"])
         self.t_width = self.pixel_count // self.t_height
 
         if self.rotate == 1 or self.rotate == 3:


### PR DESCRIPTION
Its possible to enter zero and trigger a divide by zero error in twod effects, or even using the arrow adjusters to enter a negative value which will lead to an image creation error in PIL.

This change uses the max of value AND 1, so we will never hit these crashes.

Locking vol schema to range min 1 still allows a user to enter bad values and then crash the vol validation instead, so just protect "rows" on consumption

Tested for bad case reproduction and hardened with fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an initialization method for audio attributes in the AudioReactiveEffect class.
- **Bug Fixes**
	- Adjusted the `t_height` variable to prevent division by zero errors in the calculation of dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->