### PR TITLE
chore: Update macOS runner in CI workflows

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -247,7 +247,7 @@ jobs:
   build-ledfx-osx-m1:
     name: Build LedFx (OS X) (Apple Silicon)
     needs: [build-ledfx-linux, build-ledfx-windows, build-ledfx-osx]
-    runs-on: flyci-macos-14-m2
+    runs-on: macos-latest
     strategy:
       matrix:
         python: [3.10.x,3.11.x,3.12.x]

--- a/.github/workflows/test-build-binaries.yml
+++ b/.github/workflows/test-build-binaries.yml
@@ -178,7 +178,7 @@ jobs:
           path: ${{ github.workspace }}/dist/*
   build-ledfx-osx-m1:
     name: Build LedFx (OS X) (Apple Silicon)
-    runs-on: flyci-macos-14-m2
+    runs-on: macos-latest
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4
@@ -304,8 +304,8 @@ jobs:
           chmod +x ./LedFx.app/Contents/MacOS/LedFx
           ./LedFx.app/Contents/MacOS/LedFx -vv --ci-smoke-test --offline
   run-ledfx-osx-m1:
-    name: Test LedFx (OS X) (Apple Silicon)
-    runs-on: flyci-macos-14-m2
+    name: Test LedFx (OS X [ARM64])
+    runs-on: macos-latest
     needs: [build-ledfx-windows, build-ledfx-osx-m1]
     steps:
       - name: Download LedFx Version


### PR DESCRIPTION
flyci are discontinuing their runner service.

Migrate to GH.

Thanks so much flyci, was a pleasure.