### PR TITLE
Add environment for approval prior to release creation/publishing

### DIFF
--- a/.github/workflows/test-build-binaries.yml
+++ b/.github/workflows/test-build-binaries.yml
@@ -326,6 +326,7 @@ jobs:
   create-release:
     name: Create GitHub Release
     if: startsWith(github.ref, 'refs/tags/')
+    environment: production
     runs-on: macos-latest
     needs: [run-ledfx-windows, run-ledfx-osx, run-ledfx-osx-m1, install-from-wheel, install-from-sdist]
     steps:
@@ -498,7 +499,7 @@ jobs:
           ledfx --ci-smoke-test -vv
   publish:
     name: Publish LedFx to PyPi
-    needs: [install-from-wheel, install-from-sdist, run-ledfx-windows, run-ledfx-osx, run-ledfx-osx-m1]
+    needs: [install-from-wheel, install-from-sdist, create-release]
     if: github.event_name == 'workflow_dispatch' ||  startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
@@ -536,7 +537,7 @@ jobs:
           password: ${{ secrets.PYPI_API_TOKEN }}
   notify-sentry:
       name: Notify Sentry of Release
-      needs: [publish]
+      needs: [create-release]
       if: startsWith(github.ref, 'refs/tags/')
       runs-on: ubuntu-latest
       steps:


### PR DESCRIPTION
This pull request adds an environment for approval prior to creating and publishing a release. It ensures that the release process is properly reviewed and approved before it is made available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the release process by adjusting job dependencies and setting the production environment for releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->