### PR TITLE
Feat: fallback support for all effects with timer

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -638,10 +638,6 @@ Deletes a virtual with the matching *virtual_id*
 
 Endpoint linking virtuals to effects with the matching *virtual_id* as JSON
 
-A new optional param has been added to PUT and POST "fallback": (true / false). If true, the current running effect on the virtual will be set as the fallback.
-Fallback is currently only triggered by the completed scoll of texter2d with side scroll.
-This is intended for use cases such as temporarily displaying a track name before returning to the prior effect configuration.
-
 .. rubric:: GET
 
 Returns the active effect config of a virtual
@@ -658,6 +654,23 @@ Set the virtual to a new effect based on the provided JSON configuration
 .. rubric:: DELETE
 
 Clear the active effect of a virtual
+
+Fallback effects
+----------------
+
+/api/virtuals/{virtual_id}/effects has been extended for PUT and POST with an optional fallback parameter
+
+"fallback": (true / false / seconds) 
+
+If true ( 300 seconds ) or a value in float seconds, the current running effect on the virtual will be set as the fallback.
+
+Fallback is auto triggered by the completed scoll of texter2d with side scroll or the timer expiring
+
+This is intended for use cases such as temporarily displaying a track name before returning to the prior effect configuration.
+
+Additionally a running temporary effect can be cancelled by triggering the fallback via a call to /api/virtuals/{virtual_id}/fallback
+
+This can be used for interactive scenarios such as releasing a button that triggered the temporary effect.
 
 /api/virtuals/{virtual_id}/fallback
 ===================================

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -659,6 +659,15 @@ Set the virtual to a new effect based on the provided JSON configuration
 
 Clear the active effect of a virtual
 
+/api/virtuals/{virtual_id}/fallback
+===================================
+
+.. rubric:: GET
+
+Cancel the temporary effect on virtual_id and force the fallback to trigger, removes any fallback timers
+
+Use for a button release to clear the fallback effect cycle
+
 /api/virtuals/{virtual_id}/effects/delete
 =========================================
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -660,7 +660,7 @@ Fallback effects
 
 /api/virtuals/{virtual_id}/effects has been extended for PUT and POST with an optional fallback parameter
 
-"fallback": (true / false / seconds) 
+"fallback": (true / false / seconds)
 
 If true ( 300 seconds ) or a value in float seconds, the current running effect on the virtual will be set as the fallback.
 

--- a/ledfx/api/virtual_effects.py
+++ b/ledfx/api/virtual_effects.py
@@ -11,6 +11,11 @@ from ledfx.virtuals import update_effect_config
 
 _LOGGER = logging.getLogger(__name__)
 
+# set up a long default time for fallback, this is to prevent 
+# getting stuck in a temporary effect if the caller forgets to
+# set a time and the effect has not self triggered exit
+fallback_default_time = 300.0
+
 
 class EffectsEndpoint(RestEndpoint):
     ENDPOINT_PATH = "/api/virtuals/{virtual_id}/effects"
@@ -108,7 +113,18 @@ class EffectsEndpoint(RestEndpoint):
                         val = random.randint(lower, upper)
                 effect_config[setting.schema] = val
 
-        fallback = data.get("fallback", False)
+        fallback = data.get("fallback", None)
+        if isinstance(fallback, bool):
+            if fallback == False:
+                fallback = None
+            elif fallback == True:
+                # lets default to a time value so we never get stuck in a temproary effect
+                fallback = fallback_default_time
+        elif isinstance(fallback, (int, float)) and fallback > 0:
+            pass
+        else:
+            fallback = None 
+            
 
         # See if virtual's active effect type matches this effect type,
         # if so update the effect config
@@ -253,7 +269,17 @@ class EffectsEndpoint(RestEndpoint):
             ledfx=self._ledfx, type=effect_type, config=effect_config
         )
 
