### PR TITLE
Feature: artnet pre-amble and post-amble support

### DIFF
--- a/docs/artnet.rst
+++ b/docs/artnet.rst
@@ -1,0 +1,43 @@
+===================
+    Artnet Device
+===================
+
+Artnet is a common implementation of DMX over Ethernet.
+It is widely used in the lighting industry and is supported by a large variety of devices.
+
+See https://en.wikipedia.org/wiki/Art-Net for more information.
+
+To support artnet devives, it is important to be able to set fixed values in
+channels that can be prior to, or after the RGB data to control for example, brightness
+
+For Ledfx these can only be static, but the simple implementation of
+pre-amble and post-amble values supports most simple devices.
+The pre-amble and post-amble fields can be treated as comma or space seperated values from the uint8 range 0-255.
+
+The following 3 examples show some common use cases:
+
+1. A simple single pixel RGB device with a single channel for brightness before the RGB data
+
+Set pre-amble to "255" for max brightness, leave post-amble empty
+
+The resulting channel data send to the artnet device universe in the format of
+
+[255, R, G, B]
+
+2. A simple single pixel RGB device with a single channel for brightness after the RGB data
+
+Set post-amble to "255" for max brightness, leave pre-amble empty
+
+The resulting channel data send to the artnet device universe in the format of
+
+[R, G, B, 255]
+
+3. A simple pixel RGB device with a channel for brightness 3 further channels for other settings such as strobe
+
+In this case we want the effects to be off, and brightness to be at full power
+
+Set pre-amble to "255, 0, 0, 0" for max brightness and other channels off, leave post-amble empty
+
+The resulting channel data send to the artnet device universe in the format of
+
+[255, 0, 0, 0, R, G, B]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@
    configuring
    directing_audio
    osc
+   artnet
 
 .. toctree::
    :maxdepth: 2

--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import socket
+import threading
 from abc import abstractmethod
 from functools import cached_property, partial
 
@@ -8,7 +9,6 @@ import numpy as np
 import serial
 import serial.tools.list_ports
 import voluptuous as vol
