### PR TITLE
Fix: protect from attempting to save DummyEffect in scenes 

### DIFF
--- a/ledfx/api/scenes.py
+++ b/ledfx/api/scenes.py
@@ -5,8 +5,10 @@ from aiohttp import web
 
 from ledfx.api import RestEndpoint
 from ledfx.config import save_config
+from ledfx.effects import DummyEffect
 from ledfx.events import SceneActivatedEvent
 from ledfx.utils import generate_id
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -216,9 +218,14 @@ class ScenesEndpoint(RestEndpoint):
             for virtual in self._ledfx.virtuals.values():
                 effect = {}
                 if virtual.active_effect:
-                    effect["type"] = virtual.active_effect.type
-                    effect["config"] = virtual.active_effect.config
-                    # effect['name'] = virtual.active_effect.name
+                    # prevent crash from trying to save copy / span transitions
+                    # which appear active even when the virtual is not!!!
+                    if not isinstance(virtual.active_effect, DummyEffect):
+                        effect["type"] = virtual.active_effect.type
+                        effect["config"] = virtual.active_effect.config
+                        # effect['name'] = virtual.active_effect.name
+                    else:
+                        _LOGGER.debug(f"Skipping DummyEffect for virtual {virtual.id}")
                 scene_config["virtuals"][virtual.id] = effect
         else:
             virtuals = data.get("virtuals")

--- a/ledfx/api/scenes.py
+++ b/ledfx/api/scenes.py
@@ -9,7 +9,6 @@ from ledfx.effects import DummyEffect
 from ledfx.events import SceneActivatedEvent
 from ledfx.utils import generate_id
 
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -225,7 +224,9 @@ class ScenesEndpoint(RestEndpoint):
                         effect["config"] = virtual.active_effect.config
                         # effect['name'] = virtual.active_effect.name
                     else:
-                        _LOGGER.debug(f"Skipping DummyEffect for virtual {virtual.id}")
+                        _LOGGER.debug(
+                            f"Skipping DummyEffect for virtual {virtual.id}"
+                        )
                 scene_config["virtuals"][virtual.id] = effect
         else:
             virtuals = data.get("virtuals")


### PR DESCRIPTION
as per 

https://github.com/LedFx/LedFx/issues/978

leads to attempting access type field in DummyEffect which does not exist
Copy / Span virtuals are running transitions even if not active!!!

Tested by ensuring such virtuals with long transition times, quickly create and final save a scene.

Check debug for skips and no crash reported to front end. all actually active virtual / effects are now part of scene

[DEBUG   ] ledfx.api.scenes               : Skipping DummyEffect for virtual wled2-dog
[DEBUG   ] ledfx.api.scenes               : Skipping DummyEffect for virtual wled2-cat
[DEBUG   ] ledfx.api.scenes               : Skipping DummyEffect for virtual big-copy
[DEBUG   ] ledfx.api.scenes               : Skipping DummyEffect for virtual wideboy
[DEBUG   ] ledfx.api.scenes               : Skipping DummyEffect for virtual trydump2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue that could cause the application to crash by properly handling `DummyEffect` instances when saving effects for virtual LEDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->