### PR TITLE
Feature: Add a global --pause-all launch option

### DIFF
--- a/ledfx/__main__.py
+++ b/ledfx/__main__.py
@@ -221,6 +221,13 @@ def parse_args():
         help="Launch LedFx, load the config, clear all active effects on all virtuals. Effect configurations are persisted, just turned off",
     )
 
+    parser.add_argument(
+        "--pause-all",
+        dest="pause_all",
+        action="store_true",
+        help="Start Ledfx with all virtuals paused",
+    )
+
     return parser.parse_args()
 
 
@@ -315,7 +322,7 @@ def entry_point(icon=None):
             offline_mode=args.offline_mode,
         )
 
-        exit_code = ledfx.start(open_ui=args.open_ui)
+        exit_code = ledfx.start(open_ui=args.open_ui, pause_all=args.pause_all)
 
     if icon:
         icon.stop()

--- a/ledfx/api/virtuals.py
+++ b/ledfx/api/virtuals.py
@@ -50,7 +50,7 @@ class VirtualsEndpoint(RestEndpoint):
 
     async def put(self) -> web.Response:
         """
-        Get info of all virtuals
+        Toggles a global pause on all virtuals
 
         Returns:
             web.Response: The response containing the paused virtuals.

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -324,7 +324,9 @@ class LedFxCore:
                     )
 
     def start(self, open_ui=False, pause_all=False):
-        async_fire_and_forget(self.async_start(open_ui=open_ui, pause_all=pause_all), self.loop)
+        async_fire_and_forget(
+            self.async_start(open_ui=open_ui, pause_all=pause_all), self.loop
+        )
 
         try:
             self.loop.run_forever()
@@ -383,7 +385,9 @@ class LedFxCore:
         await self.devices.async_initialize_devices()
 
         self.zeroconf = ZeroConfRunner(ledfx=self)
-        self.virtuals.create_from_config(self.config["virtuals"], pause_all=pause_all)
+        self.virtuals.create_from_config(
+            self.config["virtuals"], pause_all=pause_all
+        )
         self.integrations.create_from_config(self.config["integrations"])
 
         if self.config["scan_on_startup"]:

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -323,8 +323,8 @@ class LedFxCore:
                         "Unable to get update information", "LedFx"
                     )
 
-    def start(self, open_ui=False):
-        async_fire_and_forget(self.async_start(open_ui=open_ui), self.loop)
+    def start(self, open_ui=False, pause_all=False):
+        async_fire_and_forget(self.async_start(open_ui=open_ui, pause_all=pause_all), self.loop)
 
         try:
             self.loop.run_forever()
@@ -344,7 +344,7 @@ class LedFxCore:
 
         return self.exit_code
 
-    async def async_start(self, open_ui=False):
+    async def async_start(self, open_ui=False, pause_all=False):
         _LOGGER.info(f"Starting LedFx, listening on {self.host}:{self.port}")
 
         await self.http.start(get_ssl_certs(config_dir=self.config_dir))
@@ -383,7 +383,7 @@ class LedFxCore:
         await self.devices.async_initialize_devices()
 
         self.zeroconf = ZeroConfRunner(ledfx=self)
-        self.virtuals.create_from_config(self.config["virtuals"])
+        self.virtuals.create_from_config(self.config["virtuals"], pause_all=pause_all)
         self.integrations.create_from_config(self.config["integrations"])
 
         if self.config["scan_on_startup"]:
@@ -404,6 +404,10 @@ class LedFxCore:
 
         if not self.offline_mode:
             self.check_and_notify_updates()
+
+        if pause_all:
+            # pause at the virtuals level
+            self.virtuals.pause_all()
 
     def stop(self, exit_code):
         async_fire_and_forget(self.async_stop(exit_code), self.loop)

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -1100,7 +1100,7 @@ class Virtuals:
         self._ledfx.events.add_listener(cleanup_effects, Event.LEDFX_SHUTDOWN)
         self._virtuals = {}
 
-    def create_from_config(self, config):
+    def create_from_config(self, config, pause_all=False):
         for virtual in config:
             _LOGGER.debug(f"Loading virtual from config: {virtual}")
             self._ledfx.virtuals.create(
@@ -1142,6 +1142,10 @@ class Virtuals:
             # via the active key if it exists. Let the setter deal with it
             if "active" in virtual and not virtual["active"]:
                 self._ledfx.virtuals.get(virtual["id"]).active = False
+
+            # global pause is handled differently to virtual pause
+            if pause_all:
+                self._ledfx.virtuals.get(virtual["id"])._paused = True
 
             self._ledfx.events.fire_event(
                 VirtualConfigUpdateEvent(virtual["id"], virtual["config"])


### PR DESCRIPTION
Global pause is handled differently to virtual level pause

We recently added virtual pause persistence via observing the _active param

Persisting and observing a global pause state may take some thinking.

However global pause is not persisted. A reasonable use case is to use a --pause-all launch option

This implementation ensures that virtuals are paused at creation from the loaded config to avoid a single frame of generated data, additionally calls the global pause virtuals level method to ensure the correct flags and UI are set.

Tested launching with and without --pause-all

Ensured that the virtuals behaved accordingly and that the UI global pause state was correct and could be toggled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `--pause-all` startup option to start LedFx with all virtuals paused.
  
- **Enhancements**
  - Updated virtuals functionality to allow global pausing of all virtuals via the new `pause_all` parameter.

- **Documentation**
  - Improved documentation for the `get` method to reflect its new functionality of toggling a global pause on all virtuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->