-import threading
 
 from ledfx.config import save_config
 from ledfx.events import (

--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -8,6 +8,7 @@ import numpy as np
 import serial
 import serial.tools.list_ports
 import voluptuous as vol
+import threading
 
 from ledfx.config import save_config
 from ledfx.events import (
@@ -82,42 +83,46 @@ class Device(BaseRegistry):
         self._silence_start = None
         self._device_type = ""
         self._online = True
+        self.lock = threading.Lock()
 
     def __del__(self):
         if self._active:
             self.deactivate()
 
     def update_config(self, config):
-        # TODO: Sync locks to ensure everything is thread safe
-        if self._config is not None:
-            config = {**self._config, **config}
+        with self.lock:
+            # TODO: Sync locks to ensure everything is thread safe
+            # self.lock has been added, but is not used presently outside of
+            # artnet
+            if self._config is not None:
+                config = {**self._config, **config}
 
-        validated_config = type(self).schema()(config)
-        self._config = validated_config
+            validated_config = type(self).schema()(config)
+            self._config = validated_config
 
-        # Iterate all the base classes and check to see if there is a custom
-        # implementation of config updates. If to notify the base class.
-        valid_classes = list(type(self).__bases__)
-        valid_classes.append(type(self))
-        for base in valid_classes:
-            if hasattr(base, "config_updated"):
-                if base.config_updated != super(base, base).config_updated:
-                    base.config_updated(self, validated_config)
+            # Iterate all the base classes and check to see if there is a custom
+            # implementation of config updates. If to notify the base class.
+            valid_classes = list(type(self).__bases__)
+            valid_classes.append(type(self))
+            for base in valid_classes:
+                if hasattr(base, "config_updated"):
+                    if base.config_updated != super(base, base).config_updated:
+                        base.config_updated(self, validated_config)
 
-        _LOGGER.info(
-            f"Device {self.name} config updated to {validated_config}."
-        )
+            _LOGGER.info(
+                f"Device {self.name} config updated to {validated_config}."
+            )
 
-        for virtual_id in self._ledfx.virtuals:
-            virtual = self._ledfx.virtuals.get(virtual_id)
-            if virtual.is_device == self.id:
-                segments = [[self.id, 0, self.pixel_count - 1, False]]
-                virtual.update_segments(segments)
-                virtual.invalidate_cached_props()
+            for virtual_id in self._ledfx.virtuals:
+                virtual = self._ledfx.virtuals.get(virtual_id)
+                if virtual.is_device == self.id:
+                    segments = [[self.id, 0, self.pixel_count - 1, False]]
+                    virtual.update_segments(segments)
+                    virtual.invalidate_cached_props()
 
-        for virtual in self._virtuals_objs:
-            virtual.deactivate_segments()
-            virtual.activate_segments(virtual._segments)
+            for virtual in self._virtuals_objs:
+                virtual.deactivate_segments()
+                virtual.activate_segments(virtual._segments)
 
     def config_updated(self, config):
         """

--- a/ledfx/devices/artnet.py
+++ b/ledfx/devices/artnet.py
@@ -5,7 +5,7 @@ import voluptuous as vol
 from stupidArtnet import StupidArtnet
 
 from ledfx.devices import NetworkedDevice
-from ledfx.utils import clip_at_limit, extract_uint8_seq
+from ledfx.utils import extract_uint8_seq
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/ledfx/devices/artnet.py
+++ b/ledfx/devices/artnet.py
@@ -37,7 +37,7 @@ class ArtNetDevice(NetworkedDevice):
             ): str,
             vol.Optional(
                 "post_amble",
-                description="Channel bytes to insert after the RGB bata",
+                description="Channel bytes to insert after the RGB data",
                 default="",
             ): str,
             vol.Optional(

--- a/ledfx/devices/artnet.py
+++ b/ledfx/devices/artnet.py
@@ -3,12 +3,9 @@ import logging
 import numpy as np
 import voluptuous as vol
 from stupidArtnet import StupidArtnet
-from ledfx.utils import (
-    clip_at_limit,
-    extract_uint8_seq,
-)
 
 from ledfx.devices import NetworkedDevice
+from ledfx.utils import clip_at_limit, extract_uint8_seq
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,13 +60,20 @@ class ArtNetDevice(NetworkedDevice):
 
     def config_use(self, config):
         # get the preamble string, stip it and convert to np.arry of unint8
-        self.pre_amble = np.array(extract_uint8_seq(config.get("pre_amble", "")), dtype=np.uint8)
-        self.post_amble = np.array(extract_uint8_seq(config.get("post_amble", "")), dtype=np.uint8)
+        self.pre_amble = np.array(
+            extract_uint8_seq(config.get("pre_amble", "")), dtype=np.uint8
+        )
+        self.post_amble = np.array(
+            extract_uint8_seq(config.get("post_amble", "")), dtype=np.uint8
+        )
         # This assumes RGB - for RGBW devices this isn't gonna work.
         # TODO: Fix this when/if we ever want to move to RGBW outputs for devices
         # warning magic number 3 for RGB
-        self.channel_count = self.pre_amble.size + (
-            self._config["pixel_count"] * 3 ) + self.post_amble.size
+        self.channel_count = (
+            self.pre_amble.size
+            + (self._config["pixel_count"] * 3)
+            + self.post_amble.size
+        )
         self.packet_size = self._config["packet_size"]
         self.universe_count = (
             self.channel_count + self.packet_size - 1

--- a/ledfx/devices/artnet.py
+++ b/ledfx/devices/artnet.py
@@ -59,7 +59,7 @@ class ArtNetDevice(NetworkedDevice):
         self.activate()
 
     def config_use(self, config):
-        # get the preamble string, stip it and convert to np.arry of unint8
+        # get the preamble string, strip it and convert to np.arry of unint8
         self.pre_amble = np.array(
             extract_uint8_seq(config.get("pre_amble", "")), dtype=np.uint8
         )

--- a/ledfx/devices/artnet.py
+++ b/ledfx/devices/artnet.py
@@ -115,9 +115,9 @@ class ArtNetDevice(NetworkedDevice):
                 start = i * self.packet_size
                 end = start + self.packet_size
                 packet = np.zeros(self.packet_size, dtype=np.uint8)
-                packet[: min(self.packet_size, self.channel_count - start)] = data[
-                    start:end
-                ]
+                packet[: min(self.packet_size, self.channel_count - start)] = (
+                    data[start:end]
+                )
                 self._artnet.set_universe(i + self._config["universe"])
                 self._artnet.set(packet)
                 self._artnet.show()

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -1409,6 +1409,13 @@ def extract_positive_integers(s):
     return list({int(num) for num in numbers if int(num) >= 0})
 
 
+def extract_uint8_seq(s):
+    # Use regular expression to find all sequences of digits
+    numbers = re.findall(r"\d+", s)
+    # discard anything outside of uint8 range
+    return [int(num) for num in numbers if 0 <= int(num) <= 255]
+
+
 def clip_at_limit(numbers, limit):
     # Keep only values that are less than the limit
     return [num for num in numbers if num < limit]


### PR DESCRIPTION
There is no way to know what is in the channels we are skipping with an offset, and no way to avoid writing into those channels.

This is intended to allow support of a known fixed value such as overall brightness before or after the RGB data.

A user defined pre amble and post amble will be concatenated to the RGB data either end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced optional configuration parameters, `pre_amble` and `post_amble`, for enhanced customization in the ArtNetDevice class.
	- Improved data handling by incorporating new parameters into the output for more flexible channel management.
	- Enhanced thread safety in the `update_config` method to prevent race conditions during configuration updates.
	- Added comprehensive documentation for the ArtNetDevice, including practical examples for configuration.

- **Bug Fixes**
	- Ensured validation of the `offset_stuff` parameter to maintain data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->