### PR TITLE
Feature: Allow hard off in oneshot api

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -728,12 +728,14 @@ returns
 | Intended to allow integration of instantaneous game effects over all active virtual
 | Repeated oneshot will overwrite the previous oneshot if has not finished
 
-| color: The color to which we wish to fill the virtual, any format supported
+| color: The color to which we wish to fill the virtual, any format supported, default is white
 | ramp: The time in ms over which to ramp the color from zero to full weight over the active effect
 | hold: The time in ms to hold the color to full weight over the active effect
 | fade: The time in ms to fade the color from full weight to zero over the active effect
 
-At least one of ramp, hold or fade must be specified
+If all values for ramp, hold and fade are zero, which is default, any exisiting oneshot will be cleared
+
+A bare call to onsshot will result in a hard disable of any existing oneshot that is executing
 
 .. code-block:: json
 
@@ -871,12 +873,14 @@ returns
 | Intended to allow integration of instantaneous game effects over any active virtual
 | Repeated oneshot to a virtual will overwrite the previous oneshot if has not finished
 
-| color: The color to which we wish to fill the virtual, any format supported
+| color: The color to which we wish to fill the virtual, any format supported, default is white
 | ramp: The time in ms over which to ramp the color from zero to full weight over the active effect
 | hold: The time in ms to hold the color to full weight over the active effect
 | fade: The time in ms to fade the color from full weight to zero over the active effect
 
-At least one of ramp, hold or fade must be specified
+If all values for ramp, hold and fade are zero, which is default, any exisiting oneshot will be cleared
+
+A bare call to onsshot will result in a hard disable of any existing oneshot that is executing
 
 .. code-block:: json
 

--- a/ledfx/api/virtual_tools.py
+++ b/ledfx/api/virtual_tools.py
@@ -48,20 +48,14 @@ class VirtualToolsEndpoint(RestEndpoint):
                     virtual.force_frame(parse_color(validate_color(color)))
 
         if tool == "oneshot":
-            color = data.get("color")
-            if color is None:
-                return await self.invalid_request(
-                    "Required attribute for oneshot, color was not provided"
-                )
+            color = data.get("color", "white")
 
             ramp = data.get("ramp", 0)
             hold = data.get("hold", 0)
             fade = data.get("fade", 0)
 
-            if ramp == 0 and hold == 0 and fade == 0:
-                return await self.invalid_request(
-                    "At least one of ramp, hold or fade must be greater than 0"
-                )
+            # if all values are zero, we will now just ensure any current
+            # oneshot are cancelled
 
             # iterate through all virtuals and apply oneshot
             for virtual_id in self._ledfx.virtuals:

--- a/ledfx/api/virtuals_tools.py
+++ b/ledfx/api/virtuals_tools.py
@@ -102,20 +102,14 @@ class VirtualsToolsEndpoint(RestEndpoint):
                 )
 
         if tool == "oneshot":
-            color = data.get("color")
-            if color is None:
-                return await self.invalid_request(
-                    "Required attribute for oneshot, color was not provided"
-                )
+            color = data.get("color", "white")
 
             ramp = data.get("ramp", 0)
             hold = data.get("hold", 0)
             fade = data.get("fade", 0)
 
-            if sum(ramp, hold, fade) == 0:
-                return await self.invalid_request(
-                    "At least one of ramp, hold or fade must be greater than 0"
-                )
+            # if all values are zero, we will now just ensure any current
+            # oneshot are cancelled
 
             result = virtual.oneshot(
                 parse_color(validate_color(color)), ramp, hold, fade

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -505,9 +505,9 @@ class Virtual:
         Following calls will override any active one shot
 
         Parameters:
-            ramp time from 0% to 100% in ms
-            hold time at 100% in ms
-            fade time from 100% to 0% in ms
+            ramp time from in ms
+            hold time in ms
+            fade time in ms
         Returns:
             True if oneshot was activated, False if not
         """
@@ -520,7 +520,13 @@ class Virtual:
             self._os_hold_end = self._os_ramp + self._os_hold
             self._os_fade_end = self._os_ramp + self._os_hold + self._os_fade
             self._os_weight = 0.0
-            self._os_active = True
+
+            # if all total timings are zero, treat as a hard off
+            if self._os_fade_end == 0:
+                self._os_active = False
+            else:
+                self._os_active = True
+
             result = True
         else:
             result = False


### PR DESCRIPTION
Default color to white, so no color needs to be provided
Treat all zero timings as a hard off

Calls with missing ramp, hold, fade values will be default to zero
Calls with all zero will be treated as a hard off for any existing one shot

Tested with postman, sending virtual_tool and virtual_tools variants with explicit and default zeros against long running oneshots.

Tested default color to white as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The default color for the `oneshot` functionality is now set to white.
	- Enhanced behavior: If all parameters (`ramp`, `hold`, `fade`) are set to zero, existing oneshot actions will be cleared.

- **Bug Fixes**
	- Simplified input validation for the `oneshot` tool, removing unnecessary checks that could lead to invalid requests.

- **Documentation**
	- Updated documentation for `oneshot` parameters to clarify their behavior and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->