### PR TITLE
Add automated update checker with notifications and API endpoint

### DIFF
--- a/ledfx/__main__.py
+++ b/ledfx/__main__.py
@@ -185,7 +185,7 @@ def parse_args():
         "--offline",
         dest="offline_mode",
         action="store_true",
-        help="Disable sentry crash logger",
+        help="Disable crash logger and auto update checks",
     )
     parser.add_argument(
         "--sentry-crash-test",
@@ -304,6 +304,7 @@ def entry_point(icon=None):
             ci_testing=args.ci_smoke_test,
             clear_config=args.clear_config,
             clear_effects=args.clear_effects,
+            offline_mode=args.offline_mode,
         )
 
         exit_code = ledfx.start(open_ui=args.open_ui)

--- a/ledfx/api/__init__.py
+++ b/ledfx/api/__init__.py
@@ -135,7 +135,7 @@ class RestEndpoint(BaseRegistry):
         return web.json_response(data=response, status=resp_code)
 
     async def request_success(
-        self, type=None, message=None, resp_code=200
+        self, type=None, message=None, data=None, resp_code=200
     ) -> web.Response:
         """
         Returns a JSON response indicating a successful request.
@@ -161,6 +161,8 @@ class RestEndpoint(BaseRegistry):
                 "type": type,
                 "reason": message,
             }
+        if data:
+            response["data"] = data
         return web.json_response(data=response, status=resp_code)
 
     async def bare_request_success(self, payload) -> web.Response:

--- a/ledfx/api/check_for_updates.py
+++ b/ledfx/api/check_for_updates.py
@@ -1,0 +1,53 @@
+import logging
+import os
+
+from aiohttp import web
+
+from ledfx.api import RestEndpoint
+from ledfx.utils import UpdateChecker
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CheckLedFxUpdatesEndPoint(RestEndpoint):
+    ENDPOINT_PATH = "/api/check_for_updates"
+
+    async def get(self) -> web.Response:
+        """
+        Handle GET request for update check.
+
+        Returns:
+            web.Response: The response containing update information.
+        """
+        is_release = os.getenv("IS_RELEASE", "false").lower()
+        if is_release == "false":
+            return await self.request_success(
+                type="info",
+                message="This instance of LedFx is not an official release - happy developing!",
+            )
+        _LOGGER.info("Checking for updates...")
+        if UpdateChecker.get_release_information():
+            latest_version = UpdateChecker.get_latest_version()
+            release_age = UpdateChecker.get_release_age()
+            release_url = UpdateChecker.get_release_url()
+            if UpdateChecker.update_available():
+                msg = "New LedFx version is available"
+                _LOGGER.warning(f"{msg}.")
+                return await self.request_success(
+                    type="warning",
+                    message=msg,
+                    data={
+                        "latest_version": latest_version,
+                        "release_age": release_age,
+                        "release_url": release_url,
+                    },
+                )
+            else:
+                msg = "LedFx is up to date"
+                _LOGGER.info(f"{msg}.")
+
+                return await self.request_success(type="success", message=msg)
+        else:
+            msg = "Unable to check for updates"
+            _LOGGER.warning(f"{msg}.")
+            return await self.request_success(type="info", message=msg)

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import sys
 import time
 import warnings
@@ -25,6 +26,7 @@ from ledfx.config import (
     remove_virtuals_active_effects,
     save_config,
 )
+from ledfx.consts import PROJECT_VERSION
 from ledfx.devices import Devices
 from ledfx.effects import Effects
 from ledfx.effects.math import interpolate_pixels
@@ -41,6 +43,7 @@ from ledfx.presets import ledfx_presets
 from ledfx.scenes import Scenes
 from ledfx.utils import (
     RollingQueueHandler,
+    UpdateChecker,
     UserDefaultCollection,
     async_fire_and_forget,
     currently_frozen,
@@ -73,6 +76,7 @@ class LedFxCore:
         ci_testing=False,
         clear_config=False,
         clear_effects=False,
+        offline_mode=False,
     ):
         self.icon = icon
         self.config_dir = config_dir
@@ -92,7 +96,7 @@ class LedFxCore:
         self.port = port if port else self.config["port"]
         self.port_s = port_s if port_s else self.config["port_s"]
         self.ci_testing = ci_testing
-
+        self.offline_mode = offline_mode
         if sys.platform == "win32":
             self.loop = asyncio.ProactorEventLoop()
         else:
@@ -121,6 +125,7 @@ class LedFxCore:
         self.http = HttpServer(
             ledfx=self, host=self.host, port=self.port, port_s=self.port_s
         )
+
         self.exit_code = None
 
     def dev_enabled(self):
@@ -159,7 +164,14 @@ class LedFxCore:
         import pystray
 
         self.icon.menu = pystray.Menu(
+            pystray.MenuItem(
+                f"LedFx - {PROJECT_VERSION}", None, enabled=False
+            ),
+            pystray.Menu.SEPARATOR,
             pystray.MenuItem("Open", self.open_ui, default=True),
+            pystray.MenuItem(
+                "Check for Update", self.check_and_notify_updates
+            ),
             pystray.MenuItem("Quit Ledfx", self.stop),
         )
 
@@ -227,6 +239,56 @@ class LedFxCore:
         logqueue_handler.addFilter(log_filter)
         root_logger = logging.getLogger()
         root_logger.addHandler(logqueue_handler)
+
+    def check_and_notify_updates(self, show_check_notification=None):
+        """
+        Checks for updates of LedFx and notifies the user if a new version is available.
+
+        Args:
+            show_check_notification (object): An optional parameter that is never called with any specific value.
+                When called via pystray, it is an icon object. This behavior is unintended but functional.
+
+        Returns:
+            None
+
+        Raises:
+            None
+        """
+
+        if show_check_notification:
+            if self.icon and self.icon.HAS_NOTIFICATION:
+                self.icon.notify("Checking for updates...", "LedFx")
+        is_release = os.getenv("IS_RELEASE", "false").lower()
+        if is_release == "false":
+            _LOGGER.info("Not checking for updates - not a release.")
+            return
+        _LOGGER.info("Checking for updates...")
+        if UpdateChecker.get_release_information():
+            if UpdateChecker.update_available():
+                latest_version = UpdateChecker.get_latest_version()
+                release_url = UpdateChecker.get_release_url()
+                _LOGGER.warning(
+                    f"New version of LedFx available: {latest_version} - {release_url}"
+                )
+
+                if self.icon and self.icon.HAS_NOTIFICATION:
+                    self.icon.notify(
+                        f"New version of LedFx available: {latest_version}",
+                        "LedFx",
+                    )
+                    try:
+                        webbrowser.get().open(release_url)
+                    except webbrowser.Error:
+                        pass
+            else:
+                _LOGGER.info("LedFx is up to date.")
+        else:
+            _LOGGER.warning("Unable to get update information.")
+            if show_check_notification:
+                if self.icon and self.icon.HAS_NOTIFICATION:
+                    self.icon.notify(
+                        "Unable to get update information", "LedFx"
+                    )
 
     def start(self, open_ui=False):
         async_fire_and_forget(self.async_start(open_ui=open_ui), self.loop)
@@ -306,6 +368,9 @@ class LedFxCore:
         if self.ci_testing:
             await asyncio.sleep(5)
             self.stop(5)
+
+        if not self.offline_mode:
+            self.check_and_notify_updates()
 
     def stop(self, exit_code):
         async_fire_and_forget(self.async_stop(exit_code), self.loop)


### PR DESCRIPTION
This pull request adds an automated update checker to the codebase.

It will check against the latest github release to see if the tag matches the current tag.

It respects --offline and will fail gracefully if unable to reach github.

It uses the tray icon to pop notifications if there is updates.

Also adds a "Check for update" option to the tray, and add our name and version number to the tray icon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an offline mode that disables crash logging, automatic updates, and Sentry integration.
	- Added a new API endpoint for checking LedFx updates, providing users with update notifications.
- **Enhancements**
	- Updated the API to support additional data in success responses, enhancing API flexibility.
	- Improved update checking mechanism to notify users of available updates, ensuring they have the latest features and fixes.
- **Refactor**
	- Integrated `offline_mode` configuration across the application to respect user preferences for operating without internet connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->