### PR TITLE
Harden launchpad against loss of device

### DIFF
--- a/ledfx/devices/launchpad.py
+++ b/ledfx/devices/launchpad.py
@@ -132,10 +132,12 @@ class LaunchpadDevice(MidiDevice):
 
     def flush(self, data):
         success = self.lp.flush(
-                data, self._config["alpha_options"], self._config["diag"]
-            )
+            data, self._config["alpha_options"], self._config["diag"]
+        )
         if not success:
-            _LOGGER.warning(f"Error in Launchpad {self.lp_name} flush, setting offline")
+            _LOGGER.warning(
+                f"Error in Launchpad {self.lp_name} flush, setting offline"
+            )
             self.set_offline()
 
     def activate(self):
@@ -145,13 +147,17 @@ class LaunchpadDevice(MidiDevice):
                 self._online = True
                 super().activate()
             else:
-                _LOGGER.warning("Launchpad variant not supported or not connected")
+                _LOGGER.warning(
+                    "Launchpad variant not supported or not connected"
+                )
                 self.set_offline()
 
     def set_class(self):
         self.lp = launchpad.Launchpad()
         self.lp_name = self.validate_launchpad()
-        _LOGGER.info(f"Launchpad {self.lp_name} device class: {self.lp.__class__.__name__}")
+        _LOGGER.info(
+            f"Launchpad {self.lp_name} device class: {self.lp.__class__.__name__}"
+        )
 
     def deactivate(self):
         if self.lp is not None:

--- a/ledfx/devices/launchpad.py
+++ b/ledfx/devices/launchpad.py
@@ -127,21 +127,31 @@ class LaunchpadDevice(MidiDevice):
     def __init__(self, ledfx, config):
         super().__init__(ledfx, config)
         self.lp = None
+        self.lp_name = "unknown"
         _LOGGER.info("Launchpad device created")
 
     def flush(self, data):
-        self.lp.flush(
-            data, self._config["alpha_options"], self._config["diag"]
-        )
+        success = self.lp.flush(
+                data, self._config["alpha_options"], self._config["diag"]
+            )
+        if not success:
+            _LOGGER.warning(f"Error in Launchpad {self.lp_name} flush, setting offline")
+            self.set_offline()
 
     def activate(self):
         self.set_class()
-        super().activate()
+        if self.lp is not None:
+            if self.lp.supported:
+                self._online = True
+                super().activate()
+            else:
+                _LOGGER.warning("Launchpad variant not supported or not connected")
+                self.set_offline()
 
     def set_class(self):
         self.lp = launchpad.Launchpad()
-        self.validate_launchpad()
-        _LOGGER.info(f"Launchpad device class: {self.lp.__class__.__name__}")
+        self.lp_name = self.validate_launchpad()
+        _LOGGER.info(f"Launchpad {self.lp_name} device class: {self.lp.__class__.__name__}")
 
     def deactivate(self):
         if self.lp is not None:

--- a/ledfx/devices/launchpad_lib.py
+++ b/ledfx/devices/launchpad_lib.py
@@ -17,8 +17,8 @@ import time
 import timeit
 
 import rtmidi
-from rtmidi.midiutil import open_midiinput, open_midioutput
 from rtmidi import SystemError as RtmidiSystemError
+from rtmidi.midiutil import open_midiinput, open_midioutput
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1578,6 +1578,7 @@ class LaunchpadLPX(LaunchpadPro):
             self.lasttime = nowint
 
         return True
+
 
 # ==========================================================================
 # CLASS LaunchpadMiniMk3

--- a/ledfx/devices/launchpad_lib.py
+++ b/ledfx/devices/launchpad_lib.py
@@ -18,6 +18,7 @@ import timeit
 
 import rtmidi
 from rtmidi.midiutil import open_midiinput, open_midioutput
+from rtmidi import SystemError as RtmidiSystemError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -194,6 +195,7 @@ class LaunchpadBase:
         self.frame = 0
         self.fps = 0
         self.do_once = True
+        self.supported = False
 
     def flush(self, data, alpha, diag):
         if self.do_once:
@@ -201,6 +203,7 @@ class LaunchpadBase:
                 f"flush not implemented for {self.__class__.__name__}"
             )
             self.do_once = False
+        return False
 
     def __del__(self):
         self.Close()
@@ -719,6 +722,10 @@ class LaunchpadMk2(LaunchpadPro):
         ),
     ]
 
+    def __init__(self):
+        super().__init__()
+        self.supported = True
+
     # Overrides "LaunchpadPro" method
     def Open(self, number=0, name="Mk2"):
         return super().Open(number=number, name=name)
@@ -809,8 +816,13 @@ class LaunchpadMk2(LaunchpadPro):
                 pgm_mode_pos += 1
             self.midi.RawWriteSysEx(send_buffer)
 
-        except RuntimeError:
-            _LOGGER.error("Error in Launchpad Mk2 handling")
+        except RuntimeError as e:
+            _LOGGER.warning(f"Flush ({type(e).__name__}): {e}")
+            return False
+
+        except RtmidiSystemError as e:
+            _LOGGER.warning(f"Flush ({type(e).__name__}): {e}")
+            return False
 
         if diag:
             now = timeit.default_timer()
