### PR TITLE
fix: always default fill melbank config by passing through CONFIG_SCHEMA

### DIFF
--- a/ledfx/effects/melbank.py
+++ b/ledfx/effects/melbank.py
@@ -446,10 +446,7 @@ class Melbanks:
         self.dev_enabled = self._ledfx.dev_enabled()
 
     def update_config(self, config):
-        # validate config
-        self.melbanks_config = config
-        if not self.melbanks_config:
-            self.melbanks_config = self.CONFIG_SCHEMA(config)
+        self.melbanks_config = self.CONFIG_SCHEMA(config)
         self.melbank_collection = self._ledfx.config.get(
             "melbank_collection", []
         )


### PR DESCRIPTION
Addresses possible issues with new extended melbank configurations, by forcing default keys

Prior with config content of 

    "melbanks": {
        "max_frequencies": [
            350,
            2000,
            15000
        ],
        "min_frequency": 20
    },
    
   Code would crash with 
   
       "samples": self.melbanks_config["samples"],
               ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'samples'

This change uses the standard config validator to pick up default values for missing keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the configuration update process for effects by streamlining the assignment method in the effects module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->