### PR TITLE
Update documentation and re-add frontend development setup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,9 +24,7 @@ You can also join our `Discord`_ where community members show off their projects
 📑 Quick start guide and documentation📖
 ------------------------------------------
 
-Head over to `LedFx Builds`_ to get the latest releases for Windows, Mac and Linux.
-If you are in a hurry, grab the latest Core version for your operating system and off you go.
-For more info on what the different versions do, read the release description on the releases page
+Head over to `releases`_ to get the latest releases for Windows and Mac. For linux, use pip.
 
 **Bleeding edge (Experimental)**
 
@@ -34,7 +32,7 @@ If you want the absolute bleeding edge and are not afraid of using the terminal,
 
 **Documentation**
 
-Documentation for the LedFx-Builds can be found here: `Stable documentation`_
+Documentation for the latest release can be found here: `Stable documentation`_
 
 Documentation built against this repository can be found here: `Latest documentation`_
 
@@ -71,12 +69,11 @@ The below image describes a basic setup - LedFx running on PC, communicating wit
       - Test you can access the WLED web interface from your PC. If so, then you're good to go!
 
 #. **Install LedFx.**
-      - After you have WLED installed on your ESP device, download: `LedFx.exe`_ and install LedFx.
-      - For Mac and Linux `LedFx Builds`_, or see the `installation documentation`_ or `LedFx Guide`_.
+      - For PC and Mac, see our `releases`_, or see the `installation documentation`_ for more information.
+      - For linux, you can use pip to install ledfx - however you may need to install some dependencies first. See the `installation documentation`_ for more information.
 
 #. **Direct computer audio output to LedFx.**
-      - Follow guide, `How to: Enable Stereo Mix in Windows 10`_.
-      - Alternatively use `Voicemeeter`_. `Voicemeeter tutorial`_.
+      - By default on Windows LedFx will attempt to listen to your system audio.
       - More information for `Linux and macOS users here <https://ledfx.readthedocs.io/en/latest/directing_audio.html>`_.
       - Play some music in the background.
 
@@ -114,10 +111,10 @@ License
 
 
 .. _`GPL-3`: https://choosealicense.com/licenses/gpl-3.0/
-.. _`LedFx.exe`: https://github.com/YeonV/LedFx-Builds/releases/latest
+.. _`LedFx.exe`: https://github.com/LedFx/LedFx/releases/latest
 .. _`LedFx Guide`: https://ledfx.readthedocs.io/en/latest/index.html
 .. _`WLED`: https://kno.wled.ge
-.. _`LedFx Builds`: https://github.com/YeonV/LedFx-Builds/releases/latest
+.. _`releases`: https://github.com/LedFx/LedFx/releases/latest
 .. _`Installation documentation`: https://ledfx.readthedocs.io/en/latest/installing.html
 .. _`Stable documentation`: https://ledfx.readthedocs.io/en/stable/
 .. _`Latest documentation`: https://ledfx.readthedocs.io/en/latest/
@@ -125,8 +122,7 @@ License
 .. _`Discord`: https://discord.gg/xyyHEquZKQ
 .. _`Contributors-&-About`: https://ledfx.app/about/
 .. _`How to: Enable Stereo Mix in Windows 10`: https://thegeekpage.com/stereo-mix/
-.. _`Voicemeeter`: https://vb-audio.com/Voicemeeter/index.htm
-.. _`Voicemeeter tutorial`: https://youtu.be/ZXKDzYXS60o?start=27&end=163
+
 
 .. |Build Status| image:: https://github.com/LedFx/LedFx/actions/workflows/ci-build.yml/badge.svg
    :target: https://github.com/LedFx/LedFx/actions/workflows/ci-build.yml

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -133,83 +133,83 @@ macOS
 
 ------------------------------
 
-.. --------------------------
-..    Frontend Development
-.. --------------------------
+--------------------------
+   Frontend Development
+--------------------------
 
-.. Building the LedFx frontend is different from how the core backend is built. The frontend is based on React.js and thus
-.. uses NPM as the core package management.
+Building the LedFx frontend is different from how the core backend is built. The frontend is based on React.js and thus
+uses NPM as the core package management.
 
-.. .. note:: LedFx will need to be running in development mode for everything to work. To enable development mode,
-..           open the ``config.json`` file in the ``.ledfx`` folder and set ``dev_mode: true``)
+.. note:: LedFx will need to be running in development mode for everything to work. To enable development mode,
+          open the ``config.json`` file in the ``.ledfx`` folder and set ``dev_mode: true``)
 
-.. .. _linux-frontend:
+.. _linux-frontend:
 
-.. Linux
-.. -------
+Linux
+-------
 
