### PR TITLE
Fix: remove RPI_WS281X from device list

### DIFF
--- a/ledfx/devices/rpi_ws281x.py
+++ b/ledfx/devices/rpi_ws281x.py
@@ -27,7 +27,10 @@ COLOR_ORDERS = {
     "BGR": ColorOrder.BGR,
 }
 
-
+# This device is currently not working and never known to work
+# Disable to avoid accidental selection and crashing as seen in sentry
+# To re-enable, just remove the following decorator
+@Device.no_registration
 class RPI_WS281X(Device):
     """RPi WS281X device support"""
 

--- a/ledfx/devices/rpi_ws281x.py
+++ b/ledfx/devices/rpi_ws281x.py
@@ -27,6 +27,7 @@ COLOR_ORDERS = {
     "BGR": ColorOrder.BGR,
 }
 
+
 # This device is currently not working and never known to work
 # Disable to avoid accidental selection and crashing as seen in sentry
 # To re-enable, just remove the following decorator


### PR DESCRIPTION
As rpi_ws28ax is not known to work and is showing crash reports in sentry, likely due to users trying everything, it will be hidden via the no_registration decorator until such a time that it is revisited.