### PR TITLE
Fix: Noise effect only reseed on rotate

### DIFF
--- a/ledfx/effects/noise2d.py
+++ b/ledfx/effects/noise2d.py
@@ -69,6 +69,8 @@ class Noise2d(Twod, GradientEffect):
     )
 
     def __init__(self, ledfx, config):
+        self.first_run = True
+        self.last_rotate = 0
         super().__init__(ledfx, config)
 
     def config_updated(self, config):
@@ -86,14 +88,23 @@ class Noise2d(Twod, GradientEffect):
         )
         self.lows_impulse = 0
 
+        if self.last_rotate != self._config["rotate"]:
+            # as rotate could be non symetrical we better reseed everything
+            self.first_run = True
+            self.last_rotate = self._config["rotate"]
+
     def do_once(self):
         super().do_once()
-        self.noise3d = np.zeros(
-            (self.r_height, self.r_width), dtype=np.float64
-        )
-        self.noise_x = random.random()
-        self.noise_y = random.random()
-        self.noise_z = random.random()
+
+        if self.first_run:
+            self.noise3d = np.zeros(
+                (self.r_height, self.r_width), dtype=np.float64
+            )
+            self.noise_x = random.random()
+            self.noise_y = random.random()
+            self.noise_z = random.random()
+            self.noise = vnoise.Noise()
+            self.first_run = False
 
         self.scale_x = self.zoom / self.r_width
         self.scale_y = self.zoom / self.r_height
@@ -101,7 +112,6 @@ class Noise2d(Twod, GradientEffect):
         self.smoothness = min(250, self.intensity)
         # self.seed_image = Image.new("RGB", (self.r_width, self.r_height))
         # self.seed_matrix = True
-        self.noise = vnoise.Noise()
 
     def audio_data_updated(self, data):
         self.lows_impulse = self.lows_impulse_filter.update(


### PR DESCRIPTION
More interactive experience, as the random noise plane will only be reset on a rotate, all other sliders will just be applied to existing configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Improved the initialization and reseeding logic in the 2D noise effect, enhancing performance and reducing redundancy.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->