### PR TITLE
Fix: missing default in rpi_ws281x

### DIFF
--- a/ledfx/devices/rpi_ws281x.py
+++ b/ledfx/devices/rpi_ws281x.py
@@ -44,6 +44,7 @@ class RPI_WS281X(Device):
                 vol.Required(
                     "gpio_pin",
                     description="Raspberry Pi GPIO pin your LEDs are connected to",
+                    default=21,
                 ): vol.In(list([21, 31])),
                 vol.Required(
                     "color_order", description="Color order", default="RGB"


### PR DESCRIPTION
Without this default the UI will not create device without interaction on the drop down

https://discord.com/channels/469985374052286474/1234129876278181938/1238840489013149706

I have no position on if this device works itself, but this needs fixing regardless

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Default GPIO pin value set to `21` for easier LED configuration.
  
- **Bug Fixes**
	- Corrected the iteration logic in the `flush` method to ensure proper LED data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->