-        fallback = data.get("fallback", False)
+        fallback = data.get("fallback", None)
+        if isinstance(fallback, bool):
+            if fallback == False:
+                fallback = None
+            elif fallback == True:
+                # lets default to a time value so we never get stuck in a temproary effect
+                fallback = fallback_default_time
+        elif isinstance(fallback, (int, float)) and fallback > 0:
+            pass
+        else:
+            fallback = None 
 
         try:
             virtual.set_effect(effect, fallback=fallback)

--- a/ledfx/api/virtual_effects.py
+++ b/ledfx/api/virtual_effects.py
@@ -137,6 +137,11 @@ class EffectsEndpoint(RestEndpoint):
 
         fallback = process_fallback(data.get("fallback", None))
 
+        if fallback is not None and not virtual.active:
+            error_message = f"Unable to set effect: Virtual {virtual_id} is off or being streamed to"
+            _LOGGER.warning(error_message)
+            return await self.invalid_request(error_message, "error", resp_code=409)
+
         # See if virtual's active effect type matches this effect type,
         # if so update the effect config
         # otherwise, create a new effect and add it to the virtual
@@ -282,6 +287,14 @@ class EffectsEndpoint(RestEndpoint):
 
         fallback = process_fallback(data.get("fallback", None))
 
+        if fallback is not None and not virtual.active:
+            error_message = f"Unable to set effect: Virtual {virtual_id} is off or being streamed to"
+            _LOGGER.warning(error_message)
+            return await self.invalid_request(error_message, "error", resp_code=409)
+
+        # See if virtual's active effect type matches this effect type,
+        # if so update the effect config
+        # otherwise, create a new effect and add it to the virtual
         try:
             virtual.set_effect(effect, fallback=fallback)
         except (ValueError, RuntimeError) as msg:

--- a/ledfx/api/virtual_effects.py
+++ b/ledfx/api/virtual_effects.py
@@ -13,13 +13,16 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def process_fallback(fallback):
-    """_summary_
+    """converts the fallback param to a sanitized value
 
     Args:
         fallback (None, Bool, float, int): Fallback behaviour
+            - None: No fallback
+            - Bool: True uses a default fallback time, False no fallback
+            - float/int: fallback time in seconds
 
     Returns:
