### PR TITLE
Add warning about sounddevice in main.py

### DIFF
--- a/ledfx/__main__.py
+++ b/ledfx/__main__.py
@@ -6,6 +6,12 @@ To run this script for development purposes use:
     poetry install
     poetry run ledfx
 
+WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+WARNING                                                         WARNING
+WARNING  ⚠️⚠️⚠️ DO NOT USE SOUNDDEVICE WITHIN MAIN.PY ⚠️⚠️⚠️ WARNING
+WARNING                                                         WARNING
+WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+
 """
 
 import argparse
@@ -219,7 +225,9 @@ def parse_args():
 
 
 def main():
-    """Main entry point allowing external calls"""
+    """
+    Main entry point allowing external calls
+    """
 
     args = parse_args()
     config_helpers.ensure_config_directory(args.config)


### PR DESCRIPTION
This pull request adds a warning message in the main.py file to inform developers not to use sounddevice within the file - noting that this should include importing any classes that use/call sounddevice as well.

This is to prevent potential issues and conflicts with pystrays user of threading.

See 
https://github.com/LedFx/LedFx/pull/908 
https://discord.com/channels/469985374052286474/1226981278449143829
https://discord.com/channels/469985374052286474/1226711270489718915

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a warning message in ASCII art format to enhance user awareness.
- **Documentation**
	- Reformatted the main function's docstring for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->