### PR TITLE
demote openrgb timeout errors to warnings

### DIFF
--- a/ledfx/api/find_openrgb.py
+++ b/ledfx/api/find_openrgb.py
@@ -30,7 +30,7 @@ class FindOpenRGBDevicesEndpoint(RestEndpoint):
             error_message = (
                 f"Unable to connect to OpenRGB server at localhost:6742, {e}."
             )
-            _LOGGER.error(error_message)
+            _LOGGER.warning(error_message)
             return await self.request_success(
                 "warning",
                 error_message,
@@ -83,7 +83,7 @@ class FindOpenRGBDevicesEndpoint(RestEndpoint):
             error_message = (
                 f"Unable to connect to OpenRGB server at {server}:{port}, {e}."
             )
-            _LOGGER.error(error_message)
+            _LOGGER.warning(error_message)
             return await self.request_success(
                 "warning",
                 error_message,


### PR DESCRIPTION
Tested against timeout by turning off my openrgb server and doing the auto scan