-        Sanitized falback time or None
+        float:None: Sanitized falback time or None
     """
     if isinstance(fallback, bool):
         if fallback is False:

--- a/ledfx/api/virtual_effects.py
+++ b/ledfx/api/virtual_effects.py
@@ -115,9 +115,9 @@ class EffectsEndpoint(RestEndpoint):
 
         fallback = data.get("fallback", None)
         if isinstance(fallback, bool):
-            if fallback == False:
+            if fallback is False:
                 fallback = None
-            elif fallback == True:
+            elif fallback is True:
                 # lets default to a time value so we never get stuck in a temproary effect
                 fallback = fallback_default_time
         elif isinstance(fallback, (int, float)) and fallback > 0:
@@ -270,9 +270,9 @@ class EffectsEndpoint(RestEndpoint):
 
         fallback = data.get("fallback", None)
         if isinstance(fallback, bool):
-            if fallback == False:
+            if fallback is False:
                 fallback = None
-            elif fallback == True:
+            elif fallback is True:
                 # lets default to a time value so we never get stuck in a temproary effect
                 fallback = fallback_default_time
         elif isinstance(fallback, (int, float)) and fallback > 0:

--- a/ledfx/api/virtual_effects.py
+++ b/ledfx/api/virtual_effects.py
@@ -296,9 +296,6 @@ class EffectsEndpoint(RestEndpoint):
                 error_message, "error", resp_code=409
             )
 
-        # See if virtual's active effect type matches this effect type,
-        # if so update the effect config
-        # otherwise, create a new effect and add it to the virtual
         try:
             virtual.set_effect(effect, fallback=fallback)
         except (ValueError, RuntimeError) as msg:

--- a/ledfx/api/virtual_effects.py
+++ b/ledfx/api/virtual_effects.py
@@ -11,7 +11,7 @@ from ledfx.virtuals import update_effect_config
 
 _LOGGER = logging.getLogger(__name__)
 
-# set up a long default time for fallback, this is to prevent 
+# set up a long default time for fallback, this is to prevent
 # getting stuck in a temporary effect if the caller forgets to
 # set a time and the effect has not self triggered exit
 fallback_default_time = 300.0
@@ -123,8 +123,7 @@ class EffectsEndpoint(RestEndpoint):
         elif isinstance(fallback, (int, float)) and fallback > 0:
             pass
         else:
-            fallback = None 
-            
+            fallback = None
 
         # See if virtual's active effect type matches this effect type,
         # if so update the effect config
@@ -279,7 +278,7 @@ class EffectsEndpoint(RestEndpoint):
         elif isinstance(fallback, (int, float)) and fallback > 0:
             pass
         else:
-            fallback = None 
+            fallback = None
 
         try:
             virtual.set_effect(effect, fallback=fallback)

--- a/ledfx/api/virtual_effects.py
+++ b/ledfx/api/virtual_effects.py
@@ -140,7 +140,9 @@ class EffectsEndpoint(RestEndpoint):
         if fallback is not None and not virtual.active:
             error_message = f"Unable to set effect: Virtual {virtual_id} is off or being streamed to"
             _LOGGER.warning(error_message)
-            return await self.invalid_request(error_message, "error", resp_code=409)
+            return await self.invalid_request(
+                error_message, "error", resp_code=409
+            )
 
         # See if virtual's active effect type matches this effect type,
         # if so update the effect config
@@ -290,7 +292,9 @@ class EffectsEndpoint(RestEndpoint):
         if fallback is not None and not virtual.active:
             error_message = f"Unable to set effect: Virtual {virtual_id} is off or being streamed to"
             _LOGGER.warning(error_message)
-            return await self.invalid_request(error_message, "error", resp_code=409)
+            return await self.invalid_request(
+                error_message, "error", resp_code=409
+            )
 
         # See if virtual's active effect type matches this effect type,
         # if so update the effect config

--- a/ledfx/api/virtual_effects_cancel_fallback.py
+++ b/ledfx/api/virtual_effects_cancel_fallback.py
@@ -1,0 +1,33 @@
+import logging
+
+from aiohttp import web
+
+from ledfx.api import RestEndpoint
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EffectsEndpoint(RestEndpoint):
+    ENDPOINT_PATH = "/api/virtuals/{virtual_id}/cancel_fallback"
+
+    async def get(self, virtual_id) -> web.Response:
+        """
+        Fires a fallback trigger which will cause a virtual to return to its default effect
+
+        Args:
+            virtual_id (str): The ID of the virtual which to fire the fallback trigger
+
+        Returns:
+            web.Response: The response indicating the success or failure of the deletion.
+        """
+        virtual = self._ledfx.virtuals.get(virtual_id)
+        if virtual is None:
+            return await self.invalid_request(
+                f"Virtual with ID {virtual_id} not found"
+            )
+
+        _LOGGER.info(f"Fire fallback for virtual {virtual_id}")
+
+        virtual.fallback_fire_set()
+        response = {"status": "success"}
+        return await self.bare_request_success(response)

--- a/ledfx/api/virtual_effects_fallback.py
+++ b/ledfx/api/virtual_effects_fallback.py
@@ -8,7 +8,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class EffectsEndpoint(RestEndpoint):
-    ENDPOINT_PATH = "/api/virtuals/{virtual_id}/cancel_fallback"
+    ENDPOINT_PATH = "/api/virtuals/{virtual_id}/fallback"
 
     async def get(self, virtual_id) -> web.Response:
         """

--- a/ledfx/effects/melbank.py
+++ b/ledfx/effects/melbank.py
@@ -550,10 +550,15 @@ class Melbanks:
 
         if self.dev_enabled:
             for i in range(len(self.melbank_processors)):
