### PR TITLE
Fix PortAudioError fallback missing activation flag

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -336,6 +336,7 @@ class AudioInputSource:
         except sd.PortAudioError as e:
             _LOGGER.error(f"{e}, Reverting to default input device")
             open_audio_stream(default_device)
+            self._is_activated = True
 
     def deactivate(self):
         with self.lock:


### PR DESCRIPTION
A fallback to the default device due to a PortAudioError during activation is was missing a change to the _is_activated flag.

The side effect of this, as multiple callbacks are registered against the audio device, multiple streams are opened against the default device. This leads to a Access violation and silent death of ledfx.

Noticed via debug spam on activation of audiodevice when we should only see it once. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for audio stream activation, ensuring the system correctly updates the activation state even when an error occurs while opening an audio device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->