### PR TITLE
Fix: "coeff_types" error Flush callbacks on AudioInputSource __init__

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -170,6 +170,8 @@ class AudioInputSource:
     def __init__(self, ledfx, config):
         self._ledfx = ledfx
         self.lock = threading.Lock()
+        # We must not inherit legacy _callbacks from prior instances
+        self._callbacks = []
         self.update_config(config)
 
         def shutdown_event(e):


### PR DESCRIPTION
Inherited _callback from previous instances of an AudioInputSource will break later logic that establishes the new ones for the new instance.  

Prior to this fix, using UI Reset Config, would leave it impossible to recover audio effects without getting "coeff_types" error on enabling audio effects.

So reset config, add devices, and attempt to activate an audio effect would fail.

A full rerun would be required to recover, not even ui restart would work

With this fix, you can simply get audio effects running after a clear config.

The "coeff_types" error would occur as relevant initializations did not occur as there were legacy _callbacks detected.

Therefore when code tried to reference those elements such as "coeff_types" during effect application, it would error and return the string to the UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `AudioEffect` class to ensure each instance operates independently by managing callbacks more effectively. Users can expect more reliable behavior in callback scenarios.
  
- **Bug Fixes**
	- Resolved potential issues with legacy callbacks that could affect the performance of new instances, improving overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->