### PR TITLE
Fix: Self heal out of range segments, fixup internal error calls

### DIFF
--- a/ledfx/api/config.py
+++ b/ledfx/api/config.py
@@ -128,13 +128,9 @@ class ConfigEndpoint(RestEndpoint):
                 try:
                     config = migrate_config(config)
                 except Exception as e:
-                    _LOGGER.exception(
-                        f"Failed to migrate import config to the new standard: {e}"
-                    )
-                    return await self.internal_error(
-                        "error",
-                        f"Failed to migrate import config to the new standard: {e}",
-                    )
+                    msg = f"Failed to migrate import config to the new standard: {e}"
+                    _LOGGER.exception(msg)
+                    return await self.internal_error(msg, "error")
 
             # if we got this far, we are happy with and committing to the import config
             # so backup the old one
@@ -171,7 +167,7 @@ class ConfigEndpoint(RestEndpoint):
         except vol.MultipleInvalid as msg:
             error_message = f"Error loading config: {msg}"
             _LOGGER.warning(error_message)
-            return await self.internal_error("error", error_message)
+            return await self.internal_error(error_message, "error")
 
     async def put(self, request: web.Request) -> web.Response:
         """

--- a/ledfx/api/device.py
+++ b/ledfx/api/device.py
@@ -65,7 +65,7 @@ class DeviceEndpoint(RestEndpoint):
         except (voluptuous.Error, ValueError) as msg:
             error_message = f"Error updating device {device_id}: {msg}"
             _LOGGER.warning(error_message)
-            return await self.internal_error("error", error_message)
+            return await self.internal_error(error_message, "error")
         # Update and save the configuration
         for device in self._ledfx.config["devices"]:
             if device["id"] == device_id:
@@ -125,7 +125,7 @@ class DeviceEndpoint(RestEndpoint):
         except (voluptuous.Error, ValueError) as msg:
             error_message = f"Error creating device {device_id}: {msg}"
             _LOGGER.warning(error_message)
-            return await self.internal_error("error", error_message)
+            return await self.internal_error(error_message, "error")
 
         device.activate()
         return await self.bare_request_success(response)

--- a/ledfx/api/find_launchpad.py
+++ b/ledfx/api/find_launchpad.py
@@ -25,7 +25,7 @@ class FindLaunchpadDevicesEndpoint(RestEndpoint):
         except Exception as msg:
             error_message = f"Error checking for launchpad: {msg}"
             _LOGGER.warning(error_message)
-            return await self.internal_error("error", error_message)
+            return await self.internal_error(error_message, "error")
 
         if found is None:
             _LOGGER.warning("No launchpad found")

--- a/ledfx/api/get_nanoleaf_token.py
+++ b/ledfx/api/get_nanoleaf_token.py
@@ -58,12 +58,12 @@ class GetNanoleadTokenEndpoint(RestEndpoint):
                     "Nanoleaf did not return a token: is it in pairing mode?"
                 )
                 _LOGGER.warning(error_message)
-                return await self.internal_error("error", error_message)
+                return await self.internal_error(error_message, "error")
             data = response.json()
         except requests.exceptions.RequestException as msg:
             error_message = (
                 f"Error getting Nanoleaf token from {ip}:{port}: {msg}"
             )
             _LOGGER.warning(error_message)
-            return await self.internal_error("error", error_message)
+            return await self.internal_error(error_message, "error")
         return await self.bare_request_success(data)

--- a/ledfx/api/virtual.py
+++ b/ledfx/api/virtual.py
@@ -74,7 +74,7 @@ class VirtualEndpoint(RestEndpoint):
         except ValueError as msg:
             error_message = f"Unable to set virtual {virtual.id} status: {msg}"
             _LOGGER.warning(error_message)
-            return await self.internal_error("error", error_message)
+            return await self.internal_error(error_message, "error")
 
         # Update ledfx's config
         for idx, item in enumerate(self._ledfx.config["virtuals"]):
@@ -121,7 +121,7 @@ class VirtualEndpoint(RestEndpoint):
             )
             _LOGGER.warning(error_message)
             virtual.update_segments(old_segments)
-            return await self.internal_error("error", error_message)
+            return await self.internal_error(error_message, "error")
 
         # Update ledfx's config
         for idx, item in enumerate(self._ledfx.config["virtuals"]):

--- a/ledfx/api/virtual_effects.py
+++ b/ledfx/api/virtual_effects.py
@@ -148,7 +148,7 @@ class EffectsEndpoint(RestEndpoint):
         except (ValueError, RuntimeError) as msg:
             error_message = f"Unable to set effect: {msg}"
             _LOGGER.warning(error_message)
-            return await self.internal_error("warning", error_message)
+            return await self.internal_error(error_message, "warning")
 
         update_effect_config(self._ledfx.config, virtual_id, effect)
 
@@ -257,7 +257,7 @@ class EffectsEndpoint(RestEndpoint):
                 f"Unable to set effect {effect} on {virtual_id}: {msg}"
             )
             _LOGGER.warning(error_message)
-            return await self.internal_error("error", error_message)
+            return await self.internal_error(error_message, "error")
 
         update_effect_config(self._ledfx.config, virtual_id, effect)
 

--- a/ledfx/api/virtual_presets.py
+++ b/ledfx/api/virtual_presets.py
@@ -136,7 +136,7 @@ class VirtualPresetsEndpoint(RestEndpoint):
                 f"Unable to set effect on virtual {virtual.id}: {msg}"
             )
             _LOGGER.warning(error_message)
-            return await self.internal_error("error", error_message)
+            return await self.internal_error(error_message, "error")
 
         update_effect_config(self._ledfx.config, virtual_id, effect)
 

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -217,7 +217,9 @@ class Virtual:
             or start_pixel >= device.pixel_count
             or end_pixel >= device.pixel_count
         ):
-            _LOGGER.warning(f"Invalid segment pixels in Virtual '{self.name}': segment('{device.name}' ({start_pixel}, {end_pixel})) valid pixels between (0, {device.pixel_count - 1})")
+            _LOGGER.warning(
+                f"Invalid segment pixels in Virtual '{self.name}': segment('{device.name}' ({start_pixel}, {end_pixel})) valid pixels between (0, {device.pixel_count - 1})"
+            )
             if start_pixel < 0:
                 start_pixel = 0
             if end_pixel < 0:

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -211,13 +211,25 @@ class Virtual:
             valid = False
 
         if (
-            (start_pixel < 0)
-            or (end_pixel < 0)
-            or (start_pixel > end_pixel)
-            or (end_pixel >= device.pixel_count)
+            start_pixel < 0
+            or end_pixel < 0
+            or start_pixel > end_pixel
+            or start_pixel >= device.pixel_count
+            or end_pixel >= device.pixel_count
         ):
-            msg = f"Invalid segment pixels in Virtual '{self.name}': segment('{device.name}' ({start_pixel}, {end_pixel})) valid pixels between (0, {device.pixel_count - 1})"
-            valid = False
+            _LOGGER.warning(f"Invalid segment pixels in Virtual '{self.name}': segment('{device.name}' ({start_pixel}, {end_pixel})) valid pixels between (0, {device.pixel_count - 1})")
+            if start_pixel < 0:
+                start_pixel = 0
+            if end_pixel < 0:
+                end_pixel = 0
+            if start_pixel > end_pixel:
+                start_pixel = end_pixel
+            if start_pixel >= device.pixel_count:
+                start_pixel = device.pixel_count - 1
+            if end_pixel >= device.pixel_count:
+                end_pixel = device.pixel_count - 1
+            segment = [device_id, start_pixel, end_pixel, invert]
+            _LOGGER.warning(f"Fixed to {segment}")
 
         if not valid:
             _LOGGER.error(msg)


### PR DESCRIPTION
Harden segment handling for our of range, self heal

as per https://github.com/LedFx/LedFx/issues/799

now any bad values are forced to within limits.

Should address a population of such in sentry. This is currently the only scenario I can find to reach such bad segments

Seen to fix an intentional bad segment generated by reducing pixel count on a device against which a segment is based

Changes reach persisted config through natural cycles

All calls to internal_error had reversed params, causing a BAD SNACKBAR error on front end. Now they are fixed and the correct payload type  / message is returned, front end needs to correctly display such...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved error handling and logging across various API endpoints, enhancing user feedback during configuration migrations, device updates, and creations.
	- Adjusted error message handling for a more consistent user experience.
- **Bug Fixes**
	- Corrected segment pixel validation logic to ensure only valid values are accepted, with warnings logged for adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->