### PR TITLE
Use all audio channels for sound input

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -326,9 +326,8 @@ class AudioInputSource:
             device = input_devices[device_idx]
             if hostapis[device["hostapi"]]["name"] == "Windows WASAPI":
                 if "Loopback" in device["name"]:
-                    ch = device["max_input_channels"]
                     _LOGGER.info(
-                        f"Loopback device detected: {device['name']} with {ch} channels"
+                        f"Loopback device detected: {device['name']} with {device["max_input_channels"]} channels"
                     )
 
             if hostapis[device["hostapi"]]["name"] == "WEB AUDIO":

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -308,7 +308,9 @@ class AudioInputSource:
                     ch = 2
                 if "Logitech G560" in device["name"]:
                     ch = 8
-                    _LOGGER.warning("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Special Logitech clause triggered")
+                    _LOGGER.warning(
+                        "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Special Logitech clause triggered"
+                    )
 
             if hostapis[device["hostapi"]]["name"] == "WEB AUDIO":
                 ledfx.api.websocket.ACTIVE_AUDIO_STREAM = self._stream = (

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -72,7 +72,7 @@ class AudioInputSource:
         default_output_device_idx = sd.default.device["output"]
         default_input_device_idx = sd.default.device["input"]
         if len(device_list) == 0 or default_output_device_idx == -1:
-            _LOGGER.warn("No audio output devices found.")
+            _LOGGER.warning("No audio output devices found.")
         else:
             # target device should be the name of the default_output device plus " [Loopback]"
             default_output_device_name = device_list[
@@ -237,15 +237,16 @@ class AudioInputSource:
             self.deactivate()
             return
         valid_device_indexes = self.valid_device_indexes()
-
         _LOGGER.debug("********************************************")
         _LOGGER.debug("Valid audio input devices:")
         for index in valid_device_indexes:
+            hostapi_name = hostapis[input_devices[index]["hostapi"]]["name"]
+            device_name = input_devices[index]["name"]
+            input_channels = input_devices[index]["max_input_channels"]
             _LOGGER.debug(
-                f"Audio Device {index}\t{hostapis[input_devices[index]["hostapi"]]["name"]}\t{input_devices[index]['name']}\tinput_channels: {input_devices[index]['max_input_channels']}"
+                f"Audio Device {index}\t{hostapi_name}\t{device_name}\tinput_channels: {input_channels}"
             )
         _LOGGER.debug("********************************************")
-
         device_idx = self._config["audio_device"]
         _LOGGER.debug(
             f"default_device: {default_device} config_device: {device_idx}"

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -2,6 +2,7 @@ import logging
 import queue
 import threading
 import time
+import json
 from collections import deque
 from functools import cached_property, lru_cache
 
@@ -216,6 +217,11 @@ class AudioInputSource:
         # Enumerate all of the input devices and find the one matching the
         # configured host api and device name
         input_devices = self.query_devices()
+
+        _LOGGER.debug("********************************************")
+        _LOGGER.debug(f"Sound Device query_devices: {json.dumps(input_devices, indent=4)}")
+        _LOGGER.debug("********************************************")
+
         hostapis = self.query_hostapis()
         default_device = self.default_device_index()
         if default_device is None:
@@ -229,6 +235,8 @@ class AudioInputSource:
             return
         valid_device_indexes = self.valid_device_indexes()
         device_idx = self._config["audio_device"]
+        _LOGGER.debug(f"default_device: {default_device}")
+        _LOGGER.debug(f"config_device: {device_idx}")
 
         if device_idx > max(valid_device_indexes):
             _LOGGER.warning(
@@ -241,7 +249,7 @@ class AudioInputSource:
                 f"Audio device {input_devices[device_idx]['name']} has no input channels. Reverting to default input device."
             )
             device_idx = default_device
-
+        _LOGGER.debug(f"final id: {device_idx}")
         # Setup a pre-emphasis filter to balance the input volume of lows to highs
         self.pre_emphasis = aubio.digital_filter(3)
         # depending on the coeffs type, we need to use different pre_emphasis values to make em work better. allegedly.

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import queue
 import threading

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -75,14 +75,19 @@ class AudioInputSource:
             _LOGGER.warn("No audio output devices found.")
         else:
             # target device should be the name of the default_output device plus " [Loopback]"
-            target_device = device_list[default_output_device]['name']
+            target_device = device_list[default_output_device]["name"]
 
             # We need to run over the device list looking for the target device
             # NOTE: Some sound drivers truncate the device name, so we may not find a match
-            _LOGGER.debug(f"Looking for default audio loopback device: {default_output_device} {target_device}")
+            _LOGGER.debug(
+                f"Looking for default audio loopback device: {default_output_device} {target_device}"
+            )
             for device_index, device in enumerate(device_list):
                 # sometimes the audio device name string is truncated, so we need to match what we have and Loopback but otherwise be sloppy
-                if target_device in device["name"] and "[Loopback]" in device["name"]:
+                if (
+                    target_device in device["name"]
+                    and "[Loopback]" in device["name"]
+                ):
                     # Return the loopback device index
                     _LOGGER.debug(
                         f"Default audio loopback device found: {device_index} {device['name']}"
@@ -109,7 +114,8 @@ class AudioInputSource:
                 if len(valid_device_indexes) > 0:
                     first_valid = next(iter(valid_device_indexes))
                     _LOGGER.debug(
-                        f"No valid default audio input device found. Using first valid input device: {first_valid}")
+                        f"No valid default audio input device found. Using first valid input device: {first_valid}"
+                    )
                     return first_valid
 
     @staticmethod
@@ -232,14 +238,19 @@ class AudioInputSource:
             return
         valid_device_indexes = self.valid_device_indexes()
 
-        _LOGGER.debug("********************************************\nvalid_devices")
+        _LOGGER.debug(
+            "********************************************\nvalid_devices"
+        )
         for index in valid_device_indexes:
             _LOGGER.debug(
-                f"Audio Device {index}\t{hostapis[input_devices[index]["hostapi"]]["name"]}\t{input_devices[index]['name']}\tinput_channels: {input_devices[index]['max_input_channels']}")
+                f"Audio Device {index}\t{hostapis[input_devices[index]["hostapi"]]["name"]}\t{input_devices[index]['name']}\tinput_channels: {input_devices[index]['max_input_channels']}"
+            )
         _LOGGER.debug("********************************************")
 
         device_idx = self._config["audio_device"]
-        _LOGGER.debug(f"default_device: {default_device} config_device: {device_idx}")
+        _LOGGER.debug(
+            f"default_device: {default_device} config_device: {device_idx}"
+        )
 
         if device_idx > max(valid_device_indexes):
             _LOGGER.warning(
@@ -307,7 +318,9 @@ class AudioInputSource:
             if hostapis[device["hostapi"]]["name"] == "Windows WASAPI":
                 if "Loopback" in device["name"]:
                     ch = device["max_input_channels"]
-                    _LOGGER.info(f"Loopback device detected: {device['name']} setting channels to {ch}")
+                    _LOGGER.info(
+                        f"Loopback device detected: {device['name']} setting channels to {ch}"
+                    )
 
                     if ch != 2:
                         _LOGGER.warning(

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -327,7 +327,7 @@ class AudioInputSource:
             if hostapis[device["hostapi"]]["name"] == "Windows WASAPI":
                 if "Loopback" in device["name"]:
                     _LOGGER.info(
-                        f"Loopback device detected: {device['name']} with {device["max_input_channels"]} channels"
+                        f"Loopback device detected: {device['name']} with {device['max_input_channels']} channels"
                     )
 
             if hostapis[device["hostapi"]]["name"] == "WEB AUDIO":

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -304,6 +304,9 @@ class AudioInputSource:
             if hostapis[device["hostapi"]]["name"] == "Windows WASAPI":
                 if "Loopback" in device["name"]:
                     ch = 2
+                if "Logitech G560" in device["name"]:
+                    ch = 8
+                    _LOGGER.warning("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Special Logitech clause triggered")
 
             if hostapis[device["hostapi"]]["name"] == "WEB AUDIO":
                 ledfx.api.websocket.ACTIVE_AUDIO_STREAM = self._stream = (


### PR DESCRIPTION
Updated logging and removal of number of channels to open - by default will open all channels for the device.

We downmix to mono as part of resampling so this does not make us "stereo" - we will use the mean of all channels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for selecting and activating audio devices, improving the identification of default output and input devices.
	- Introduced dynamic channel count for loopback devices based on available input channels.

- **Bug Fixes**
	- Improved robustness in detecting loopback audio devices and handling invalid device indices.

- **Documentation**
	- Expanded logging for better traceability during audio device activation and selection processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->