### PR TITLE
dev: Move renovate to .github and enable automerge for minor/patch updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended", "helpers:automergeMinor"
   ]
+
 }


### PR DESCRIPTION
This pull request moves the renovate configuration file to the .github directory and enables automerge for minor and patch updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Renovate configuration to automatically merge minor version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->