### PR TITLE
Fix: Parse background_color and check for None

### DIFF
--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -393,7 +393,7 @@ class Effect(BaseRegistry):
 
             self.flip = self._config["flip"]
             self.mirror = self._config["mirror"]
-            self.background_color = self._config["background_color"]
+            self.background_color = parse_color(self._config["background_color"])
             self.brightness = self._config["brightness"]
 
             def inherited(cls, method):
@@ -459,7 +459,7 @@ class Effect(BaseRegistry):
                         pixels = np.concatenate(
                             (pixels[-1 + len(pixels) % -2 :: -2], pixels[::2])
                         )
-                    if self.background_color:
+                    if self.background_color is not None:
                         pixels += self._bg_color
                     if self.brightness is not None:
                         np.multiply(


### PR DESCRIPTION
Ensure that background_color has been correctly parsed
Check for None to prevent crash