### PR TITLE
Feature: add Deactive to black switch

### DIFF
--- a/frontend/src/pages/Settings/GeneralCard.tsx
+++ b/frontend/src/pages/Settings/GeneralCard.tsx
@@ -9,7 +9,7 @@ import {
   Info
 } from '@mui/icons-material'
 import isElectron from 'is-electron'
-import { Divider } from '@mui/material'
+import { Divider, Tooltip } from '@mui/material'
 import useStore from '../../store/useStore'
 import { deleteFrontendConfig, download } from '../../utils/helpers'
 import PopoverSure from '../../components/Popover/Popover'
@@ -186,6 +186,23 @@ const GeneralCard = () => {
             onSystemSettingsChange('create_segments', !settings.create_segments)
           }
         />
+      </div>
+      <div
+        className={`${classes.settingsRow} step-settings-ten `}
+        style={{ flexBasis: '100%' }}
+      >
+        <label>Deactivate to black</label>
+        <Tooltip title="On deactivation, virtuals and devices will fill pixels with black. If off pixels will be left with the last rendered color from before deactivation, this is the original LedFX behaviour">
+          <SettingsSwitch
+            checked={settings.flush_on_deactivate}
+            onChange={() =>
+              onSystemSettingsChange(
+                'flush_on_deactivate',
+                !settings.flush_on_deactivate
+              )
+            }
+          />
+        </Tooltip>
       </div>
     </div>
   )

--- a/frontend/src/store/api/storeConfig.tsx
+++ b/frontend/src/store/api/storeConfig.tsx
@@ -81,6 +81,7 @@ export interface ISystemConfig {
   configuration_version: string
   scenes: undefined
   scan_on_startup: boolean
+  flush_on_deactivate: boolean
 }
 
 const storeConfig = (set: any) => ({


### PR DESCRIPTION
Inheriting from 

https://github.com/YeonV/LedFx-Frontend-v2/commit/37d100e1fac155894d463f2922065d789075b378

I think I have not submitted some key assets post build, advice needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new settings option "Deactivate to black" in the GeneralCard component.
	- Added a tooltip providing information about the new setting, allowing users to toggle the `flush_on_deactivate` functionality.
- **Enhancements**
	- Updated system configuration options to include the `flush_on_deactivate` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->