### PR TITLE
(fix) readd found device in response of find_launchpad

### DIFF
--- a/ledfx/api/find_launchpad.py
+++ b/ledfx/api/find_launchpad.py
@@ -32,4 +32,4 @@ class FindLaunchpadDevicesEndpoint(RestEndpoint):
             return await self.request_success("info", "No launchpad found")
 
         _LOGGER.info(f"Found launchpad: {found}")
-        return await self.request_success("info", "Found launchpad")
+        return await self.request_success("info", "Found launchpad", found)


### PR DESCRIPTION
This [refactoring](https://github.com/LedFx/LedFx/commit/451e2cb5a9166bbefe8d42550217898b8ed45ec9#diff-909e0222c479b6571d6551e2a3540839a2ae1abace7b8524ff30c5cfc02c5b36L35) removed the found device from the response

readded respecting the `request_success` interface

=> found device will be in `response.data` (in oppose to `response.device`)