### PR TITLE
Protect from NaNs in melbanks

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -894,6 +894,18 @@ class AudioReactiveEffect(Effect):
         new = np.linspace(0, 1, size)
         return (new, old)
 
+    def melbank_no_nan(self, melbank):
+        # Check for NaN values in the melbank array, replace with 0 in place
+        # Difficult to determine why this happens, but it seems to be related to
+        # the audio input device.
+        # TODO: Investigate why NaNs are present in the melbank array for some people/devices
+        if np.isnan(melbank).any():
+            _LOGGER.warning(
+                "NaN values detected in the melbank array and replaced with 0."
+            )
+            # Replace NaN values with 0
+            np.nan_to_num(melbank, copy=False)
+
     @lru_cache(maxsize=None)
     def melbank(self, filtered=False, size=0):
         """
@@ -912,6 +924,9 @@ class AudioReactiveEffect(Effect):
             melbank = self.audio.melbanks.melbanks[self._selected_melbank][
                 self._melbank_min_idx : self._melbank_max_idx
             ]
+
+        self.melbank_no_nan(melbank)
+
         if size and (self._input_mel_length != size):
             return np.interp(*self._melbank_interp_linspaces(size), melbank)
         else:
@@ -926,14 +941,6 @@ class AudioReactiveEffect(Effect):
         mel_length = len(melbank)
         splits = tuple(map(lambda i: int(i * mel_length), [0.2, 0.5]))
 
-        # Check for NaN values in the melbank array
-        # Difficult to determine why this happens, but it seems to be related to
-        # the audio input device. If NaNs are present, replace them with 0
-        # TODO: Investigate why NaNs are present in the melbank array for some people/devices
-        if np.isnan(melbank).any():
-            _LOGGER.warning(
-                "NaN values detected in the melbank array and replaced with 0."
-            )
-            # Replace NaN values with 0
-            melbank = np.nan_to_num(melbank)
+        self.melbank_no_nan(melbank)
+
         return np.split(melbank, splits)


### PR DESCRIPTION
protect against NaNs in the melbanks, uses in place to reduce copy implications

Using the np mass check and in place should be as efficient as we can reasonably get

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved audio effect handling by addressing NaN values in the `melbank` array, ensuring more reliable audio visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->