@@ -823,6 +835,8 @@ class LaunchpadMk2(LaunchpadPro):
                 self.frame += 1
             _LOGGER.info(f"Launchpad Mk2 flush {self.fps} : {now - start}")
             self.lasttime = nowint
+
+        return True
 
 
 # ==========================================================================
@@ -1324,6 +1338,10 @@ class LaunchpadLPX(LaunchpadPro):
 
     device_id = 12
 
+    def __init__(self):
+        super().__init__()
+        self.supported = True
+
     # -------------------------------------------------------------------------------------
     # Overrides "LaunchpadPro" method
     def Open(self, number=0, name="AUTO"):
@@ -1539,8 +1557,13 @@ class LaunchpadLPX(LaunchpadPro):
                 pgm_mode_pos += 1
             self.midi.RawWriteSysEx(send_buffer)
 
-        except RuntimeError:
-            _LOGGER.error("Error in LaunchpadLPX handling")
+        except RuntimeError as e:
+            _LOGGER.warning(f"Flush ({type(e).__name__}): {e}")
+            return False
+
+        except RtmidiSystemError as e:
+            _LOGGER.warning(f"Flush ({type(e).__name__}): {e}")
+            return False
 
         if diag:
             now = timeit.default_timer()
@@ -1554,6 +1577,7 @@ class LaunchpadLPX(LaunchpadPro):
             _LOGGER.info(f"Launchpad X flush {self.fps} : {now - start}")
             self.lasttime = nowint
 
+        return True
 
 # ==========================================================================
 # CLASS LaunchpadMiniMk3
@@ -2013,6 +2037,10 @@ class LaunchpadS(LaunchpadPro):
 
     buffer0 = True
 
+    def __init__(self):
+        super().__init__()
+        self.supported = True
+
     def Open(self, number=0, name="Launchpad S"):
         retval = super().Open(number=number, name=name)
         if retval is True:
@@ -2074,30 +2102,39 @@ class LaunchpadS(LaunchpadPro):
 
         send_status = True
 
-        for index, map in enumerate(self.pixel_map2):
-            if (index % 2) == 0:
-                out1 = self.scolmap(data[map][0], data[map][1])
-            else:
-                out2 = self.scolmap(data[map][0], data[map][1])
-
-                if alpha:
-                    if send_status:
-                        self.midi.RawWrite(0x92, out1, out2)
-                        send_status = False
-                    else:
-                        self.midi.RawWriteTwo(out1, out2)
+        try:
+            for index, map in enumerate(self.pixel_map2):
+                if (index % 2) == 0:
+                    out1 = self.scolmap(data[map][0], data[map][1])
                 else:
-                    self.midi.RawWrite(0x92, out1, out2)
+                    out2 = self.scolmap(data[map][0], data[map][1])
 
-        if self.buffer0:
-            # Display buffer 0, and write to buffer 1
-            self.midi.RawWrite(0xB0, 0x00, 0x24)
-        else:
-            # Display buffer 1, and write to buffer 0
-            self.midi.RawWrite(0xB0, 0x00, 0x21)
+                    if alpha:
+                        if send_status:
+                            self.midi.RawWrite(0x92, out1, out2)
+                            send_status = False
+                        else:
+                            self.midi.RawWriteTwo(out1, out2)
+                    else:
+                        self.midi.RawWrite(0x92, out1, out2)
 
-        # and flip buffers
-        self.buffer0 = not self.buffer0
+            if self.buffer0:
+                # Display buffer 0, and write to buffer 1
+                self.midi.RawWrite(0xB0, 0x00, 0x24)
+            else:
+                # Display buffer 1, and write to buffer 0
+                self.midi.RawWrite(0xB0, 0x00, 0x21)
+
+            # and flip buffers
+            self.buffer0 = not self.buffer0
+
+        except RuntimeError as e:
+            _LOGGER.warning(f"Flush ({type(e).__name__}): {e}")
+            return False
+
+        except RtmidiSystemError as e:
+            _LOGGER.warning(f"Flush ({type(e).__name__}): {e}")
+            return False
 
         if diag:
             now = timeit.default_timer()
@@ -2110,3 +2147,5 @@ class LaunchpadS(LaunchpadPro):
                 self.frame += 1
             _LOGGER.info(f"Launchpad S flush {self.fps} : {now - start}")
             self.lasttime = nowint
+
+        return True


### PR DESCRIPTION
Launchpad device will not set to offline if we get a midi failure at startup or during active session

Device can be recovered by reconnecting and hitting refresh in UI

addresses https://github.com/LedFx/LedFx/issues/798

Tested locally against a Launchpad X. Leave device off at system startup, check is marked offline, connect device, ensure refresh button recovers device. Then pull device during active session, check it goes offline, and can again be recovered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved device support and error handling for Launchpad devices.
- **Bug Fixes**
	- Enhanced stability when flushing data to Launchpad devices by handling additional exceptions and setting devices offline as needed.
- **Refactor**
	- Updated Launchpad device classes for better initialization and error management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->