### PR TITLE
Feat: Add option for fixing hues in HSV effects

### DIFF
--- a/ledfx/effects/glitch.py
+++ b/ledfx/effects/glitch.py
@@ -95,7 +95,11 @@ class Glitch(AudioReactiveEffect, HSVEffect):
         np.multiply(s1, s2, out=s1)
         self.array_triangle(s1)
         np.subtract(1, s1, out=s1)
-        s1 = np.clip(s1, self.config["saturation_threshold"], 1)
+        # np.clip is slower than array slicing on large arrays
+        s1[s1 < self._config["saturation_threshold"]] = self._config[
+            "saturation_threshold"
+        ]
+        s1[s1 > 1] = 1
         self.hsv_array[:, 0] = h
         self.hsv_array[:, 1] = s1
         self.hsv_array[:, 2] = 1


### PR DESCRIPTION
Adds an option for fixing hues in HSV effects, allowing users to choose whether to use perceptual hue mapping for HSV effects. This defaults to true - it should result in more "even" rainbows since HSV colorspace isn't evenly percieved by eyes.

Also riding along is glitch changing to use array slicing for saturation clipping instead of np.clip, which improves performance on large arrays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
	- Optimized array clipping in the Glitch effect for enhanced performance.
- **New Features**
	- Added a `fix_hues` configuration option in the HSV Effect to allow users to control hue distribution for more personalized lighting effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->