### PR TITLE
Nan protection in get_freq_power

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -673,9 +673,11 @@ class AudioAnalysisSource(AudioInputSource):
 
     def get_freq_power(self, i, filtered=True):
         if filtered:
-            return self.freq_power_filter.value[i]
+            value = self.freq_power_filter.value[i]
         else:
-            return self.freq_power_raw[i]
+            value = self.freq_power_raw[i]
+
+        return value if not np.isnan(value) else 0.0
 
     def beat_power(self, filtered=True):
         """

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -780,6 +780,10 @@ class AudioReactiveEffect(Effect):
         "High": "high_power",
     }
 
+    def __init__(self, ledfx, config):
+        super().__init__(ledfx, config)
+        self.audio = None
+
     def activate(self, channel):
         _LOGGER.info("Activating AudioReactiveEffect.")
         super().activate(channel)

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -782,10 +782,6 @@ class AudioReactiveEffect(Effect):
         "High": "high_power",
     }
 
-    def __init__(self, ledfx, config):
-        super().__init__(ledfx, config)
-        self.audio = None
-
     def activate(self, channel):
         _LOGGER.info("Activating AudioReactiveEffect.")
         super().activate(channel)


### PR DESCRIPTION
Its possible to have NaN values in the return of the power funcs

This will cause a crash if the effect converts the result of a calc to an int.

Force return of 0.0 in case of NaN

Multiple hits across effects in Sentry