### PR TITLE
feat: improve color gradient resolution for low pixel counts

### DIFF
--- a/ledfx/effects/hsv_effect.py
+++ b/ledfx/effects/hsv_effect.py
@@ -49,7 +49,6 @@ class HSVEffect(GradientEffect):
     def render(self):
         # update the timestep, converting ns to s
         self._dt = time.time_ns() - self._start_time
-        self._assert_gradient()
         self.render_hsv()
 
         hsv = np.copy(self.hsv_array)
@@ -64,8 +63,7 @@ class HSVEffect(GradientEffect):
         h *= self.pixel_count - 1
         h = h.astype(int)
         # Grab the colors from the gradient
-        self._assert_gradient()
-        pixels[:] = self._gradient_curve[:, h].T
+        pixels[:] = self.get_gradient()[:, h].T
         # Apply saturation to colors
         pixels += (np.max(pixels, axis=1).reshape(-1, 1) - pixels) * (1 - s)
         # Apply value (brightness) to colors


### PR DESCRIPTION
Enhance the visual fidelity of gradient-based effects on devices with low pixel counts by separating the gradient scale from the device's pixel count.  This update ensures every gradient incorporates a minimum of 256 color shades.

Before this improvement, the number of colors in a gradient was directly proportional to the pixel count of the device, leading to suboptimal color representation on low-pixel devices. For instance, a device with two pixels would use just two distinct colors, and a single-pixel device would be limited to a singular color. This adjustment addresses issue #673 and replaces the draft PR #681.

I tested this on devices with 1, 10, and 1000 pixels by cycling through the effects and validating that no exception is logged to the console. This obviously doesn't cover all combinations of effect settings, so I'm not sure whether this is sufficient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved gradient calculations in effects for more accurate color transitions.
	- Streamlined color retrieval process in HSV effect for enhanced performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->