### PR TITLE
Fix: Remove deprecated get_html_theme_path() call

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,6 @@ linkcheck_timeout = 2
 # a list of builtin themes.
 #
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 
 def setup(app):


### PR DESCRIPTION
as per

https://github.com/readthedocs/sphinx_rtd_theme/blob/master/sphinx_rtd_theme/__init__.py#L25