### PR TITLE
devices POST error return

### DIFF
--- a/ledfx/api/devices.py
+++ b/ledfx/api/devices.py
@@ -67,7 +67,7 @@ class DevicesEndpoint(RestEndpoint):
         except ValueError as msg:
             error_message = f"Error creating device: {msg}"
             _LOGGER.warning(error_message)
-            return await self.internal_error(error_message)
+            return await self.invalid_request(error_message)
 
         response = {
             "status": "success",


### PR DESCRIPTION
Fix error message return for trying to create a device with existing ip

Now passes full message back to front end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling by changing the response for invalid requests in device management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->