### PR TITLE
Fix: PUSH flag handling for exact multiples of 480 in DDP

### DIFF
--- a/ledfx/devices/ddp.py
+++ b/ledfx/devices/ddp.py
@@ -95,7 +95,13 @@ class DDPDevice(UDPDevice):
             data_start = i * DDPDevice.MAX_DATALEN
             data_end = data_start + DDPDevice.MAX_DATALEN
             DDPDevice.send_packet(
-                sock, dest, port, sequence, i, byteData[data_start:data_end], i == packets
+                sock,
+                dest,
+                port,
+                sequence,
+                i,
+                byteData[data_start:data_end],
+                i == packets,
             )
 
     @staticmethod

--- a/ledfx/devices/ddp.py
+++ b/ledfx/devices/ddp.py
@@ -95,28 +95,22 @@ class DDPDevice(UDPDevice):
             data_start = i * DDPDevice.MAX_DATALEN
             data_end = data_start + DDPDevice.MAX_DATALEN
             DDPDevice.send_packet(
-                sock, dest, port, sequence, i, byteData[data_start:data_end]
+                sock, dest, port, sequence, i, byteData[data_start:data_end], i == packets
             )
 
     @staticmethod
-    def send_packet(sock, dest, port, sequence, packet_count, data):
+    def send_packet(sock, dest, port, sequence, packet_count, data, last):
         bytes_length = len(data)
         udpData = bytearray()
         header = struct.pack(
             "!BBBBLH",
-            DDPDevice.VER1
-            | (
-                DDPDevice.VER1
-                if (bytes_length == DDPDevice.MAX_DATALEN)
-                else DDPDevice.PUSH
-            ),
+            DDPDevice.VER1 | (DDPDevice.PUSH if last else 0),
             sequence,
             DDPDevice.DATATYPE,
             DDPDevice.SOURCE,
             packet_count * DDPDevice.MAX_DATALEN,
             bytes_length,
         )
-
         udpData.extend(header)
         udpData.extend(data)
 


### PR DESCRIPTION
With the prior code with exact multiples of 480 pixels counts the PUSH flag would never be set

Treating it as a display now flag, although its definition is not quite definitive in this regard

http://www.3waylabs.com/ddp/

This addresses the issues discussed at 

https://discord.com/channels/469985374052286474/1216471237090480259

Where a WLED setup with exactly 480 pixels would not update, although the WLED peek does work

Also tested on the Falcon Player Pro as a DDP endpoint, which does not care about the PUSH flag at all.

To gain most benefit from prior maturity, preserved prior expression of sending push flag on last packet of a frame, now also for if it is an exact multiple of 480 pixels.

Tested as not working / working on a 512 WLED endpoint with ledfx device set to 480 which could be seen to only work for Peek and not pixels prior to fix

Now shows full effect at all times.

Regression tested on 16K FPP as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved packet sending mechanism for devices by introducing a parameter to identify the final packet, enhancing the construction of packet headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->