### PR TITLE
Fix: remove fallback warning level logging on rest path

### DIFF
--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -384,7 +384,7 @@ class Virtual:
                 raise ValueError(error)
 
             if fallback:
-                _LOGGER.warning("Fallback requested")
+                _LOGGER.info("Fallback requested")
                 if self._active_effect is not None:
                     if self.fallback_effect_type is None:
                         self.fallback_effect_type = self._active_effect.type


### PR DESCRIPTION
Demote warning level to info level to prevent propagation of debug to frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated logging level for fallback requests from warning to info, reflecting a change in operational communication.
	- Minor adjustments to comments and formatting for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->