### PR TITLE
Fix conditional check for openRGB devices

### DIFF
--- a/frontend/src/store/api/storeActions.tsx
+++ b/frontend/src/store/api/storeActions.tsx
@@ -11,7 +11,7 @@ import nameToIcon from '../../utils/nameToIcon'
 const storeActions = (set: any) => ({
   scanForOpenRgbDevices: async () => {
     const resp = await Ledfx('/api/find_openrgb', 'GET', {})
-    if (resp && resp.status === 'success') {
+    if (resp && resp.status === 'success' && resp.devices) {
       set(
         produce((state: IStore) => {
           state.openRgbDevices = resp.devices as IOpenRgbDevice[]


### PR DESCRIPTION
Previously this would result in uncaught errors when there was not a functioning openrgb server.

Now we display a nice snackbar instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved device scanning by adding an extra validation step to ensure device presence before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->