### PR TITLE
E131 crash protection

### DIFF
--- a/ledfx/api/__init__.py
+++ b/ledfx/api/__init__.py
@@ -60,11 +60,14 @@ class RestEndpoint(BaseRegistry):
             )
         except Exception as e:
             # _LOGGER.exception(e)
-            reason = getattr(e, "args", None)
+            reason = getattr(e, "args", None)  # Extract the args attribute
             if reason:
-                reason = reason[0]
+                # Ensure reason is always a string, even if e.args is present
+                reason = str(reason[0]) if reason else str(e)
             else:
-                reason = repr(e)
+                # Use str(e) to ensure reason is a string, which is always JSON-serializable
+                reason = str(e)
+
             response = {
                 "status": "failed",
                 "payload": {

--- a/ledfx/devices/e131.py
+++ b/ledfx/devices/e131.py
@@ -123,7 +123,7 @@ class E131Device(NetworkedDevice):
         """Flush the data to all the E1.31 channels account for spanning universes"""
 
         with self.device_lock:
-            if self._sacn != None:
+            if self._sacn is not None:
                 if data.size != self._config["channel_count"]:
                     raise Exception(
                         f"Invalid buffer size. {data.size} != {self._config['channel_count']}"

--- a/ledfx/devices/e131.py
+++ b/ledfx/devices/e131.py
@@ -3,6 +3,7 @@ import logging
 import numpy as np
 import sacn
 import voluptuous as vol
+import threading
 
 from ledfx.devices import NetworkedDevice
 
@@ -68,37 +69,40 @@ class E131Device(NetworkedDevice):
             self._config["universe_end"] -= 1
 
         self._sacn = None
+        self.device_lock = threading.Lock()
 
     def activate(self):
-        if self._config["ip_address"].lower() == "multicast":
-            multicast = True
-        else:
-            multicast = False
+        with self.device_lock:
+            if self._config["ip_address"].lower() == "multicast":
+                multicast = True
+            else:
+                multicast = False
 
-        if self._sacn:
-            _LOGGER.warning(
-                f"sACN sender already started for device {self.id}"
-            )
+            if self._sacn:
+                _LOGGER.warning(
+                    f"sACN sender already started for device {self.id}"
+                )
 
-        # Configure sACN and start the dedicated thread to flush the buffer
-        # Some variables are immutable and must be called here
-        self._sacn = sacn.sACNsender(source_name=self.name)
+            # Configure sACN and start the dedicated thread to flush the buffer
+            # Some variables are immutable and must be called here
+            self._sacn = sacn.sACNsender(source_name=self.name)
 
-        for universe in range(
-            self._config["universe"], self._config["universe_end"] + 1
-        ):
-            _LOGGER.info(f"sACN activating universe {universe}")
-            self._sacn.activate_output(universe)
-            self._sacn[universe].priority = self._config["packet_priority"]
-            self._sacn[universe].multicast = multicast
-            if not multicast:
-                self._sacn[universe].destination = self.destination
+            for universe in range(
+                self._config["universe"], self._config["universe_end"] + 1
+            ):
+                _LOGGER.info(f"sACN activating universe {universe}")
+                self._sacn.activate_output(universe)
+                self._sacn[universe].priority = self._config["packet_priority"]
+                self._sacn[universe].multicast = multicast
+                if not multicast:
+                    self._sacn[universe].destination = self.destination
 
-        self._sacn.start()
-        self._sacn.manual_flush = True
+            self._sacn.start()
+            self._sacn.manual_flush = True
 
-        _LOGGER.info(f"sACN sender for {self.config['name']} started.")
-        super().activate()
+            _LOGGER.info(f"sACN sender for {self.config['name']} started.")
+            super().activate()
+
 
     def deactivate(self):
         super().deactivate()
@@ -110,72 +114,59 @@ class E131Device(NetworkedDevice):
 
         self.flush(np.zeros(self._config["channel_count"]))
 
-        self._sacn.stop()
-        self._sacn = None
-        _LOGGER.info(f"sACN sender for {self.config['name']} stopped.")
+        with self.device_lock:
+            self._sacn.stop()
+            self._sacn = None
+            _LOGGER.info(f"sACN sender for {self.config['name']} stopped.")
 
     def flush(self, data):
         """Flush the data to all the E1.31 channels account for spanning universes"""
 
-        if not self._sacn:
-            self.activate()
-        if data.size != self._config["channel_count"]:
-            raise Exception(
-                f"Invalid buffer size. {data.size} != {self._config['channel_count']}"
-            )
+        with self.device_lock:
+            if self._sacn != None:
+                if data.size != self._config["channel_count"]:
+                    raise Exception(
+                        f"Invalid buffer size. {data.size} != {self._config['channel_count']}"
+                    )
 
-        data = data.flatten()
-        current_index = 0
-        for universe in range(
-            self._config["universe"], self._config["universe_end"] + 1
-        ):
-            # Calculate offset into the provide input buffer for the channel. There are some
-            # cleaner ways this can be done... This is just the quick and dirty
-            universe_start = (
-                universe - self._config["universe"]
-            ) * self._config["universe_size"]
-            universe_end = (
-                universe - self._config["universe"] + 1
-            ) * self._config["universe_size"]
+                data = data.flatten()
+                current_index = 0
+                for universe in range(
+                    self._config["universe"], self._config["universe_end"] + 1
+                ):
+                    # Calculate offset into the provide input buffer for the channel. There are some
+                    # cleaner ways this can be done... This is just the quick and dirty
+                    universe_start = (
+                        universe - self._config["universe"]
+                    ) * self._config["universe_size"]
+                    universe_end = (
+                        universe - self._config["universe"] + 1
+                    ) * self._config["universe_size"]
 
-            dmx_start = (
-                max(universe_start, self._config["channel_offset"])
-                % self._config["universe_size"]
-            )
-            dmx_end = (
-                min(
-                    universe_end,
-                    self._config["channel_offset"]
-                    + self._config["channel_count"],
-                )
-                % self._config["universe_size"]
-            )
-            if dmx_end == 0:
-                dmx_end = self._config["universe_size"]
+                    dmx_start = (
+                        max(universe_start, self._config["channel_offset"])
+                        % self._config["universe_size"]
+                    )
+                    dmx_end = (
+                        min(
+                            universe_end,
+                            self._config["channel_offset"]
+                            + self._config["channel_count"],
+                        )
+                        % self._config["universe_size"]
+                    )
+                    if dmx_end == 0:
+                        dmx_end = self._config["universe_size"]
 
-            input_start = current_index
-            input_end = current_index + dmx_end - dmx_start
-            current_index = input_end
+                    input_start = current_index
+                    input_end = current_index + dmx_end - dmx_start
+                    current_index = input_end
 
-            dmx_data = np.array(self._sacn[universe].dmx_data)
-            dmx_data[dmx_start:dmx_end] = data[input_start:input_end]
+                    dmx_data = np.array(self._sacn[universe].dmx_data)
+                    dmx_data[dmx_start:dmx_end] = data[input_start:input_end]
 
-            # Because the sACN library checks for data to be of int type, we have to
-            # convert the numpy array into a python list of ints using tolist()
-            self._sacn[universe].dmx_data = dmx_data.clip(0, 255).tolist()
-            # output = dmx_data.clip(0, 255)
+                    # Because the sACN library checks for data to be of int type, we have to
+                    # convert the numpy array into a python list of ints using tolist()
+                    self._sacn[universe].dmx_data = dmx_data.tolist()
 
-        # This is ugly - weird race condition where loading on startup from a device with a short ID results in the sACN thread trying to send data to NoneType.
-        # No idea how to properly handle it - but this stops it breaking and seems to be reasonably resilient. Sorry to whoever stumbles onto it. -Shaun
-        try:
-            self._sacn.flush()
-        except AttributeError:
-            _LOGGER.info(
-                "Attempted to start sACN thread prior to sACN activating. Restarting sACN thread."
-            )
-            self.activate()
-
-        # # Hack up a manual flush of the E1.31 data vs having a background thread
-        # if self._sacn._output_thread._socket:
-        #     for output in list(self._sacn._output_thread._outputs.values()):
-        #         self._sacn._output_thread.send_out(output)
+                self._sacn.flush()


### PR DESCRIPTION
Could reproduce bad manipulations on self._sacn prior in about 1 in 3 shutdowns and about 1 in 5 startups

With a single e131 endpoint!

Footprints are visible in sentry

With this protection, we lock between activate, flush and deactivate as they all manipulate self._sacn

If flush is called prior  to activation or after deactivation it will just return

Might want to rework deactivate a little more, definately need to hammer test

Likely causes

https://ledfx-org.sentry.io/issues/4976833966/?project=4506350233321472&query=&referrer=project-issue-stream

https://ledfx-org.sentry.io/issues/4990067124/?project=4506350233321472&query=&referrer=project-issue-stream

https://ledfx-org.sentry.io/issues/4980344810/?project=4506350233321472&query=&referrer=project-issue-stream

https://ledfx-org.sentry.io/issues/4962664587/?project=4506350233321472&query=&referrer=project-issue-stream

https://ledfx-org.sentry.io/issues/4958446377/?project=4506350233321472&query=&referrer=project-issue-stream


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
    - Improved thread safety in device operations to ensure reliable access to shared resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->