### PR TITLE
Rename Soap2d class to Noise2d and add vnoise to hidden_imports

### DIFF
--- a/hiddenimports.py
+++ b/hiddenimports.py
@@ -37,4 +37,5 @@ hiddenimports = [
     "sentry_sdk.integrations.argv",
     "sentry_sdk.integrations.logging",
     "sentry_sdk.integrations.threading",
+    "vnoise",
 ]

--- a/ledfx/effects/noise2d.py
+++ b/ledfx/effects/noise2d.py
@@ -16,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 # https://github.com/Aircoookie/WLED/blob/f513cae66eecb2c9b4e8198bd0eb52d209ee281f/wled00/FX.cpp#L7472
 
 
-class Soap2d(Twod, GradientEffect):
+class Noise2d(Twod, GradientEffect):
     NAME = "Noise"
     CATEGORY = "Matrix"
     # add keys you want hidden or in advanced here


### PR DESCRIPTION
This pull request renames the `Soap2d` class to `Noise2d` and adds `vnoise` to the `hidden_imports` list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed an effect class to more accurately represent its functionality.
- **Chores**
	- Updated internal imports list for enhanced compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->