### PR TITLE
Update macOS (ARM) runner to flyci-macos-14-m2

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -247,7 +247,7 @@ jobs:
   build-ledfx-osx-m1:
     name: Build LedFx (OS X) (Apple Silicon)
     needs: [build-ledfx-linux, build-ledfx-windows, build-ledfx-osx]
-    runs-on: flyci-macos-large-latest-m1
+    runs-on: flyci-macos-14-m2
     strategy:
       matrix:
         python: [3.10.x,3.11.x,3.12.x]

--- a/.github/workflows/test-build-binaries.yml
+++ b/.github/workflows/test-build-binaries.yml
@@ -178,7 +178,7 @@ jobs:
           path: ${{ github.workspace }}/dist/*
   build-ledfx-osx-m1:
     name: Build LedFx (OS X) (Apple Silicon)
-    runs-on: flyci-macos-large-latest-m1
+    runs-on: flyci-macos-14-m2
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4
@@ -305,7 +305,7 @@ jobs:
           ./LedFx.app/Contents/MacOS/LedFx -vv --ci-smoke-test --offline
   run-ledfx-osx-m1:
     name: Test LedFx (OS X) (Apple Silicon)
-    runs-on: flyci-macos-large-latest-m1
+    runs-on: flyci-macos-14-m2
     needs: [build-ledfx-windows, build-ledfx-osx-m1]
     steps:
       - name: Download LedFx Version


### PR DESCRIPTION
This pull request updates the macOS runner to flyci-macos-14-m2. This change ensures that the LedFx (OS X) (Apple Silicon) job runs on the correct runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the build and test workflows to utilize the latest macOS 14 environment on M2 hardware, enhancing compatibility and performance for the LedFx application on Apple Silicon.
- **Chores**
	- Maintained the existing workflow structure while improving the underlying environment configuration for better build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->