### PR TITLE
Fix: Removing audio device check due to audio check + tray icon = bad crash

### DIFF
--- a/ledfx/__main__.py
+++ b/ledfx/__main__.py
@@ -14,7 +14,6 @@ import os
 import sys
 from logging.handlers import RotatingFileHandler
 
-from ledfx.effects.audio import AudioAnalysisSource
 from ledfx.sentry_config import setup_sentry
 
 try:
@@ -259,18 +258,6 @@ def main():
         _LOGGER.warning("Steering LedFx into a brick wall.")
         div_by_zero = 1 / 0
 
-    # Check if there are any audio input devices and quit if there are none.
-    # TODO: Review the sentry hits for this logger statement and see if it's worth supporting without a mic.
-    # NOTE: We don't do this in CI - some runners don't have audio devices.
-    if (
-        AudioAnalysisSource.audio_input_device_exists() is False
-        and args.ci_smoke_test is False
-    ):
-        _LOGGER.critical(
-            "No audio input devices found. Please connect a microphone or input device and restart LedFx."
-        )
-        # Exit with code 2 to indicate that there are no audio input devices.
-        sys.exit(2)
     if (args.tray or currently_frozen()) and not args.no_tray:
         # If pystray is imported on a device that can't display it, it explodes. Catch it
         try:


### PR DESCRIPTION
Windows systems in 2.0.97 with tray icon crash hard at audio startup

Reproduced in dev builds with --tray switch
Avoided in 2.0.97 with --no-tray switch

import AudioAnalysisSource must be removed to be effective

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the unnecessary check for audio input devices to prevent erroneous exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->