### PR TITLE
Fix: Protect against mismatched shapes during transitions

### DIFF
--- a/ledfx/transitions.py
+++ b/ledfx/transitions.py
@@ -1,5 +1,6 @@
-import numpy as np
 import logging
+
+import numpy as np
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +35,9 @@ class Transitions(metaclass=IterClass):
 
     def pre_validate(self, x1, x2):
         if np.shape(x1) != np.shape(x2):
-            _LOGGER.error(f"Transitions.pre_validate: Shapes of x1 and x2 do not match: {np.shape(x1)} != {np.shape(x2)}")
+            _LOGGER.error(
+                f"Transitions.pre_validate: Shapes of x1 and x2 do not match: {np.shape(x1)} != {np.shape(x2)}"
+            )
             return False
         return True
 

--- a/ledfx/transitions.py
+++ b/ledfx/transitions.py
@@ -1,4 +1,7 @@
 import numpy as np
+import logging
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class IterClass(type):
@@ -28,6 +31,12 @@ class Transitions(metaclass=IterClass):
     def _validate(x1, x2, weight):
         assert np.shape(x1) == np.shape(x2)
         assert 0 <= weight <= 1
+
+    def pre_validate(self, x1, x2):
+        if np.shape(x1) != () and np.shape(x2) != () and np.shape(x1) != np.shape(x2):
+            _LOGGER.error(f"Transitions.pre_validate: Shapes of x1 and x2 do not match: {np.shape(x1)} != {np.shape(x2)}")
+            return False
+        return True
 
     def add(self, x1, x2, weight):
         """

--- a/ledfx/transitions.py
+++ b/ledfx/transitions.py
@@ -33,7 +33,7 @@ class Transitions(metaclass=IterClass):
         assert 0 <= weight <= 1
 
     def pre_validate(self, x1, x2):
-        if np.shape(x1) != () and np.shape(x2) != () and np.shape(x1) != np.shape(x2):
+        if np.shape(x1) != np.shape(x2):
             _LOGGER.error(f"Transitions.pre_validate: Shapes of x1 and x2 do not match: {np.shape(x1)} != {np.shape(x2)}")
             return False
         return True

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -676,9 +676,12 @@ class Virtual:
                         / self.transition_frame_total
                     )
 
-                self.frame_transitions(
-                    self.transitions, frame, transition_frame, weight
-                )
+                # we will pre validate the transition, which will generate a sentry report if it fails and return False
+                if self.transitions.pre_validate(frame, transition_frame):
+                    # only call the transition effect if it will not crash
+                    self.frame_transitions(
+                        self.transitions, frame, transition_frame, weight
+                    )
                 if (
                     self.transition_frame_counter
                     == self.transition_frame_total


### PR DESCRIPTION
Its a high hitter in our general population

Have seen it a few times myself while manually developing.

I have tried extensively to get a deterministic reproduction but have not triggered in 20,000+ randomised tests.

Adding a protection that will skip the transition effect if the frames are not of the same shape

Should be passive.

_LOGGER.error should report into Sentry still.

Protects against https://github.com/LedFx/LedFx/issues/1121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a validation mechanism for transition effects, ensuring that only valid transitions are executed.
	- Added a new method to check input array compatibility before processing transitions.

- **Bug Fixes**
	- Enhanced error logging for invalid transition scenarios, improving troubleshooting and user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->