### PR TITLE
Add websocket docs and capture _sender connection reset errors. 

### DIFF
--- a/ledfx/api/websocket.py
+++ b/ledfx/api/websocket.py
@@ -138,7 +138,6 @@ class WebsocketConnection:
 
         This method is an asynchronous write loop that pulls messages from the sender queue and sends them over the websocket connection.
         It continuously checks for new messages in the queue until the websocket connection is closed.
-        If a message is None, it breaks the loop and stops sending messages.
         If there is an error serializing the message to JSON, it logs an error message.
         If the websocket connection is closed by the client, it logs a message and breaks the loop.
         """

--- a/ledfx/api/websocket.py
+++ b/ledfx/api/websocket.py
@@ -52,9 +52,8 @@ class WebsocketEndpoint(RestEndpoint):
         try:
             return await WebsocketConnection(self._ledfx).handle(request)
         except ConnectionResetError:
-            _LOGGER.debug(
-                "Connection Reset Error on Websocket Connection - retrying."
-            )
+            _LOGGER.debug("Connection Reset Error on Websocket Connection.")
+            return self.internal_error("Connection Reset Error.")
 
 
 class WebsocketConnection:
@@ -67,18 +66,29 @@ class WebsocketConnection:
         self._sender_queue = asyncio.Queue(maxsize=MAX_PENDING_MESSAGES)
 
     def close(self):
-        """Closes the websocket connection"""
+        """
+        Closes the websocket connection.
+
+        This method cancels the receiver and sender tasks, if they exist, to close the websocket connection.
+        """
         if self._receiver_task:
             self._receiver_task.cancel()
         if self._sender_task:
             self._sender_task.cancel()
 
     def clear_subscriptions(self):
+        """
+        Clears all the subscriptions by calling the registered listener functions.
+        """
         for func in self._listeners.values():
             func()
 
     def send(self, message):
-        """Sends a message to the websocket connection"""
+        """Sends a message to the websocket connection
+
+        Args:
+            message (str): The message to be sent
+        """
 
         # If the queue is full, dump it and start again
         if self._sender_queue.qsize() == MAX_PENDING_MESSAGES:
@@ -93,7 +103,14 @@ class WebsocketConnection:
             self.close()
 
     def send_error(self, id, message):
-        """Sends an error string to the websocket connection"""
+        """Sends an error string to the websocket connection.
+
+        Args:
+            id (int): The ID of the error message.
+            message (str): The error message to be sent.
+
+
+        """
 
         return self.send(
             {
@@ -104,19 +121,30 @@ class WebsocketConnection:
         )
 
     def send_event(self, id, event):
-        """Sends an event notification to the websocket connection"""
+        """
+        Sends an event notification to the websocket connection.
+
+        Args:
+            id (str): The ID of the event.
+            event (Event): The event object to be sent.
+
+        """
 
         return self.send({"id": id, "type": "event", **event.to_dict()})
 
     async def _sender(self):
-        """Async write loop to pull from the queue and send"""
+        """
+        Async write loop to pull from the queue and send
 
-        _LOGGER.info("Starting sender")
+        This method is an asynchronous write loop that pulls messages from the sender queue and sends them over the websocket connection.
+        It continuously checks for new messages in the queue until the websocket connection is closed.
+        If a message is None, it breaks the loop and stops sending messages.
+        If there is an error serializing the message to JSON, it logs an error message.
+        If the websocket connection is closed by the client, it logs a message and breaks the loop.
+        """
+        _LOGGER.info("Starting websocket sender")
         while not self._socket.closed:
             message = await self._sender_queue.get()
-            if message is None:
-                break
-
             try:
                 # _LOGGER.debug("Sending websocket message")
                 await self._socket.send_json(message, dumps=json.dumps)
@@ -126,8 +154,11 @@ class WebsocketConnection:
                     err,
                     message,
                 )
+            except ConnectionResetError:
+                _LOGGER.info("Websocket connection closed by the client.")
+                break
 
-        _LOGGER.info("Stopping sender")
+        _LOGGER.info("Stopped websocket sender.")
 
     async def handle(self, request):
         """Handle the websocket connection"""
@@ -189,7 +220,7 @@ class WebsocketConnection:
                     websocket_handlers[message["type"]](self, message)
                 else:
                     _LOGGER.error(
-                        ("Received unknown command {}").format(message["type"])
+                        f"Received unknown command {message['type']}"
                     )
                     self.send_error(message["id"], "Unknown command type.")
 
@@ -234,9 +265,7 @@ class WebsocketConnection:
             self.send_event(message["id"], event)
 
         _LOGGER.debug(
-            "Websocket subscribing to event {} with filter {}".format(
-                message.get("event_type"), message.get("event_filter")
-            )
+            f"Websocket subscribing to event {message.get('event_type')} with filter {message.get('event_filter')}"
         )
         self._listeners[message["id"]] = self._ledfx.events.add_listener(
             notify_websocket,
@@ -272,10 +301,7 @@ class WebsocketConnection:
     @websocket_handler("audio_stream_config")
     def audio_stream_config_handler(self, message):
         _LOGGER.info(
-            "WebAudioConfig from {}: {}".format(
-                message.get("client"),
-                message.get("data"),
-            )
+            f"WebAudioConfig from {message.get('client')}: {message.get('data')}"
         )
 
     @websocket_handler("audio_stream_data")


### PR DESCRIPTION
Add docs to most but not all of the websocketendpoint.

Adds protection from connection reset errors - usually caused by browsers disconnecting mid-message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved handling of `ConnectionResetError` to enhance stability and user feedback during websocket disruptions.
- **Documentation**
	- Added and updated documentation for websocket connection management and messaging, improving developer understanding and usage of the API.
- **Refactor**
	- Updated logging messages and adopted f-string formatting for better readability and consistency in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->