### PR TITLE
Feat: Support speed_option_1 = 0 as center text for side_scroll texter2d

### DIFF
--- a/ledfx/effects/texter2d.py
+++ b/ledfx/effects/texter2d.py
@@ -260,8 +260,20 @@ class Texter2d(Twod, GradientEffect):
         # each word will be offset by the word before and a space
         # first we need the first word width in screen units
 
-        offset = 1
         self.base_speed = self.speed_option_1
+
+        if self.speed_option_1 != 0:
+            offset = 1
+        else:
+            # we want to center the text, so we need to know the overall sentence size
+            # we can then calculate the offset to center the text
+            sentence_width = 0
+            for idx, word in enumerate(self.sentence.wordblocks):
+                sentence_width += word.w_width
+                sentence_width += self.sentence.space_block.w_width
+            # remove the trailing space implication
+            sentence_width -= self.sentence.space_block.w_width
+            offset = -sentence_width / 2
 
         for idx, word in enumerate(self.sentence.wordblocks):
             offset += word.w_width / 2
@@ -280,7 +292,7 @@ class Texter2d(Twod, GradientEffect):
             # call the set_fallback function of the parent virtual as we completed a cycle
             self._virtual.fallback_fire = True
         for word in self.sentence.wordblocks:
-            if self.option_1:
+            if self.option_1 and self.speed_option_1 != 0:
                 word.pose.d_pos = (
                     self.base_speed
                     + (self.lows_impulse * self.multiplier * self.base_speed),

--- a/ledfx/effects/texter2d.py
+++ b/ledfx/effects/texter2d.py
@@ -262,7 +262,7 @@ class Texter2d(Twod, GradientEffect):
 
         self.base_speed = self.speed_option_1
 
-        if self.speed_option_1 != 0:
+        if self.base_speed != 0:
             offset = 1
         else:
             # we want to center the text, so we need to know the overall sentence size
@@ -292,7 +292,7 @@ class Texter2d(Twod, GradientEffect):
             # call the set_fallback function of the parent virtual as we completed a cycle
             self._virtual.fallback_fire = True
         for word in self.sentence.wordblocks:
-            if self.option_1 and self.speed_option_1 != 0:
+            if self.option_1 and self.base_speed != 0:
                 word.pose.d_pos = (
                     self.base_speed
                     + (self.lows_impulse * self.multiplier * self.base_speed),


### PR DESCRIPTION
All this needs rework to separate the text effects out once we have hierarchical effect selection

Then things like speed_option_1 can get renamed to effect specific behaviours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced text scrolling functionality for improved visual effects.
	- Text is now properly centered on the screen when there is no movement.

- **Bug Fixes**
	- Fixed issues with text positioning when the scrolling speed is set to zero, ensuring consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->