### PR TITLE
Add strobe pattern to BPM Strobe effect

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -798,9 +798,8 @@ class AudioAnalysisSource(AudioInputSource):
             oscillator = (
                 1 - (self.beat_period - time_since_beat) / self.beat_period
             ) + self.beat_counter
-            # ensure it's between 0 and 1. useful when audio cuts
-            oscillator = min(4, oscillator)
-            oscillator = max(0, oscillator)
+            # ensure it's between [0 and 4). useful when audio cuts
+            oscillator = oscillator % 4
         return oscillator
 
     def beat_oscillator(self):

--- a/ledfx/effects/strobe.py
+++ b/ledfx/effects/strobe.py
@@ -61,9 +61,9 @@ class Strobe(AudioReactiveEffect, GradientEffect):
         self.brightness = (
             ((-o % (1 / self.freq)) * self.freq) ** self.strobe_decay
         ) * (1 - o) ** self.beat_decay
-        
+
         bar_idx = int(bar)
-        strobe_mask = int(self.strobe_pattern[bar_idx]=="*")
+        strobe_mask = int(self.strobe_pattern[bar_idx] == "*")
         self.brightness *= strobe_mask
 
     def render(self):

--- a/ledfx/effects/strobe.py
+++ b/ledfx/effects/strobe.py
@@ -35,6 +35,11 @@ class Strobe(AudioReactiveEffect, GradientEffect):
                 description="How much the strobes fade across the beat. Higher -> less bright strobes towards end of beat",
                 default=2,
             ): vol.All(vol.Coerce(float), vol.Range(min=0, max=10)),
+            vol.Optional(
+                "strobe_pattern",
+                description="When to fire (*) or skip (.) the strobe (Note that beat 1 is arbitrary)",
+                default="****",
+            ): vol.In(list(["****", "*.*.", ".*.*", "*...", "...*"])),
         }
     )
 
@@ -46,14 +51,20 @@ class Strobe(AudioReactiveEffect, GradientEffect):
         self.freq = self.MAPPINGS[self._config["strobe_frequency"]]
         self.strobe_decay = self._config["strobe_decay"]
         self.beat_decay = self._config["beat_decay"]
+        self.strobe_pattern = self._config["strobe_pattern"]
 
     def audio_data_updated(self, data):
         o = data.beat_oscillator()
-        self.color = self.get_gradient_color(data.bar_oscillator() / 4)
+        bar = data.bar_oscillator()
+        self.color = self.get_gradient_color(bar / 4)
 
         self.brightness = (
             ((-o % (1 / self.freq)) * self.freq) ** self.strobe_decay
         ) * (1 - o) ** self.beat_decay
+        
+        bar_idx = int(bar)
+        strobe_mask = int(self.strobe_pattern[bar_idx]=="*")
+        self.brightness *= strobe_mask
 
     def render(self):
         self.pixels[:] = self.color * self.brightness


### PR DESCRIPTION
Strobe pattern selectable from list. Defaults to every beat to mimic existing behavior
Fix bar_oscillator output range (could occasionally get a 4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `strobe_pattern` parameter in the strobe effect, allowing users to customize strobe firing sequences based on beat patterns.

- **Improvements**
  - Enhanced oscillator value handling in the bar oscillator effect for more consistent performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->