### PR TITLE
Fix: remove wled_on_deactivate

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -52,7 +52,6 @@ You may instead ask for any number of the config keys:
 - *user_presets*
 - *ledfx_presets*
 - *flush_on_deactivate*
-- *wled_on_deactivate*
 
 example: Get LedFx audio configuration
 

--- a/ledfx/api/utils.py
+++ b/ledfx/api/utils.py
@@ -53,7 +53,6 @@ PERMITTED_KEYS = {
         "global_brightness",
         "melbank_collection",
         "flush_on_deactivate",
-        "wled_on_deactivate",
     ),
 }
 

--- a/ledfx/config.py
+++ b/ledfx/config.py
@@ -44,7 +44,6 @@ CORE_CONFIG_KEYS_NO_RESTART = [
     "visualisation_maxlen",
     "visualisation_fps",
     "flush_on_deactivate",
-    "wled_on_deactivate",
 ]
 # Collection of keys that are used for visualisation configuration - used to check if we need to restart the visualisation event listeners
 VISUALISATION_CONFIG_KEYS = [
@@ -137,7 +136,6 @@ CORE_CONFIG_SCHEMA = vol.Schema(
         vol.Optional("scan_on_startup", default=False): bool,
         vol.Optional("create_segments", default=False): bool,
         vol.Optional("flush_on_deactivate", default=False): bool,
-        vol.Optional("wled_on_deactivate", default=True): bool,
         vol.Optional("wled_preferences", default={}): dict,
         vol.Optional(
             "configuration_version", default=CONFIGURATION_VERSION


### PR DESCRIPTION
Remove any trace of wled_on_deactivate

On consideration wled off behaviour is good enough.

ledfx can wake up an off device and it returns to off when deactivated within ledfx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated API documentation to reflect the removal of the `wled_on_deactivate` configuration option, reducing the total available options.
  
- **Configuration Changes**
	- Removed the `wled_on_deactivate` setting from configuration management, affecting how deactivation scenarios are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->