### PR TITLE
Fix: reason return on rest api error

### DIFF
--- a/ledfx/api/__init__.py
+++ b/ledfx/api/__init__.py
@@ -62,10 +62,8 @@ class RestEndpoint(BaseRegistry):
             # _LOGGER.exception(e)
             reason = getattr(e, "args", None)  # Extract the args attribute
             if reason:
-                # Ensure reason is always a string, even if e.args is present
                 reason = str(reason[0]) if reason else str(e)
             else:
-                # Use str(e) to ensure reason is a string, which is always JSON-serializable
                 reason = str(e)
 
             response = {

--- a/ledfx/api/__init__.py
+++ b/ledfx/api/__init__.py
@@ -60,11 +60,14 @@ class RestEndpoint(BaseRegistry):
             )
         except Exception as e:
             # _LOGGER.exception(e)
-            reason = getattr(e, "args", None)
+            reason = getattr(e, "args", None)  # Extract the args attribute
             if reason:
-                reason = reason[0]
+                # Ensure reason is always a string, even if e.args is present
+                reason = str(reason[0]) if reason else str(e)
             else:
-                reason = repr(e)
+                # Use str(e) to ensure reason is a string, which is always JSON-serializable
+                reason = str(e)
+
             response = {
                 "status": "failed",
                 "payload": {

--- a/ledfx/api/__init__.py
+++ b/ledfx/api/__init__.py
@@ -62,7 +62,7 @@ class RestEndpoint(BaseRegistry):
             # _LOGGER.exception(e)
             reason = getattr(e, "args", None)
             if reason:
-                reason = str(reason[0]) if reason else str(e)
+                reason = str(reason[0])
             else:
                 reason = str(e)
 

--- a/ledfx/api/__init__.py
+++ b/ledfx/api/__init__.py
@@ -60,7 +60,7 @@ class RestEndpoint(BaseRegistry):
             )
         except Exception as e:
             # _LOGGER.exception(e)
-            reason = getattr(e, "args", None)  # Extract the args attribute
+            reason = getattr(e, "args", None)
             if reason:
                 reason = str(reason[0]) if reason else str(e)
             else:


### PR DESCRIPTION
As per sentry example

https://ledfx-org.sentry.io/issues/4985345081/?project=4506350233321472&query=release%3Aledfx%402.0.93&referrer=release-issue-stream

If the reason return is complex, the json serialisation in the rest call response can fail.

In this case, setting min freq to 0 by typing in device edit and directly hitting save allows an out of range return

The reason is an object and existing code would pass that on, leading to a generic error in the front and a report back into sentry

This fix hardens the handling of reason when found, and ensures conversion to string

Tested by forcing the zero value in min freq and hitting save, now reports correct reason string to front end. No crash trace triggered in console

Note call to repr(e) was replaced with str(e) due to advice from chatgpt. quoting...

Use of str() Over repr(): While repr(e) is also a string, str(e) is generally more user-friendly and intended for end-user display. This change makes the error message more suitable for inclusion in a JSON response intended for client applications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling by ensuring error reasons are correctly converted to strings for clearer messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->