-                self._ledfx.events.fire_event(
-                    GraphUpdateEvent(
-                        f"melbank_{i}",
-                        self.melbanks_filtered[i],
-                        self.melbank_processors[i].melbank_frequencies,
-                    )
+                self.send_melbank_event(i)
+        else:
+            self.send_melbank_event(len(self.melbank_processors) - 1)
+
+    def send_melbank_event(self, i):
+        self._ledfx.events.fire_event(
+                GraphUpdateEvent(
+                    f"melbank_{i}",
+                    self.melbanks_filtered[i],
+                    self.melbank_processors[i].melbank_frequencies,
                 )
+            )

--- a/ledfx/effects/texter2d.py
+++ b/ledfx/effects/texter2d.py
@@ -290,7 +290,7 @@ class Texter2d(Twod, GradientEffect):
         ):
             self.side_scroll_init()
             # call the set_fallback function of the parent virtual as we completed a cycle
-            self._virtual.fallback_fire = True
+            self._virtual.fallback_fire_set()
         for word in self.sentence.wordblocks:
             if self.option_1 and self.base_speed != 0:
                 word.pose.d_pos = (

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -368,7 +368,7 @@ class Virtual:
             # make sure fallback is disabled
             self.fallback_effect_type = None
             self.fallback_suppress_transition = False
-            _LOGGER.info(f"set_fallback: suppress = False")
+            _LOGGER.info(f"{self.name} set_fallback: suppress = False")
 
     def fallback_clear(self):
         self.fallback_effect_type = None
@@ -376,11 +376,11 @@ class Virtual:
             self.fallback_timer.cancel()
             self.fallback_timer = None
         self.fallback_suppress_transition = False
-        _LOGGER.info(f"fallback_clear: suppress = False")
+        _LOGGER.info(f"{self.name} fallback_clear: suppress = False")
 
     def fallback_start(self, fallback: float):
         self.fallback_suppress_transition = True
-        _LOGGER.info(f"fallback_start: suppress = True")
+        _LOGGER.info(f"{self.name} fallback_start: suppress = True")
 
         if self.fallback_timer is not None:
             self.fallback_timer.cancel()

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -410,7 +410,9 @@ class Virtual:
 
         Args:
             effect: The effect to set as the active effect.
-            fallback: If True, the current active effect is set as the fallback effect
+            fallback: If not None, the current active effect is set as the fallback effect 
+                      and a fallback timer triggered for fallback seconds
+                      If None, the new effect is set and any existing fallback timer is cleared
 
         Raises:
             ValueError: If no configured device segments are available.

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -370,7 +370,6 @@ class Virtual:
             self.fallback_suppress_transition = False
             _LOGGER.info(f"set_fallback: suppress = False")
 
-
     def fallback_clear(self):
         self.fallback_effect_type = None
         if self.fallback_timer is not None:
@@ -378,7 +377,7 @@ class Virtual:
             self.fallback_timer = None
         self.fallback_suppress_transition = False
         _LOGGER.info(f"fallback_clear: suppress = False")
-    
+
     def fallback_start(self, fallback: float):
         self.fallback_suppress_transition = True
         _LOGGER.info(f"fallback_start: suppress = True")
@@ -386,7 +385,7 @@ class Virtual:
         if self.fallback_timer is not None:
             self.fallback_timer.cancel()
         _LOGGER.info(f"Setting fallback timer for {fallback} seconds")
-        self.fallback_timer = threading.Timer(fallback, self.fallback_fire_set)  
+        self.fallback_timer = threading.Timer(fallback, self.fallback_fire_set)
         self.fallback_timer.start()
 
     def fallback_fire_set(self):

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -380,6 +380,7 @@ class Virtual:
 
     def fallback_start(self, fallback: float):
         """Suppress transitions, clear and start the fallback timer
+        This funciton should only be called from within the virtual lock
 
         Args:
             fallback (float): Time in seconds to wait before firing the fallback
@@ -394,12 +395,14 @@ class Virtual:
         self.fallback_timer.start()
 
     def fallback_fire_set(self):
-        """clear fallback timers and trigger the fallback to enact"""
-        _LOGGER.info(f"{self.name} fallback_fire_set")
-        if self.fallback_timer is not None:
-            self.fallback_timer.cancel()
-            self.fallback_timer = None
-        self.fallback_fire = True
+        """clear fallback timers and trigger the fallback to enact
+        Called from api context and effects so protect with lock"""
+        with self.lock:
+            _LOGGER.info(f"{self.name} fallback_fire_set")
+            if self.fallback_timer is not None:
+                self.fallback_timer.cancel()
+                self.fallback_timer = None
+            self.fallback_fire = True
 
     def set_effect(self, effect, fallback: Optional[float] = None):
         """

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -410,7 +410,7 @@ class Virtual:
 
         Args:
             effect: The effect to set as the active effect.
-            fallback: If not None, the current active effect is set as the fallback effect 
+            fallback: If not None, the current active effect is set as the fallback effect
                       and a fallback timer triggered for fallback seconds
                       If None, the new effect is set and any existing fallback timer is cleared
 

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -364,13 +364,14 @@ class Virtual:
                 config=self._ledfx.config,
                 config_dir=self._ledfx.config_dir,
             )
