### PR TITLE
Fix: improve queue protection

### DIFF
--- a/ledfx/effects/melt_and_sparkle.py
+++ b/ledfx/effects/melt_and_sparkle.py
@@ -8,7 +8,6 @@ from ledfx.effects import smooth
 from ledfx.effects.audio import AudioReactiveEffect
 from ledfx.effects.hsv_effect import HSVEffect
 from ledfx.effects.math import triangle
-from ledfx.utils import empty_queue
 
 
 class MeltSparkle(AudioReactiveEffect, HSVEffect):

--- a/ledfx/effects/melt_and_sparkle.py
+++ b/ledfx/effects/melt_and_sparkle.py
@@ -79,11 +79,6 @@ class MeltSparkle(AudioReactiveEffect, HSVEffect):
         self.strobe_overlay = np.zeros(self.pixel_count)
         self.onsets_queue = queue.Queue()
 
-    def deactivate(self):
-        empty_queue(self.onsets_queue)
-        self.onsets_queue = None
-        return super().deactivate()
-
     def config_updated(self, config):
         # lows power seems to be on a 0-1 scale
         self._lows_power = 0
@@ -130,6 +125,7 @@ class MeltSparkle(AudioReactiveEffect, HSVEffect):
             data.onset()
             and currentTime - self.last_strobe_time > self.strobe_wait_time
             and intensities[2] > self.strobe_cutoff
+            and self.onsets_queue is not None
         ):
             self.onsets_queue.put(True)
             self.last_strobe_time = currentTime

--- a/ledfx/effects/real_strobe.py
+++ b/ledfx/effects/real_strobe.py
@@ -61,7 +61,10 @@ class Strobe(AudioReactiveEffect, GradientEffect):
         self.onsets_queue = queue.Queue()
 
     def deactivate(self):
-        empty_queue(self.onsets_queue)
+        # Sometimes we lose the queue? No idea why.
+        # Second protection from sentry sighting
+        if self.onsets_queue is not None:
+            empty_queue(self.onsets_queue)
         self.onsets_queue = None
         return super().deactivate()
 

--- a/ledfx/effects/real_strobe.py
+++ b/ledfx/effects/real_strobe.py
@@ -60,14 +60,6 @@ class Strobe(AudioReactiveEffect, GradientEffect):
         self.bass_strobe_overlay = np.zeros(np.shape(self.pixels))
         self.onsets_queue = queue.Queue()
 
-    def deactivate(self):
-        # Sometimes we lose the queue? No idea why.
-        # Second protection from sentry sighting
-        if self.onsets_queue is not None:
-            empty_queue(self.onsets_queue)
-        self.onsets_queue = None
-        return super().deactivate()
-
     def config_updated(self, config):
         self.color_shift_step = self._config["color_step"]
 

--- a/ledfx/effects/real_strobe.py
+++ b/ledfx/effects/real_strobe.py
@@ -7,7 +7,6 @@ import voluptuous as vol
 from ledfx.color import parse_color, validate_color, validate_gradient
 from ledfx.effects.audio import AudioReactiveEffect
 from ledfx.effects.gradient import GradientEffect
-from ledfx.utils import empty_queue
 
 
 class Strobe(AudioReactiveEffect, GradientEffect):

--- a/ledfx/effects/real_strobe.py
+++ b/ledfx/effects/real_strobe.py
@@ -55,6 +55,10 @@ class Strobe(AudioReactiveEffect, GradientEffect):
         }
     )
 
+    def __init__(self, ledfx, config):
+        super().__init__(ledfx, config)
+        self.onsets_queue = queue.Queue()
+
     def on_activate(self, pixel_count):
         self.strobe_overlay = np.zeros(np.shape(self.pixels))
         self.bass_strobe_overlay = np.zeros(np.shape(self.pixels))


### PR DESCRIPTION
Sentry crash sighting https://github.com/LedFx/LedFx/issues/1097

Allow gc to handle queue going out of scope
Add protection to melt_and_sparkle

Tested Strobe is still functional with change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the onsets queue in the Strobe effect to prevent potential errors during activation and rendering.
	- Added checks to ensure the onsets queue is initialized before use.

- **New Features**
	- Enhanced audio reactivity and strobe effect management in the MeltSparkle and Strobe classes.
	- Updated configuration options for strobe effects, including color shifts and decay rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->