### PR TITLE
honor the active key for virtuals, which is used to control pause / play

### DIFF
--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -1137,6 +1137,12 @@ class Virtuals:
                     )
                 except RuntimeError:
                     pass
+
+            # This adds support for configs that are configured as paused
+            # via the active key if it exists. Let the setter deal with it
+            if "active" in virtual and not virtual["active"]:
+                self._ledfx.virtuals.get(virtual["id"]).active = False
+
             self._ledfx.events.fire_event(
                 VirtualConfigUpdateEvent(virtual["id"], virtual["config"])
             )


### PR DESCRIPTION
Addresses https://github.com/LedFx/LedFx/issues/950

The active key at the virtual level is used to control play / pause, as opposed to active_effect, which registers the effect that would otherwise play.

Create from config had no handling for the active key, so inherits active at virtual creation.

Adding this key handling will now allow ledfx to honor the persisted value of the active key at the virtual level

Of course _paused is something else!!!

Tested by changing virtual state to play / paused and ensuring on restart that play / pause and active effect are preserved