### PR TITLE
Correct Debug on segment failure

### DIFF
--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -216,7 +216,7 @@ class Virtual:
             or (start_pixel > end_pixel)
             or (end_pixel >= device.pixel_count)
         ):
-            msg = f"Invalid segment pixels: ({start_pixel}, {end_pixel}). Device '{self.name}' valid pixels between (0, {self.pixel_count - 1})"
+            msg = f"Invalid segment pixels: ({start_pixel}, {end_pixel}). Device '{self.name}' valid pixels between (0, {device.pixel_count - 1})"
             valid = False
 
         if not valid:


### PR DESCRIPTION
We have a population in Sentry of 

Invalid segment pixels: (0, 179). Device 'studio' valid pixels between (0, -1)

and similar.

The current debug statement is incorrect and dumps the virtual pixel count which at this point is always zero, therefore 0-1 shows -1 in the debug above

Correcting debug to the violated device.pixel_count so we can get more insight

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the error message in device validation to accurately reflect the correct device pixel count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->