### PR TITLE
Fix: OpenRGB data length field for 0.91+

### DIFF
--- a/ledfx/devices/packets.py
+++ b/ledfx/devices/packets.py
@@ -189,7 +189,9 @@ def build_openrgb_packet(
             device_id,
             1050,  # RGBCONTROLLER_UPDATELEDS packet
             struct.calcsize(f"IH{3 * frame_size}b{frame_size}x"),   # total packet length
-            (frame_size * 4 + 2),  # body length
+            # body length inlcuding self should match packet total packet length
+            # openRGB 0.9 ignored this field, but 0.91 enforces it
+            (frame_size * 4 + 2 + 4),
             frame_size,  # number of pixels
         )
         # fmt: on


### PR DESCRIPTION
OpenRGB protocol version 3 ignored data length
now enforces packet length = data length
ledfx prior used data length as payload length excluding self
OpenRGB now enforces that payload length field must include self

Main docs

https://gitlab.com/CalcProgrammer1/OpenRGB/-/blob/master/Documentation/OpenRGBSDK.md
https://gitlab.com/CalcProgrammer1/OpenRGB/-/blob/master/Documentation/OpenRGBSDK.md#netpacketheader-structure
https://gitlab.com/CalcProgrammer1/OpenRGB/-/blob/master/Documentation/OpenRGBSDK.md#net_packet_id_rgbcontroller_updateleds

Code that now enforces allows a zero value, but otherwise must match

https://gitlab.com/CalcProgrammer1/OpenRGB/-/blob/master/NetworkServer.cpp#L692

0:  ORGB    Magic value
4:  \x02\x00\x00\x00    Device index
8:  \x1a\x04\x00\x00    Packet ID (0x41a) = 1050
12: \x0e\x00\x00\x00    Packet size (0xe) = 14

16: \n\x00\x00\x00      Little endian 10 Size of all data in packet <--- this SHALL now be 14, not 10
20: \x02\x00            Little endian pixel count
22: \xff\xff\x00\x00    Yellow
26: \xff\x00\x00\x00    Red
