### PR TITLE
feat: pixel grouping

### DIFF
--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -330,14 +330,14 @@ class Effect(BaseRegistry):
         """Attaches an output channel to the effect"""
         with self.lock:
             self._virtual = virtual
-            self.pixels = np.zeros((virtual.effect_pixel_count, 3))
+            self.pixels = np.zeros((virtual.effective_pixel_count, 3))
             # Iterate all the base classes and check to see if the base
             # class has an on_activate method. If so, call it
             valid_classes = list(type(self).__bases__)
             valid_classes.append(type(self))
             for base in valid_classes:
                 if hasattr(base, "on_activate"):
-                    base.on_activate(self, virtual.effect_pixel_count)
+                    base.on_activate(self, virtual.effective_pixel_count)
             self._active = True
             _LOGGER.info(f"Effect {self.NAME} activated.")
 

--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -330,14 +330,14 @@ class Effect(BaseRegistry):
         """Attaches an output channel to the effect"""
         with self.lock:
             self._virtual = virtual
-            self.pixels = np.zeros((virtual.pixel_count, 3))
+            self.pixels = np.zeros((virtual.effect_pixel_count, 3))
             # Iterate all the base classes and check to see if the base
             # class has an on_activate method. If so, call it
             valid_classes = list(type(self).__bases__)
             valid_classes.append(type(self))
             for base in valid_classes:
                 if hasattr(base, "on_activate"):
-                    base.on_activate(self, virtual.pixel_count)
+                    base.on_activate(self, virtual.effect_pixel_count)
             self._active = True
             _LOGGER.info(f"Effect {self.NAME} activated.")
 

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -233,7 +233,7 @@ class Virtual:
             "_devices",
             "_segments_by_device",
             "effective_pixel_count",
-            "group_size"
+            "group_size",
         ]:
             if hasattr(self, prop):
                 delattr(self, prop)

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -232,6 +232,8 @@ class Virtual:
             "refresh_rate",
             "_devices",
             "_segments_by_device",
+            "effective_pixel_count",
+            "group_size"
         ]:
             if hasattr(self, prop):
                 delattr(self, prop)
@@ -1013,6 +1015,7 @@ class Virtual:
                     if _config["grouping"] != self._config["grouping"]:
                         # The effect needs to be reactivated later after the config has been applied
                         reactivate_effect = True
+                        self.invalidate_cached_props()
 
         setattr(self, "_config", _config)
 
@@ -1027,7 +1030,7 @@ class Virtual:
         if reactivate_effect:
             self._reactivate_effect()
 
-    @property
+    @cached_property
     def effective_pixel_count(self):
         """The number of pixels to calculate by effects.
 
@@ -1036,7 +1039,7 @@ class Virtual:
         """
         return self._get_effective_pixel_count(self.pixel_count)
 
-    @property
+    @cached_property
     def group_size(self):
         """The number of physical pixels to group into virtual effect pixels."""
         grouping = self._config["grouping"]

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -478,7 +478,9 @@ class Virtual:
             frame = self.assembled_frame
 
         self._ledfx.events.fire_event(
-            VirtualUpdateEvent(self.id, self._effective_to_physical_pixels(frame))
+            VirtualUpdateEvent(
+                self.id, self._effective_to_physical_pixels(frame)
+            )
         )
 
     def oneshot(self, color, ramp, hold, fade):
@@ -775,8 +777,10 @@ class Virtual:
                             device_end,
                         ) in segments:
                             target_physical_len = device_end - device_start + 1
-                            target_effect_len = self._get_effective_pixel_count(
-                                target_physical_len
+                            target_effect_len = (
+                                self._get_effective_pixel_count(
+                                    target_physical_len
+                                )
                             )
                             # In copy mode, we need to scale the effect and afterwards expand the
                             # pixel groups separately for every segment, because pre-calculating once
@@ -1046,7 +1050,9 @@ class Virtual:
         """Calculates the number of effective pixels for a given number of physical pixels, considering pixel grouping."""
         return int(np.ceil(physical_pixel_count / self.group_size))
 
-    def _effective_to_physical_pixels(self, effective_pixels, pixel_count=None):
+    def _effective_to_physical_pixels(
+        self, effective_pixels, pixel_count=None
+    ):
         """Projects an array of effective pixels into an array of pixels for physical rendering, considering pixel grouping."""
         if self.group_size <= 1:
             return effective_pixels
@@ -1054,9 +1060,9 @@ class Virtual:
         if not pixel_count:
             pixel_count = self.pixel_count
 
-        effective_pixels = np.repeat(effective_pixels, self.group_size, axis=0)[
-            :pixel_count, :
-        ]
+        effective_pixels = np.repeat(
+            effective_pixels, self.group_size, axis=0
+        )[:pixel_count, :]
 
         return effective_pixels
 

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -781,9 +781,9 @@ class Virtual:
                             # In copy mode, we need to scale the effect and afterwards expand the
                             # pixel groups separately for every segment, because pre-calculating once
                             # and scaling would lead to incorrect pixel group lengths.
-                            seg = interpolate_pixels(pixels, target_effect_len)[
-                                ::step
-                            ]
+                            seg = interpolate_pixels(
+                                pixels, target_effect_len
+                            )[::step]
                             seg = self._effect_to_physical_pixels(
                                 seg, target_physical_len
                             )


### PR DESCRIPTION
Add a "grouping" configuration field to devices and virtuals which allows grouping physical pixels into coarser groups of virtual pixels. This is similar to the [grouping functionality in WLED](https://kno.wled.ge/features/segments/#grouping-and-spacing), but without a spacing option.

Examples:
- Setting "grouping" to `10` on a device with `200` pixels leads to `20` virtual pixels with the following implications: (1) effects are calculated for 20 pixels, (2) every run of 10 pixels displays the same color.
- Setting "grouping" to `100` on a device with a `10x10` pixel matrix converts it to a uniform "spotlight".

I tested this on individual devices and multi-segment virtuals by cycling through effects, dynamically changing device pixel counts and group settings, and validating that no exception is logged. I have no idea whether this covers all use cases, so it would be great is someone knowledgeable tested this as well.

Possible future extensions:
- Add "spacing" option similar to WLED. This is typically used to interleave multiple effects, but I'm not sure whether the current architecture would allow it, or if this is even a useful use case.
- Add per-segment "grouping" option in the virtual segment editor. Requires updating the UI too.

Resolves #696.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `grouping` field for combining physical pixels into virtual pixel groups for enhanced lighting effects.
- **Bug Fixes**
	- Improved accuracy in effect activation by utilizing `virtual.effect_pixel_count` in the activation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->