### PR TITLE
Fix DDP connections error to warn once

### DIFF
--- a/ledfx/devices/ddp.py
+++ b/ledfx/devices/ddp.py
@@ -64,14 +64,18 @@ class DDPDevice(UDPDevice):
                 self.frame_count,
             )
             if self.connection_warning:
-                _LOGGER.info(f"DDP connection reestablished to {self.config['name']}")
+                _LOGGER.info(
+                    f"DDP connection reestablished to {self.config['name']}"
+                )
                 self.connection_warning = False
         except AttributeError:
             self.activate()
         except OSError as e:
             # print warning only once until it clears
             if not self.connection_warning:
-                _LOGGER.warning(f"Error in DDP connection to {self.config['name']}: {e}")
+                _LOGGER.warning(
+                    f"Error in DDP connection to {self.config['name']}: {e}"
+                )
                 self.connection_warning = True
 
     @staticmethod

--- a/ledfx/devices/ddp.py
+++ b/ledfx/devices/ddp.py
@@ -51,6 +51,7 @@ class DDPDevice(UDPDevice):
         super().__init__(ledfx, config)
         self._device_type = "DDP"
         self.frame_count = 0
+        self.connection_warning = False
 
     def flush(self, data):
         self.frame_count += 1
@@ -62,8 +63,16 @@ class DDPDevice(UDPDevice):
                 data,
                 self.frame_count,
             )
+            if self.connection_warning:
+                _LOGGER.info(f"DDP connection reestablished to {self.config['name']}")
+                self.connection_warning = False
         except AttributeError:
             self.activate()
+        except OSError as e:
+            # print warning only once until it clears
+            if not self.connection_warning:
+                _LOGGER.warning(f"Error in DDP connection to {self.config['name']}: {e}")
+                self.connection_warning = True
 
     @staticmethod
     def send_out(sock, dest, port, data, frame_count):


### PR DESCRIPTION
I have DDP receivers but sometimes the connection drops off or they are simply not powered on.
This breaks the DDP sender on `sock.sendto()` with a stack trace on "OSError: [Errno 65] No route to host" when the router announces the unavailability.

Catching and logging this would spam the log. Deactivation is also not desirable as the device might simply come back.

How do you feel about a solution like this where a single error is logged until the connection comes back?
I could change the logic to using `connection_ok` if that is more in line or more obvious to grasp.

And maybe a timeout could be introduced to repeat the warning on an interval (a value of 10 s to 10 m might seem reasonable). But personally I don't see the benefit of repeated warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved error handling by introducing a one-time connection warning message for device communication issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->