### PR TITLE
fix: use a lifx lib logger instead of root and suppress

### DIFF
--- a/ledfx/__main__.py
+++ b/ledfx/__main__.py
@@ -96,6 +96,7 @@ def setup_logging(loglevel, config_dir):
     logging.getLogger("sacn").setLevel(logging.WARNING)
     logging.getLogger("aiohttp.access").setLevel(logging.WARNING)
     logging.getLogger("zeroconf").setLevel(logging.WARNING)
+    logging.getLogger("lifxdev").setLevel(logging.WARNING)
 
     global _LOGGER
     _LOGGER = logging.getLogger(__name__)

--- a/ledfx/libraries/lifxdev/__init__.py
+++ b/ledfx/libraries/lifxdev/__init__.py
@@ -2,5 +2,6 @@
 
 import logging
 
+
 def get_library_logger():
-    return logging.getLogger('lifxdev')
+    return logging.getLogger("lifxdev")

--- a/ledfx/libraries/lifxdev/__init__.py
+++ b/ledfx/libraries/lifxdev/__init__.py
@@ -1,1 +1,6 @@
 """lifxdev"""
+
+import logging
+
+def get_library_logger():
+    return logging.getLogger('lifxdev')

--- a/ledfx/libraries/lifxdev/devices/device_manager.py
+++ b/ledfx/libraries/lifxdev/devices/device_manager.py
@@ -12,10 +12,10 @@ from typing import Any
 
 import yaml
 
+from ledfx.libraries.lifxdev import get_library_logger
 from ledfx.libraries.lifxdev.colors import color
 from ledfx.libraries.lifxdev.devices import device, light, multizone, tile
 from ledfx.libraries.lifxdev.messages import device_messages, packet
-from ledfx.libraries.lifxdev import get_library_logger
 
 logger = get_library_logger()
 

--- a/ledfx/libraries/lifxdev/devices/device_manager.py
+++ b/ledfx/libraries/lifxdev/devices/device_manager.py
@@ -6,7 +6,6 @@ import collections
 import dataclasses
 import enum
 import functools
-import logging
 import pathlib
 from collections.abc import Callable
 from typing import Any
@@ -16,6 +15,9 @@ import yaml
 from ledfx.libraries.lifxdev.colors import color
 from ledfx.libraries.lifxdev.devices import device, light, multizone, tile
 from ledfx.libraries.lifxdev.messages import device_messages, packet
+from ledfx.libraries.lifxdev import get_library_logger
+
+logger = get_library_logger()
 
 CONFIG_PATH = pathlib.Path.home() / ".lifx" / "devices.yaml"
 
@@ -225,7 +227,7 @@ class DeviceManager(device.LifxDevice):
             num_retries: (int) Number of GetService calls made.
         """
 
-        logging.info("Scanning for LIFX devices.")
+        logger.info("Scanning for LIFX devices.")
         state_service_dict: dict[str, packet.LifxResponse] = {}
         # Disabling the timeout speeds up discovery
         for _ in range(num_retries):
@@ -234,7 +236,7 @@ class DeviceManager(device.LifxDevice):
                 ip = response.addr[0]
                 state_service_dict[ip] = response
 
-        logging.info("Getting device info for discovered devices.")
+        logger.info("Getting device info for discovered devices.")
         device_dict: dict[str, ProductInfo] = {}
         for ip, state_service in state_service_dict.items():
             port = state_service.payload["port"]
@@ -242,7 +244,7 @@ class DeviceManager(device.LifxDevice):
                 label = self.get_label(ip, port=port)
                 product_dict = self.get_product_info(ip, port=port)
             except packet.NoResponsesError as e:
-                logging.error(e)
+                logger.error(e)
                 continue
 
             product_name = product_dict["name"]

--- a/ledfx/libraries/lifxdev/messages/packet.py
+++ b/ledfx/libraries/lifxdev/messages/packet.py
@@ -13,6 +13,7 @@ import struct
 import sys
 from collections.abc import Callable
 from typing import Any, cast
+
 from ledfx.libraries.lifxdev import get_library_logger
 
 BUFFER_SIZE = 65535

--- a/ledfx/libraries/lifxdev/messages/packet.py
+++ b/ledfx/libraries/lifxdev/messages/packet.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import collections
 import dataclasses
 import enum
-import logging
 import os
 import re
 import selectors
@@ -14,10 +13,13 @@ import struct
 import sys
 from collections.abc import Callable
 from typing import Any, cast
+from ledfx.libraries.lifxdev import get_library_logger
 
 BUFFER_SIZE = 65535
 LIFX_PORT = 56700
 TIMEOUT_S = 1
+
+logger = get_library_logger()
 
 
 class NoResponsesError(Exception):
@@ -677,7 +679,7 @@ class PacketComm:
         """
         self._comm = comm
         self._comm.comm.setblocking(False)
-        self._log_func = logging.info if verbose else logging.debug
+        self._log_func = logger.info if verbose else logger.debug
         self._timeout = timeout
 
     @property
@@ -900,7 +902,7 @@ class PacketComm:
         Returns:
             Source identifier of the packet for responses
         """
-        log_func = logging.info if verbose else self._log_func
+        log_func = logger.info if verbose else self._log_func
         addr = (ip or self._comm.ip, port or self._comm.port)
         comm = comm or self._comm.comm
         kwargs["mac_addr"] = mac_addr or self._comm.mac_addr
@@ -920,7 +922,7 @@ class PacketComm:
         verbose: bool = False,
         **kwargs,
     ) -> list[LifxResponse]:
-        log_func = logging.info if verbose else self._log_func
+        log_func = logger.info if verbose else self._log_func
         comm = comm or self._comm.comm
         payload_name = kwargs["payload"].name
 


### PR DESCRIPTION
with -vv lifxdex lib  is pumping out message debug each frame.
Existing lib which is carried in our source ( not sure of the history here, not keen on it ) uses the root logger
These changes establish a lifxdev logger in line with the lib naming, and then suppresses to warning by default in ledfx __main__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved logging within the lifxdev library for enhanced clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->