-.. .. note:: The following instructions assume you have already followed the steps above to :ref:`install the LedFx dev environment <linux-dev>`
+.. note:: The following instructions assume you have already followed the steps above to :ref:`install the LedFx dev environment <linux-dev>`
 
-.. To get started, first install npm and all the requirements:
+To get started, first install yarn and all the requirements:
 
-.. **1.** Start in the LedFx repo directory:
+**1.** Start in the LedFx repo directory:
 
-.. .. code:: console
+.. code:: console
 
-..     $ pip install yarn
-..     $ cd frontend
-..     $ yarn
+    $ pip install yarn
+    $ cd frontend
+    $ yarn
 
-.. The easiest way to test and validate your changes is to run a watcher that will automatically rebuild as you save and then
-.. just leave LedFx running in a separate command window.
+The easiest way to test and validate your changes is to run a watcher that will automatically rebuild as you save and then
+just leave LedFx running in a separate command window.
 
-.. **2.** Start LedFx in development mode and start the watcher:
+**2.** Start LedFx in development mode and start the watcher:
 
-.. .. code:: console
+.. code:: console
 
-..     $ python3 ledfx
-..     $ yarn start
+    $ poetry shell ledfx
+    $ yarn start
 
-.. At that point any change you make to the frontend will be recompiled and after a browser refresh LedFx will pick up the
-.. new files. After development and testing you will need to run a full build to generate the appropriate distribution files
-.. prior to submitting any changes.
+At that point any change you make to the frontend will be recompiled and after a browser refresh LedFx will pick up the
+new files. After development and testing you will need to run a full build to generate the appropriate distribution files
+prior to submitting any changes.
 
-.. **3.** When you are finished with your changes, build the frontend:
+**3.** When you are finished with your changes, build the frontend:
 
-.. .. code:: console
+.. code:: console
 
-..     $ yarn build
+    $ yarn build
 
-.. .. _macos-frontend:
+.. _macos-frontend:
 
-.. macOS
-.. -------
+macOS
+-------
 
-.. .. note:: The following instructions assume you have already followed the steps above to :ref:`install the LedFx dev environment <macos-dev>`
+.. note:: The following instructions assume you have already followed the steps above to :ref:`install the LedFx dev environment <macos-dev>`
 
-.. **1.** Install nodejs and NPM requirements using `homebrew`_:
+**1.** Install nodejs and NPM requirements using `homebrew`_:
 
-.. .. code:: console
+.. code:: console
 
-..     $ brew install nodejs
-..     $ brew install yarn
-..     $ cd ~/frontend
-..     $ yarn
+    $ brew install nodejs
+    $ brew install yarn
+    $ cd ~/frontend
+    $ yarn
 
-.. **2.** Start LedFx in developer mode and start the NPM watcher:
+**2.** Start LedFx in developer mode and start the NPM watcher:
 
-.. .. code:: console
+.. code:: console
 
-..     $ python3 ledfx
-..     $ yarn start
+    $ poetry shell ledfx
+    $ yarn start
 
-.. **3.** When you are finished with your changes, build the frontend:
+**3.** When you are finished with your changes, build the frontend:
 
-.. .. code:: console
+.. code:: console
 
-..     $ yarn build
+    $ yarn build
 
-.. ------------------------------
+------------------------------
 
 .. include:: README.rst
 

--- a/docs/directing_audio.rst
+++ b/docs/directing_audio.rst
@@ -81,6 +81,7 @@ Windows
 =======
 Tested on Windows 10 (21H2)
 
+
 Windows have output devices and input devices. LedFx works processing an input device.
 
 .. rubric:: Stereo Mix (analog output)
@@ -156,3 +157,5 @@ Webaudio
 When creating a new webaudio device, you may see, below the name entering field, an ability to choose between ws-v1 and ws-v2. Unless something does not work, you should always use ws-v2.
 The reason for that is ws-v2 using significantly less bandwidth. The ws-v1 setting sends audio data (which is float type) as plain text, meaning that for each number a byte is sent (can be up to 6 bytes per number), even though
 the audio data being sampled is only 16-bit. The ws-v2 setting instead sends the audio data as base64, which is a binary data encoding method, greatly reducing the used bandwidth.
+
+


### PR DESCRIPTION
This pull request updates the documentation and re-adds the frontend development setup. It includes changes to the Windows setup instructions, installation documentation, and links to the latest releases for Windows and Mac. Additionally, it provides instructions for Linux users to install ledfx using pip and mentions the need to install dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the `README.rst` with new links for the latest releases and detailed installation instructions for Windows, Mac, and Linux. Also, provided updated guidance for setting up LedFx with WLED and system audio.
	- Made formatting and textual adjustments in the `developer.rst` document, focusing on building the LedFx frontend on macOS and Linux.
	- Added extra blank lines for clarity in the `directing_audio.rst`, specifically in the Windows section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->