### PR TITLE
Force x64 macOS runners version to macos-13

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -175,7 +175,7 @@ jobs:
           path: ${{ github.workspace }}/debug_config/ledfx.log
   build-ledfx-osx:
     name: Build LedFx (OS X)
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
         python: [3.9.x,3.10.x,3.11.x,3.12.x]

--- a/.github/workflows/test-build-binaries.yml
+++ b/.github/workflows/test-build-binaries.yml
@@ -102,7 +102,7 @@ jobs:
           path: ${{ github.workspace }}/dist/*
   build-ledfx-osx:
     name: Build LedFx (OS X)
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4
@@ -283,7 +283,7 @@ jobs:
           LedFx/LedFx.exe -vv --ci-smoke-test --offline
   run-ledfx-osx:
     name: Test LedFx (OS X)
-    runs-on: macos-latest
+    runs-on: macos-13
     needs: [build-ledfx-windows, build-ledfx-osx]
     steps:
       - name: Download LedFx Version
@@ -330,7 +330,7 @@ jobs:
     name: Create GitHub Release
     if: startsWith(github.ref, 'refs/tags/')
     environment: production
-    runs-on: macos-latest
+    runs-on: macos-13
     needs: [run-ledfx-windows, run-ledfx-osx, run-ledfx-osx-m1, install-from-wheel, install-from-sdist]
     steps:
       - name: Check out code from GitHub
@@ -345,12 +345,12 @@ jobs:
         run: |
           echo ledfx-version=$(cat dist/ledfx_version.txt) >> $GITHUB_OUTPUT
           rm -rf dist/ledfx_version.txt
-      - name: Download OSX (intel) Binary
+      - name: Download OSX (x64) Binary
         uses: actions/download-artifact@v4
         with:
           name: LedFx-${{ steps.ledfx-version.outputs.ledfx-version }}-osx-intel
           path: dist/
-      - name: Package OS X (intel) archive
+      - name: Package OS X (x64) archive
         run: |
           xattr -cr dist/LedFx.app
           chmod +x dist/LedFx.app/Contents/MacOS/LedFx


### PR DESCRIPTION
macos-latest now points to arm64 images - pinned to latest non-arm64 runner image.