-
             # make sure fallback is disabled
             self.fallback_effect_type = None
             self.fallback_suppress_transition = False
             _LOGGER.info(f"{self.name} set_fallback: suppress = False")
 
     def fallback_clear(self):
+        """clear any down all fallback behaviours, normally called after a fallback has completed
+        """
         self.fallback_effect_type = None
         if self.fallback_timer is not None:
             self.fallback_timer.cancel()
@@ -379,6 +380,11 @@ class Virtual:
         _LOGGER.info(f"{self.name} fallback_clear: suppress = False")
 
     def fallback_start(self, fallback: float):
+        """Suppress transitions, clear and start the fallback timer
+
+        Args:
+            fallback (float): Time in seconds to wait before firing the fallback
+        """
         self.fallback_suppress_transition = True
         _LOGGER.info(f"{self.name} fallback_start: suppress = True")
 
@@ -389,9 +395,13 @@ class Virtual:
         self.fallback_timer.start()
 
     def fallback_fire_set(self):
-        _LOGGER.info("Fallback timer expired")
+        """clear fallback timers and trigger the fallback to enact
+        """
+        _LOGGER.info(f"{self.name} fallback_fire_set")
+        if self.fallback_timer is not None:
+            self.fallback_timer.cancel()
+            self.fallback_timer = None
         self.fallback_fire = True
-        self.fallback_timer = None
 
     def set_effect(self, effect, fallback: Optional[float] = None):
         """


### PR DESCRIPTION
WARNING: Does not currently address fallback on virtuals that are streaming. TBD phase 2

Docs for api calls are here

https://ledfx--1195.org.readthedocs.build/en/1195/api.html#api-virtuals-virtual-id-effects

Fallback param is now primarily intended to be number of seconds to display effect before fallback.

Just True will be translated as 300 secs.

Testing done with fallbacks in the 100ms range. Message propagation is ~5ms

With the introduction of 

https://ledfx--1195.org.readthedocs.build/en/1195/api.html#api-virtuals-virtual-id-effects

A front end can trigger a temporary effect with a long timer on button down and call this API on button up, giving the end user the ability to RIFF on effects.

Transition time on effect change is suppressed to 0 for entering an effect with fallback active and for the fallback itself.

Added some lock protection where implied, no actual sightings.

Hammer tested with fallback effect and fallback force with postman on 100ms cycles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Expanded documentation for the LedFx REST API, including new endpoints for interacting with Nanoleaf devices, GIFs, and images.
	- Added functionality to manage fallback effects for virtual entities, including new methods and parameters.
	- Enhanced integration management for QLC and Spotify.

- **Bug Fixes**
	- Improved error handling and response clarity for various API endpoints.

- **Refactor**
	- Improved code organization and readability in the event firing mechanism for melbanks and virtual effects.

- **Documentation**
	- Comprehensive updates to API documentation, including detailed examples and error handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->