### PR TITLE
Added a condition for Steelseries sonar to have 8 channels

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -288,6 +288,8 @@ class AudioInputSource:
             if hostapis[device["hostapi"]]["name"] == "Windows WASAPI":
                 if "Loopback" in device["name"]:
                     ch = 2
+                if "SteelSeries Sonar" in device["name"]:
+                    ch = 8
 
             if hostapis[device["hostapi"]]["name"] == "WEB AUDIO":
                 ledfx.api.websocket.ACTIVE_AUDIO_STREAM = self._stream = (


### PR DESCRIPTION
**Hello there**

This is an easy fix for SteelSeries Sonar to work. Steelseries uses virtual audio lines with 8 channels.

Before this my LedFx just kept on crashing (with Steelseries Sonar Audio selected) on startup. Now it works perfekt with Steelseries Sonar Audio selected.