### PR TITLE
Fix: Deactivate devices when no active virtuals

### DIFF
--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -1300,9 +1300,11 @@ class Virtuals:
     def check_and_deactivate_devices(self):
         """
         Checks all active virtuals and segments to compile a list of active devices,
-        then deactivates any active devices not in that list. This process ensures that devices
-        are only deactivated if no virtual or segment is using them, which is especially
-        relevant during virtual or segment deactivation or reconfiguration.
+        then deactivates any active devices not in that list. 
+        
+        This process ensures that devices are only deactivated if no virtual or segment
+        is using them, which is especially relevant during virtual or segment deactivation
+        or reconfiguration.
 
         Note: This is a relatively expensive operation but only runs when a virtual
         is deactivated or segments are modified.

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -317,7 +317,7 @@ class Virtual:
             _LOGGER.debug(
                 f"Virtual {self.id}: updated with {len(self._segments)} segments, totalling {self.pixel_count} pixels"
             )
-            self._ledfx.virtuals.check_and_deactivate_devices
+            self._ledfx.virtuals.check_and_deactivate_devices()
 
     def set_preset(self, preset_info):
         """

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -1300,8 +1300,8 @@ class Virtuals:
     def check_and_deactivate_devices(self):
         """
         Checks all active virtuals and segments to compile a list of active devices,
-        then deactivates any active devices not in that list. 
-        
+        then deactivates any active devices not in that list.
+
         This process ensures that devices are only deactivated if no virtual or segment
         is using them, which is especially relevant during virtual or segment deactivation
         or reconfiguration.

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -1296,18 +1296,18 @@ class Virtuals:
 
     def get(self, *args):
         return self._virtuals.get(*args)
-    
+
     def check_and_deactivate_devices(self):
         """
         Checks all active virtuals and segments to compile a list of active devices,
-        then deactivates any active devices not in that list. This process ensures that devices 
+        then deactivates any active devices not in that list. This process ensures that devices
         are only deactivated if no virtual or segment is using them, which is especially
         relevant during virtual or segment deactivation or reconfiguration.
 
-        Note: This is a relatively expensive operation but only runs when a virtual 
+        Note: This is a relatively expensive operation but only runs when a virtual
         is deactivated or segments are modified.
         """
-        
+
         active_devices = set()
         for virtual in self.values():
             if virtual.active:
@@ -1315,7 +1315,9 @@ class Virtuals:
                     active_devices.add(device_id)
         for device in self._ledfx.devices.values():
             if device.id not in active_devices and device.is_active():
-                _LOGGER.info(f"Deactivating device {device.id} as it is not in use by any active virtuals")
+                _LOGGER.info(
+                    f"Deactivating device {device.id} as it is not in use by any active virtuals"
+                )
                 device.deactivate()
 
 


### PR DESCRIPTION
See function comments in diff for explanation

Intended to address https://github.com/LedFx/LedFx/issues/1174

TESTING:
Observing info logging in trivial cases seems healthy

Govee device now immediately returns to local effects on effect deactivation, and will now happily return to ledfx control if left for prior observed timeout, as we now correct reestablish udp control at the activate / session level

Some complex scenarios with multiple virtuals to non overlapping segments, behavior as expected, devices only deactivate when no segments being written

Segment edit scenarios leading to removal of last active segment on a device. Successfully deactivates and reactivates if added back

RISK: poorly exercised pre-existing device deactivate() override methods may have latent issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to check and deactivate unused devices, improving device management during virtual effects.
- **Improvements**
	- Enhanced the deactivation process for virtuals to ensure efficient device management.
	- Updated segment management to better handle device activation states.
- **Bug Fixes**
	- Improved logging messages for clearer feedback during activation and deactivation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->