### PR TITLE
Feature: add device repeat to artnet

### DIFF
--- a/docs/artnet.rst
+++ b/docs/artnet.rst
@@ -1,43 +1,71 @@
-===================
-    Artnet Device
-===================
+Artnet Device
+=============
 
-Artnet is a common implementation of DMX over Ethernet.
-It is widely used in the lighting industry and is supported by a large variety of devices.
+**Artnet** is a common implementation of DMX over Ethernet. It is widely used in the lighting industry and is supported by a large variety of devices.
 
-See https://en.wikipedia.org/wiki/Art-Net for more information.
+For more information, see `Art-Net on Wikipedia <https://en.wikipedia.org/wiki/Art-Net>`_.
 
-To support artnet devives, it is important to be able to set fixed values in
-channels that can be prior to, or after the RGB data to control for example, brightness
+Pre and Post Amble
+==================
 
-For Ledfx these can only be static, but the simple implementation of
-pre-amble and post-amble values supports most simple devices.
-The pre-amble and post-amble fields can be treated as comma or space seperated values from the uint8 range 0-255.
+To support Artnet devices, it is important to be able to set fixed values in channels that can be positioned before or after the RGB data, for example, to control brightness.
 
-The following 3 examples show some common use cases:
+In LedFx, these values can only be static, but the simple implementation of **pre-amble** and **post-amble** values supports most simple devices. The pre-amble and post-amble fields can be treated as comma or space-separated values from the ``uint8`` range (0-255).
 
-1. A simple single pixel RGB device with a single channel for brightness before the RGB data
+Common Use Cases
+----------------
 
-Set pre-amble to "255" for max brightness, leave post-amble empty
+1. **Single Pixel RGB Device with Brightness Before RGB Data:**
 
-The resulting channel data send to the artnet device universe in the format of
+   - Set the pre-amble to ``255`` for maximum brightness and leave the post-amble empty.
+   - The resulting channel data sent to the Artnet device universe will be in the format::
 
-[255, R, G, B]
+     [255, R, G, B]
 
-2. A simple single pixel RGB device with a single channel for brightness after the RGB data
+2. **Single Pixel RGB Device with Brightness After RGB Data:**
 
-Set post-amble to "255" for max brightness, leave pre-amble empty
+   - Set the post-amble to ``255`` for maximum brightness and leave the pre-amble empty.
+   - The resulting channel data sent to the Artnet device universe will be in the format::
 
-The resulting channel data send to the artnet device universe in the format of
+     [R, G, B, 255]
 
-[R, G, B, 255]
+3. **Pixel RGB Device with Brightness and Additional Channels:**
 
-3. A simple pixel RGB device with a channel for brightness 3 further channels for other settings such as strobe
+   - Set the pre-amble to ``255, 0, 0, 0`` for maximum brightness with other channels turned off. Leave the post-amble empty.
+   - The resulting channel data sent to the Artnet device universe will be in the format::
 
-In this case we want the effects to be off, and brightness to be at full power
+     [255, 0, 0, 0, R, G, B]
 
-Set pre-amble to "255, 0, 0, 0" for max brightness and other channels off, leave post-amble empty
+Device Repeat
+=============
 
-The resulting channel data send to the artnet device universe in the format of
+It is common to have multiple Artnet devices on one universe with the same channel format. Each device requires its own pre- and post-amble. The ``device_repeat`` field can be set to the number of pixels assigned to each device. LedFx will then consume that number of pixels serially, wrapping each set with pre- and post-amble sequences until all pixels are used. Any leftover pixels are ignored.
 
