### PR TITLE
Update renovate.json with new package rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,16 @@
   "extends": [
     "config:recommended",
     ":automergeMinor",
-    ":automergeLinters",
-    ":automergeMonthly"
-]
+    ":automergeLinters"
+  ],
+  "packageRules": [
+    {
+      "updateTypes": ["minor", "patch"],
+      "schedule": ["every month"]
+    },
+    {
+      "updateTypes": ["major"],
+      "schedule": ["every week"]
+    }
+  ]
 }


### PR DESCRIPTION
This pull request updates the renovate.json file to include new package rules. The new rules specify that minor and patch updates should be automatically merged every month, while major updates should be automatically merged every week.