### PR TITLE
Fix: Overlapping segments of virtuals could lead to orphaned device updates

### DIFF
--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -700,11 +700,11 @@ class Virtual:
             f"Virtual {self.id}: Activating with segments {self._segments}"
         )
         if not self._active:
+            self._active = True
             try:
                 self.activate_segments(self._segments)
             except ValueError as e:
                 _LOGGER.error(e)
-            self._active = True
             self._os_active = False
 
         # self.thread_function()


### PR DESCRIPTION
Ensure that a virtual is active prior to adding segments to ensure the at the priority virtual is correct when begin cached

This was difficult to trigger, but it was possible to leave a device with a None priority virutal, as the new virtual being applied was not set to active until after segments were added.

Been looking for side effects but cannot find them.

Reproduction scenario discussed in

https://discord.com/channels/469985374052286474/1285038362327126056


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the activation process to ensure the system reflects an activation attempt, even if an error occurs during segment activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->