-[255, 0, 0, 0, R, G, B]
+If ``device_repeat`` is set to ``0``, all pixels are sent to the first device, wrapped with the pre- and post-amble sequences.
+
+Examples
+--------
+
+- **Pixel Count:** 6
+- **Pre-amble:** ``255``
+- **Post-amble:** ``0, 0``
+
+With ``device_repeat`` set to ``0``::
+
+    [255, RGB1, RGB2, RGB3, RGB4, RGB5, RGB6, 0, 0]
+
+With ``device_repeat`` set to ``1`` (6 endpoints with 1 pixel each)::
+
+    [255, RGB1, 0, 0, 255, RGB2, 0, 0, 255, RGB3, 0, 0, 255, RGB4, 0, 0, 255, RGB5, 0, 0, 255, RGB6, 0, 0]
+
+With ``device_repeat`` set to ``2`` (3 endpoints with 2 pixels each)::
+
+    [255, RGB1, RGB2, 0, 0, 255, RGB3, RGB4, 0, 0, 255, RGB5, RGB6, 0, 0]
+
+With ``device_repeat`` set to ``3`` (2 endpoints with 3 pixels each)::
+
+    [255, RGB1, RGB2, RGB3, 0, 0, 255, RGB4, RGB5, RGB6, 0, 0]
+
+With ``device_repeat`` set to ``4`` (1 endpoint with 4 pixels, last 2 pixels dropped)::
+
+    [255, RGB1, RGB2, RGB3, RGB4, 0, 0]

--- a/ledfx/devices/artnet.py
+++ b/ledfx/devices/artnet.py
@@ -165,4 +165,3 @@ class ArtNetDevice(NetworkedDevice):
                 self._artnet.set_universe(i + self._config["universe"])
                 self._artnet.set(packet)
                 self._artnet.show()
-                _LOGGER.debug(f"devices_data:\n{devices_data}")

--- a/ledfx/devices/artnet.py
+++ b/ledfx/devices/artnet.py
@@ -78,7 +78,8 @@ class ArtNetDevice(NetworkedDevice):
         # warning magic number 3 for RGB
 
         # treat a default value of zero in device_repeat as all pixels in one device
-        if self.device_repeat == 0:
+        # also protect against greater than pixel_count
+        if self.device_repeat == 0 or self.device_repeat > self.pixel_count:
             self.device_repeat = self.pixel_count
 
         # if the user has not set enough pixels to fully fill the last device

--- a/ledfx/devices/artnet.py
+++ b/ledfx/devices/artnet.py
@@ -131,13 +131,15 @@ class ArtNetDevice(NetworkedDevice):
             if not self._artnet:
                 self.activate()
 
-            data = data.flatten()[:self.data_max * 3]
+            data = data.flatten()[: self.data_max * 3]
 
             # pre allocate the space
             devices_data = np.empty(self.channel_count, dtype=np.uint8)
 
             # Reshape the data into (self.devices, self.device_repeat * 3)
-            reshaped_data = data.reshape((self.devices, self.device_repeat * 3))
+            reshaped_data = data.reshape(
+                (self.devices, self.device_repeat * 3)
+            )
 
             # Create the pre_amble and post_amble arrays to match the device count
             pre_amble_repeated = np.tile(self.pre_amble, (self.devices, 1))
@@ -145,7 +147,8 @@ class ArtNetDevice(NetworkedDevice):
 
             # Concatenate the pre_amble, reshaped data, and post_amble along the second axis
             full_device_data = np.concatenate(
-                (pre_amble_repeated, reshaped_data, post_amble_repeated), axis=1
+                (pre_amble_repeated, reshaped_data, post_amble_repeated),
+                axis=1,
             )
 
             devices_data[:] = full_device_data.ravel()


### PR DESCRIPTION
By adding a device_repeat config param to artnet, the user can select how many pixels to slice out and repeat sequences of 

pre_amble - device_pixels - post_amble.

This way a user with serialised chains of devices with the same format can be supported.

ie where D is dimmer

DRGB00 DRGB00 DRG00

Testing as per

https://discord.com/channels/469985374052286474/1277704338566938666/1279465537553825823

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new configuration option, `device_repeat`, allowing users to specify the number of pixels consumed per device, enhancing flexibility in pixel data handling.

- **Improvements**
  - Updated the data transmission logic for the ArtNetDevice, ensuring better control over how pixel data is structured and sent across multiple devices.
  - Enhanced documentation for the Artnet Device, including clearer explanations and examples related to the new `device_repeat` functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->