### PR TITLE
demote discard device

### DIFF
--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -633,7 +633,7 @@ class Devices(RegistryLoader):
                     self._ledfx.loop, self._ledfx.thread_executor, device_ip
                 )
             except ValueError:
-                _LOGGER.error(f"Discarding device {device_ip}")
+                _LOGGER.warning(f"Discarding device {device_ip}")
                 return
 
             for existing_device in self._ledfx.devices.values():


### PR DESCRIPTION
We should not be pushing unresolvable devices at sentry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the logging level for discarding a device based on its IP address from error to warning to better reflect the nature of the action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->