### PR TITLE
fix for failed Apple Silicon builds

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -305,6 +305,7 @@ jobs:
 
       - name: Install LedFx
         run: |
+          export CFLAGS="-Wno-incompatible-function-pointer-types"
           poetry install --with dev
 
       - name: Check LedFx launches

--- a/.github/workflows/test-build-binaries.yml
+++ b/.github/workflows/test-build-binaries.yml
@@ -230,6 +230,7 @@ jobs:
           export PATH="/opt/homebrew/opt/mbedtls@2/bin:$PATH"
           export LDFLAGS="-L/opt/homebrew/opt/mbedtls@2/lib"
           export CPPFLAGS="-I/opt/homebrew/opt/mbedtls@2/include"
+          export CFLAGS="-Wno-incompatible-function-pointer-types"
           poetry install --with dev --extras hue
       - name: Get LedFx Version
         id: ledfx-version


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build configuration to suppress warnings related to incompatible function pointer types in GitHub Actions workflows. This change enhances the build process and may improve compatibility during dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->