### PR TITLE
Fix: Update preset categories in store and API - allow user preset selection

### DIFF
--- a/frontend/src/components/Dialogs/SceneDialogs/EditSceneDialog.tsx
+++ b/frontend/src/components/Dialogs/SceneDialogs/EditSceneDialog.tsx
@@ -50,7 +50,7 @@ const EditSceneDialog = () => {
   const [midiActivate, setMIDIActivate] = useState('')
   const [invalid, setInvalid] = useState(false)
   const [lp, setLp] = useState(undefined as any)
-  // const [user_presets, setUp] = useState(undefined as any)
+  const [user_presets, setUp] = useState(undefined as any)
   const [disabledPSelector, setDisabledPSelector] = useState([] as string[])
   const [scVirtualsToIgnore, setScVirtualsToIgnore] = useState<string[]>([])
   const medium = useMediaQuery('(max-width: 920px )')
@@ -76,7 +76,7 @@ const EditSceneDialog = () => {
   const getImage = useStore((state) => state.getImage)
   const [imageData, setImageData] = useState(null)
 
-  // const getFullConfig = useStore((state) => state.getFullConfig)
+  const getFullConfig = useStore((state) => state.getFullConfig)
 
   const toggletSceneActiveTag = useStore(
     (state) => state.ui.toggletSceneActiveTag
@@ -216,16 +216,16 @@ const EditSceneDialog = () => {
   }
 
   useEffect(() => {
-    // if (open) getFullConfig()
+    if (open) getFullConfig()
 
     if (open)
       getLedFxPresets().then((ledfx_presets) => {
         setLp(ledfx_presets)
       })
-    if (open) getUserPresets()
-    // .then((u_presets) => {
-    //     // setUp(u_presets)
-    //   })
+    if (open)
+      getUserPresets().then((u_presets) => {
+        setUp(u_presets)
+      })
   }, [open])
   useEffect(() => {
     if (open) activateScene(data.name?.toLowerCase().replaceAll(' ', '-'))
@@ -260,8 +260,6 @@ const EditSceneDialog = () => {
     }
   }, [])
 
-  const { user_presets } = useStore((state) => state.config)
-
   const renderPresets = (ledfx_presets: any, dev: string, effectId: string) => {
     if (ledfx_presets) {
       const ledfxPreset =
@@ -295,7 +293,7 @@ const EditSceneDialog = () => {
         <Select
           defaultValue={ledfxPreset || userPreset}
           onChange={(e) => {
-            let category = 'default_presets'
+            let category = 'ledfx_presets'
             if (
               user_presets &&
               user_presets[effectId] &&
@@ -304,7 +302,7 @@ const EditSceneDialog = () => {
                 e.target.value
               )
             ) {
-              category = 'custom_presets'
+              category = 'user_presets'
             }
 
             return (
@@ -349,7 +347,7 @@ const EditSceneDialog = () => {
         <Select
           defaultValue="Not saved as Preset"
           onChange={(e) => {
-            let category = 'default_presets'
+            let category = 'ledfx_presets'
             if (
               user_presets &&
               user_presets[effectId] &&
@@ -358,7 +356,7 @@ const EditSceneDialog = () => {
                 e.target.value
               )
             ) {
-              category = 'custom_presets'
+              category = 'user_presets'
             }
 
             return (

--- a/frontend/src/components/Dialogs/SceneDialogs/EditSceneDialog.tsx
+++ b/frontend/src/components/Dialogs/SceneDialogs/EditSceneDialog.tsx
@@ -49,8 +49,8 @@ const EditSceneDialog = () => {
   const [payload, setPayload] = useState('')
   const [midiActivate, setMIDIActivate] = useState('')
   const [invalid, setInvalid] = useState(false)
-  const [lp, setLp] = useState(undefined as any)
-  const [user_presets, setUp] = useState({} as any)
+  const [ledfx_presets, setLedFxPresets] = useState({} as any)
+  const [user_presets, setUserPresets] = useState({} as any)
   const [disabledPSelector, setDisabledPSelector] = useState([] as string[])
   const [scVirtualsToIgnore, setScVirtualsToIgnore] = useState<string[]>([])
   const medium = useMediaQuery('(max-width: 920px )')
@@ -216,16 +216,11 @@ const EditSceneDialog = () => {
   }
 
   useEffect(() => {
-    if (open) getFullConfig()
-
-    if (open)
-      getLedFxPresets().then((ledfx_presets) => {
-        setLp(ledfx_presets)
-      })
-    if (open)
-      getUserPresets().then((u_presets) => {
-        setUp(u_presets)
-      })
+    if (open) {
+      getFullConfig()
+      getLedFxPresets().then(setLedFxPresets)
+      getUserPresets().then(setUserPresets)
+    }
   }, [open])
   useEffect(() => {
     if (open) activateScene(data.name?.toLowerCase().replaceAll(' ', '-'))
@@ -260,15 +255,20 @@ const EditSceneDialog = () => {
     }
   }, [])
 
-  const renderPresets = (ledfx_presets: any, dev: string, effectId: string) => {
-    if (ledfx_presets) {
+  const renderPresets = (
+    current_ledfx_presets: any,
+    dev: string,
+    effectId: string
+  ) => {
+    if (current_ledfx_presets) {
       const ledfxPreset =
-        ledfx_presets &&
-        Object.keys(ledfx_presets).length > 0 &&
-        Object.keys(ledfx_presets).find(
+        current_ledfx_presets &&
+        Object.keys(current_ledfx_presets).length > 0 &&
+        Object.keys(current_ledfx_presets).find(
           (k) =>
-            JSON.stringify(ordered((ledfx_presets[k] as any).config)) ===
-            JSON.stringify(ordered(sVirtuals[dev].config))
+            JSON.stringify(
+              ordered((current_ledfx_presets[k] as any).config)
+            ) === JSON.stringify(ordered(sVirtuals[dev].config))
         )
       const userPresets =
         user_presets[effectId] &&
@@ -325,9 +325,11 @@ const EditSceneDialog = () => {
               scVirtualsToIgnore.indexOf(dev) > -1 ? 'line-through' : ''
           }}
         >
-          {ledfx_presets && <ListSubheader>LedFx Presets</ListSubheader>}
-          {ledfx_presets &&
-            Object.keys(ledfx_presets)
+          {current_ledfx_presets && (
+            <ListSubheader>LedFx Presets</ListSubheader>
+          )}
+          {current_ledfx_presets &&
+            Object.keys(current_ledfx_presets)
               .sort((k) => (k === 'reset' ? -1 : 1))
               .map((ke, i) => (
                 <MenuItem key={ke + i} value={ke}>
@@ -372,9 +374,11 @@ const EditSceneDialog = () => {
           disableUnderline
         >
           <MenuItem value="Not saved as Preset">Not saved as Preset</MenuItem>
-          {ledfx_presets && <ListSubheader>LedFx Presets</ListSubheader>}
-          {ledfx_presets &&
-            Object.keys(ledfx_presets)
+          {current_ledfx_presets && (
+            <ListSubheader>LedFx Presets</ListSubheader>
+          )}
+          {current_ledfx_presets &&
+            Object.keys(current_ledfx_presets)
               .sort((k) => (k === 'reset' ? -1 : 1))
               .map((ke, i) => (
                 <MenuItem key={ke + i} value={ke}>
@@ -941,7 +945,7 @@ const EditSceneDialog = () => {
                     dev
                   )}
                   <span style={{ width: 180, textAlign: 'right' }}>
-                    {lp &&
+                    {ledfx_presets &&
                       renderPresets(
                         lp[
                           scenes[data.name?.toLowerCase().replaceAll(' ', '-')]

--- a/frontend/src/components/Dialogs/SceneDialogs/EditSceneDialog.tsx
+++ b/frontend/src/components/Dialogs/SceneDialogs/EditSceneDialog.tsx
@@ -947,7 +947,7 @@ const EditSceneDialog = () => {
                   <span style={{ width: 180, textAlign: 'right' }}>
                     {ledfx_presets &&
                       renderPresets(
-                        lp[
+                        ledfx_presets[
                           scenes[data.name?.toLowerCase().replaceAll(' ', '-')]
                             .virtuals[dev].type
                         ],

--- a/frontend/src/components/Dialogs/SceneDialogs/EditSceneDialog.tsx
+++ b/frontend/src/components/Dialogs/SceneDialogs/EditSceneDialog.tsx
@@ -50,7 +50,7 @@ const EditSceneDialog = () => {
   const [midiActivate, setMIDIActivate] = useState('')
   const [invalid, setInvalid] = useState(false)
   const [lp, setLp] = useState(undefined as any)
-  const [user_presets, setUp] = useState(undefined as any)
+  const [user_presets, setUp] = useState({} as any)
   const [disabledPSelector, setDisabledPSelector] = useState([] as string[])
   const [scVirtualsToIgnore, setScVirtualsToIgnore] = useState<string[]>([])
   const medium = useMediaQuery('(max-width: 920px )')

--- a/frontend/src/pages/Device/Presets.tsx
+++ b/frontend/src/pages/Device/Presets.tsx
@@ -187,7 +187,7 @@ const PresetsCard = ({ virtual, effectType, presets, style }: any) => {
     if (list && !Object.keys(list)?.length) {
       return (
         <Button style={{ margin: '1rem 0 0.5rem 1rem' }} size="medium" disabled>
-          No {CATEGORY === 'default_presets' ? '' : 'Custom'} Presets
+          No {CATEGORY === 'ledfx_presets' ? '' : 'Custom'} Presets
         </Button>
       )
     }
@@ -202,7 +202,7 @@ const PresetsCard = ({ virtual, effectType, presets, style }: any) => {
         //   console.log(preset, diff(virtual.effect.config, list[preset].config))
         return (
           <Grid item key={preset}>
-            {CATEGORY !== 'default_presets' ? (
+            {CATEGORY !== 'ledfx_presets' ? (
               <PresetButton
                 buttonColor={
                   JSON.stringify(virtual.effect.config) ===
@@ -254,7 +254,7 @@ const PresetsCard = ({ virtual, effectType, presets, style }: any) => {
       const promises = Object.keys(cloudEffects).flatMap((effect) => {
         return cloudEffects[effect].map((p: any, ind: number) => {
           return new Promise((resolve) => {
-            if (!presets.custom_presets[p.effect.ledfx_id]) {
+            if (!presets.user_presets[p.effect.ledfx_id]) {
               setTimeout(() => {
                 handleCloudPresets(p, true)
                 resolve(null)
@@ -290,11 +290,11 @@ const PresetsCard = ({ virtual, effectType, presets, style }: any) => {
       />
       <CardContent>
         <Grid spacing={2} container>
-          {renderPresetsButton(presets?.default_presets, 'default_presets')}
+          {renderPresetsButton(presets?.ledfx_presets, 'ledfx_presets')}
         </Grid>
         <Divider style={{ margin: '1rem 0' }} />
         <Grid spacing={2} container>
-          {renderPresetsButton(presets?.custom_presets, 'custom_presets')}
+          {renderPresetsButton(presets?.user_presets, 'user_presets')}
           <Grid item>
             <Popover
               popoverStyle={{ padding: '0.5rem' }}
@@ -307,25 +307,25 @@ const PresetsCard = ({ virtual, effectType, presets, style }: any) => {
                 <TextField
                   onKeyDown={(e: any) => e.key === 'Enter' && handleAddPreset()}
                   error={
-                    presets.default_presets &&
-                    (Object.keys(presets.default_presets).indexOf(name) > -1 ||
-                      Object.values(presets.default_presets).filter(
+                    presets.ledfx_presets &&
+                    (Object.keys(presets.ledfx_presets).indexOf(name) > -1 ||
+                      Object.values(presets.ledfx_presets).filter(
                         (p: any) => p.name === name
                       ).length > 0)
                   }
                   size="small"
                   id="presetNameInput"
                   label={
-                    presets.default_presets &&
-                    (Object.keys(presets.default_presets).indexOf(name) > -1 ||
-                      Object.values(presets.default_presets).filter(
+                    presets.ledfx_presets &&
+                    (Object.keys(presets.ledfx_presets).indexOf(name) > -1 ||
+                      Object.values(presets.ledfx_presets).filter(
                         (p: any) => p.name === name
                       ).length > 0)
                       ? 'Default presets are readonly'
-                      : presets.custom_presets &&
-                          (Object.keys(presets.custom_presets).indexOf(name) >
+                      : presets.user_presets &&
+                          (Object.keys(presets.user_presets).indexOf(name) >
                             -1 ||
-                            Object.values(presets.custom_presets).filter(
+                            Object.values(presets.user_presets).filter(
                               (p: any) => p.name === name
                             ).length > 0)
                         ? 'Preset already exsisting'
@@ -336,11 +336,11 @@ const PresetsCard = ({ virtual, effectType, presets, style }: any) => {
                   onChange={(e) => {
                     setName(e.target.value)
                     if (
-                      presets.custom_presets &&
-                      (Object.keys(presets.custom_presets).indexOf(
+                      presets.user_presets &&
+                      (Object.keys(presets.user_presets).indexOf(
                         e.target.value
                       ) > -1 ||
-                        Object.values(presets.custom_presets).filter(
+                        Object.values(presets.user_presets).filter(
                           (p: any) => p.name === e.target.value
                         ).length > 0)
                     ) {
@@ -363,9 +363,9 @@ const PresetsCard = ({ virtual, effectType, presets, style }: any) => {
               }
               confirmDisabled={
                 name.length === 0 ||
-                (presets.default_presets &&
-                  (Object.keys(presets.default_presets).indexOf(name) > -1 ||
-                    Object.values(presets.default_presets).filter(
+                (presets.ledfx_presets &&
+                  (Object.keys(presets.ledfx_presets).indexOf(name) > -1 ||
+                    Object.values(presets.ledfx_presets).filter(
                       (p: any) => p.name === name
                     ).length > 0)) ||
                 !valid

--- a/frontend/src/pages/Home/BladeScene.tsx
+++ b/frontend/src/pages/Home/BladeScene.tsx
@@ -39,7 +39,7 @@ const BladeScene = ({ onClick }: { onClick: () => void }) => {
     // if (noAuto) {
     large.map((v) => {
       setEffect(v, 'melt', {}, true)
-      return activatePreset(v, 'default_presets', 'melt', 'purple-red')
+      return activatePreset(v, 'ledfx_presets', 'melt', 'purple-red')
     })
     medium.map((v, _i) => {
       setEffect(v, 'blade_power_plus', {}, true)
@@ -47,7 +47,7 @@ const BladeScene = ({ onClick }: { onClick: () => void }) => {
       //   updateEffect(v, 'blade_power_plus', { flip: true }, false)
       return activatePreset(
         v,
-        'default_presets',
+        'ledfx_presets',
         'blade_power_plus',
         'purplered-bass'
       )
@@ -57,7 +57,7 @@ const BladeScene = ({ onClick }: { onClick: () => void }) => {
       setEffect(v, 'blade_power_plus', {}, true)
       return activatePreset(
         v,
-        'default_presets',
+        'ledfx_presets',
         'blade_power_plus',
         'orange-hi-hat'
       )
@@ -68,7 +68,7 @@ const BladeScene = ({ onClick }: { onClick: () => void }) => {
         (a, b) => virtuals[a].pixel_count - virtuals[b].pixel_count
       )[0]
       setEffect(v, 'blade_power_plus', {}, true)
-      activatePreset(v, 'default_presets', 'blade_power_plus', 'orange-hi-hat')
+      activatePreset(v, 'ledfx_presets', 'blade_power_plus', 'orange-hi-hat')
     }
     // Use medium as large
     if (Object.keys(large).length === 0 && Object.keys(medium).length > 2) {
@@ -76,7 +76,7 @@ const BladeScene = ({ onClick }: { onClick: () => void }) => {
         (a, b) => virtuals[a].pixel_count - virtuals[b].pixel_count
       )[Object.keys(medium).length - 1]
       setEffect(v, 'melt', {}, true)
-      activatePreset(v, 'default_presets', 'melt', 'purple-red')
+      activatePreset(v, 'ledfx_presets', 'melt', 'purple-red')
     }
 
     // Use large as smalls
@@ -85,7 +85,7 @@ const BladeScene = ({ onClick }: { onClick: () => void }) => {
         (a, b) => virtuals[a].pixel_count - virtuals[b].pixel_count
       )[0]
       setEffect(v, 'blade_power_plus', {}, true)
-      activatePreset(v, 'default_presets', 'blade_power_plus', 'orange-hi-hat')
+      activatePreset(v, 'ledfx_presets', 'blade_power_plus', 'orange-hi-hat')
     }
     // Use large as medium
     if (Object.keys(medium).length === 0 && Object.keys(large).length > 2) {
@@ -93,7 +93,7 @@ const BladeScene = ({ onClick }: { onClick: () => void }) => {
         (a, b) => virtuals[a].pixel_count - virtuals[b].pixel_count
       )[1]
       setEffect(v, 'blade_power_plus', {}, true)
-      activatePreset(v, 'default_presets', 'blade_power_plus', 'purplered-bass')
+      activatePreset(v, 'ledfx_presets', 'blade_power_plus', 'purplered-bass')
     }
     if (Object.keys(matrix).length > 0) {
       matrix.map((v) => {

--- a/frontend/src/store/api/storeConfig.tsx
+++ b/frontend/src/store/api/storeConfig.tsx
@@ -30,8 +30,8 @@ export interface IPreset {
 }
 export interface IPresets {
   effect: string
-  default_presets: Record<string, IPreset>
-  custom_presets: Record<string, IPreset>
+  ledfx_presets: Record<string, IPreset>
+  user_presets: Record<string, IPreset>
 }
 
 export interface IDevice {

--- a/ledfx/api/presets.py
+++ b/ledfx/api/presets.py
@@ -59,8 +59,8 @@ class PresetsEndpoint(RestEndpoint):
         response = {
             "status": "success",
             "effect": effect_id,
-            "default_presets": default,
-            "custom_presets": custom,
+            "ledfx_presets": default,
+            "user_presets": custom,
         }
         return await self.bare_request_success(response)
 

--- a/ledfx/api/virtual_presets.py
+++ b/ledfx/api/virtual_presets.py
@@ -56,8 +56,8 @@ class VirtualPresetsEndpoint(RestEndpoint):
             "status": "success",
             "virtual": virtual_id,
             "effect": effect_id,
-            "default_presets": default,
-            "custom_presets": custom,
+            "ledfx_presets": default,
+            "user_presets": custom,
         }
         return await self.bare_request_success(response)
 
@@ -102,15 +102,10 @@ class VirtualPresetsEndpoint(RestEndpoint):
                 f'Required attributes {", ".join(missing_attributes)} were not provided'
             )
 
-        if category not in ["default_presets", "custom_presets"]:
+        if category not in ["ledfx_presets", "user_presets"]:
             return await self.invalid_request(
-                f'Category {category} is not "default_presets" or "custom_presets"'
+                f'Category {category} is not "ledfx_presets" or "user_presets"'
             )
-
-        if category == "default_presets":
-            category = "ledfx_presets"
-        else:
-            category = "user_presets"
 
         if category == "ledfx_presets" and preset_id == "reset":
             effect_config = generate_default_config(
@@ -160,7 +155,7 @@ class VirtualPresetsEndpoint(RestEndpoint):
 
     async def post(self, virtual_id, request) -> web.Response:
         """
-        Save configuration of active virtual effect as a custom preset.
+        Save configuration of active virtual effect as a user preset.
 
         Args:
             virtual_id (str): The ID of the virtual effect.


### PR DESCRIPTION
This pull request updates the preset categories in the store and API. It renames the "default_presets" category to "ledfx_presets" and the "custom_presets" category to "user_presets". This change ensures consistency and clarity in the codebase.

Will likely break downstream consumers of API but... oh well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced user presets functionality, allowing users to save and manage their own effect configurations.
- **Refactor**
	- Updated preset categorization to differentiate between LedFx presets and user presets across the application.
	- Improved preset activation logic for enhanced user experience.
- **Bug Fixes**
	- Fixed issues related to preset handling and display, ensuring accurate representation of available presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->