### PR TITLE
Fix: Add deduplication queue for vis update

### DIFF
--- a/ledfx/api/websocket.py
+++ b/ledfx/api/websocket.py
@@ -13,6 +13,7 @@ from aiohttp import web
 from ledfx.api import RestEndpoint
 from ledfx.events import Event
 from ledfx.utils import empty_queue
+from ledfx.dedupequeue import VisDeduplicateQ
 
 _LOGGER = logging.getLogger(__name__)
 MAX_PENDING_MESSAGES = 256
@@ -68,7 +69,7 @@ class WebsocketConnection:
         self._listeners = {}
         self._receiver_task = None
         self._sender_task = None
-        self._sender_queue = asyncio.Queue(maxsize=MAX_PENDING_MESSAGES)
+        self._sender_queue = VisDeduplicateQ(maxsize=MAX_PENDING_MESSAGES)
 
     def close(self):
         """

--- a/ledfx/dedupequeue.py
+++ b/ledfx/dedupequeue.py
@@ -7,6 +7,20 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class VisDeduplicateQ(asyncio.Queue):
+    """
+    Deduplicate queue for visualisation updates
+
+    Queues carrying visualisation updates to devices and virtual 
+    in the front end can lag hard if the front end is struggling.
+
+    Although the backend forces a queue flush if the depth gets to 256
+    any visualisation update in in the queue is just old data
+    it is better not to queue an update if one is already in the queue
+    rather than let 10s of old updates build up
+
+    Uses private access to  _queue to check for duplicates
+    """
+
     def __init__(self, maxsize=0):
         super().__init__(maxsize)
 

--- a/ledfx/dedupequeue.py
+++ b/ledfx/dedupequeue.py
@@ -16,8 +16,7 @@ class VisDeduplicateQ(asyncio.Queue):
         if item.get("event_type") == Event.DEVICE_UPDATE or item.get("event_type") == Event.VISUALISATION_UPDATE:
             # check if it is a duplicate and just return without queing if it is
             if any(self.is_similar(item, existing_item) for existing_item in self._queue):
-                # TODO: remove this logging
-                _LOGGER.warning(f"Queue: {hex(id(self))} discarding, qsize {self.qsize()}")
+                _LOGGER.info(f"Queue: {hex(id(self))} discarding, qsize {self.qsize()}")
                 return
         super().put_nowait(item)
 

--- a/ledfx/dedupequeue.py
+++ b/ledfx/dedupequeue.py
@@ -17,7 +17,7 @@ class VisDeduplicateQ(asyncio.Queue):
             # check if it is a duplicate and just return without queing if it is
             if any(self.is_similar(item, existing_item) for existing_item in self._queue):
                 # TODO: remove this logging
-                _LOGGER.warning(f"Queue: {id(self)} discarding, qsize {self.qsize()}")
+                _LOGGER.warning(f"Queue: {hex(id(self))} discarding, qsize {self.qsize()}")
                 return
         super().put_nowait(item)
 

--- a/ledfx/dedupequeue.py
+++ b/ledfx/dedupequeue.py
@@ -1,0 +1,29 @@
+import asyncio
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+from ledfx.events import (
+    Event,
+)
+
+class VisDeduplicateQ(asyncio.Queue):
+    def __init__(self, maxsize=0):
+        super().__init__(maxsize)
+
+    def put_nowait(self, item):
+        # Check if is a visualisation update message
+        if item.get("event_type") == Event.DEVICE_UPDATE or item.get("event_type") == Event.VISUALISATION_UPDATE:
+            # check if it is a duplicate and just return without queing if it is
+            if any(self.is_similar(item, existing_item) for existing_item in self._queue):
+                # TODO: remove this logging
+                _LOGGER.warning(f"Queue: {id(self)} discarding, qsize {self.qsize()}")
+                return
+        super().put_nowait(item)
+
+    def is_similar(self, new, queued):
+        # We know we are already one of the correct types, but is it the same as queued
+        # then check if it is for the same device
+        if new.get("event_type") == queued.get("event_type") and new.get("vis_id") == queued.get("vis_id"):
+            return True
+        return False

--- a/ledfx/dedupequeue.py
+++ b/ledfx/dedupequeue.py
@@ -10,7 +10,7 @@ class VisDeduplicateQ(asyncio.Queue):
     """
     Deduplicate queue for visualisation updates
 
-    Queues carrying visualisation updates to devices and virtual 
+    Queues carrying visualisation updates to devices and virtual
     in the front end can lag hard if the front end is struggling.
 
     Although the backend forces a queue flush if the depth gets to 256


### PR DESCRIPTION
Wrap the standard queue with a capability to throw away duplicated visualization updates for device and visualization

Tested by watching queue depth, with 13 live devices, and multiple browser instances we can lag the queue.

It used to fill to the 256 queue depth limit, then throw them all away on overflow

That protection is still in place, but now never triggers.

This is not the end of the story, we can still see considerable lag so there must be another buffer in the render pipeline above the socket to find...

Moved the debug on packet discard to info level, opening for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new message queue system that enhances message handling by preventing duplicates for visualization updates.
	- Added a logging mechanism to track duplicate message attempts.

- **Bug Fixes**
	- Improved error handling when the message queue is full, ensuring smoother message processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->