### PR TITLE
Fix: Gracefully handle loss of openRGB server

### DIFF
--- a/ledfx/api/__init__.py
+++ b/ledfx/api/__init__.py
@@ -60,11 +60,14 @@ class RestEndpoint(BaseRegistry):
             )
         except Exception as e:
             # _LOGGER.exception(e)
-            reason = getattr(e, "args", None)
+            reason = getattr(e, "args", None)  # Extract the args attribute
             if reason:
-                reason = reason[0]
+                # Ensure reason is always a string, even if e.args is present
+                reason = str(reason[0]) if reason else str(e)
             else:
-                reason = repr(e)
+                # Use str(e) to ensure reason is a string, which is always JSON-serializable
+                reason = str(e)
+
             response = {
                 "status": "failed",
                 "payload": {

--- a/ledfx/devices/adalight.py
+++ b/ledfx/devices/adalight.py
@@ -48,7 +48,7 @@ class AdalightDevice(SerialDevice):
             )
 
         except serial.SerialException:
-            _LOGGER.critical(
+            _LOGGER.warning(
                 "Serial Connection Interrupted. Please check connections and ensure your device is functioning correctly."
             )
             self.deactivate()

--- a/ledfx/devices/openrgb.py
+++ b/ledfx/devices/openrgb.py
@@ -107,11 +107,14 @@ class OpenRGB(NetworkedDevice):
             )
         except AttributeError:
             self.activate()
-        except ConnectionAbortedError:
-            _LOGGER.warning(f"Device disconnected: {self.openrgb_device_id}")
+        except (ConnectionAbortedError, ConnectionResetError) as e:
+            _LOGGER.warning(
+                f"Device connection issue ({type(e).__name__}): {e}")
             self._ledfx.events.fire_event(DevicesUpdatedEvent(self.id))
             self._online = False
             self.deactivate()
+        except Exception as e:
+            _LOGGER.error(f"Error sending data to OpenRGB device: {e}")
 
     @staticmethod
     def send_out(sock: socket.socket, data: np.ndarray, device_id: int):

--- a/ledfx/devices/openrgb.py
+++ b/ledfx/devices/openrgb.py
@@ -113,8 +113,6 @@ class OpenRGB(NetworkedDevice):
             self._ledfx.events.fire_event(DevicesUpdatedEvent(self.id))
             self._online = False
             self.deactivate()
-        except Exception as e:
-            _LOGGER.error(f"Error sending data to OpenRGB device: {e}")
 
     @staticmethod
     def send_out(sock: socket.socket, data: np.ndarray, device_id: int):


### PR DESCRIPTION
As per high hitter in sentry

https://ledfx-org.sentry.io/issues/4963969336/?project=4506350233321472&query=&referrer=project-issue-stream

It is possible for openRGB server to crash ( I used to see this often ) or be manually closed

Manually closing can be seen to generate either 

`Device connection issue (ConnectionAbortedError): [WinError 10053] An established connection was aborted by the software in your host machine`

Which was already handled well

OR

`Device connection issue (ConnectionResetError): [WinError 10054] An existing connection was forcibly closed by the remote host`

Which was not handled, and would lead to a dead device in that ledfx session and a crash trace back to sentry

With these changes, the passive warning is logged and the device is disabled with the recycle arrow icon to attempt to reconnect

Relaunching openRGB and starting the server allows device to be reconnected to cleanly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved exception handling in device connectivity to include `ConnectionResetError`, providing more detailed error logging for troubleshooting.
	- Adjusted log level in the `flush` method of `adalight.py` from `critical` to `warning` for better handling of `SerialException` messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->