### PR TITLE
Dev: virtual streaming state and fallback for non active devices

### DIFF
--- a/ledfx/api/device.py
+++ b/ledfx/api/device.py
@@ -6,6 +6,7 @@ from aiohttp import web
 
 from ledfx.api import RestEndpoint
 from ledfx.config import save_config
+from ledfx.api.virtual import make_virtual_response
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -103,24 +104,7 @@ class DeviceEndpoint(RestEndpoint):
             response = {"status": "success", "virtuals": {}}
             response["paused"] = self._ledfx.virtuals._paused
             for virtual in self._ledfx.virtuals.values():
-                response["virtuals"][virtual.id] = {
-                    "config": virtual.config,
-                    "id": virtual.id,
-                    "is_device": virtual.is_device,
-                    "auto_generated": virtual.auto_generated,
-                    "segments": virtual.segments,
-                    "pixel_count": virtual.pixel_count,
-                    "active": virtual.active,
-                    "effect": {},
-                }
-                if virtual.active_effect:
-                    effect_response = {}
-                    effect_response["config"] = virtual.active_effect.config
-                    effect_response["name"] = virtual.active_effect.name
-                    effect_response["type"] = virtual.active_effect.type
-                    response["virtuals"][virtual.id][
-                        "effect"
-                    ] = effect_response
+                response["virtuals"][virtual.id] = make_virtual_response(virtual)
 
         except (voluptuous.Error, ValueError) as msg:
             error_message = f"Error creating device {device_id}: {msg}"

--- a/ledfx/api/device.py
+++ b/ledfx/api/device.py
@@ -5,8 +5,8 @@ import voluptuous
 from aiohttp import web
 
 from ledfx.api import RestEndpoint
-from ledfx.config import save_config
 from ledfx.api.virtual import make_virtual_response
+from ledfx.config import save_config
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -104,7 +104,9 @@ class DeviceEndpoint(RestEndpoint):
             response = {"status": "success", "virtuals": {}}
             response["paused"] = self._ledfx.virtuals._paused
             for virtual in self._ledfx.virtuals.values():
-                response["virtuals"][virtual.id] = make_virtual_response(virtual)
+                response["virtuals"][virtual.id] = make_virtual_response(
+                    virtual
+                )
 
         except (voluptuous.Error, ValueError) as msg:
             error_message = f"Error creating device {device_id}: {msg}"

--- a/ledfx/api/virtual.py
+++ b/ledfx/api/virtual.py
@@ -10,6 +10,29 @@ from ledfx.effects import DummyEffect
 
 _LOGGER = logging.getLogger(__name__)
 
+def make_virtual_response(virtual):
+    virtual_response = {
+        "config": virtual.config,
+        "id": virtual.id,
+        "is_device": virtual.is_device,
+        "auto_generated": virtual.auto_generated,
+        "segments": virtual.segments,
+        "pixel_count": virtual.pixel_count,
+        "active": virtual.active,
+        "streaming": virtual.streaming,
+        "effect": {},
+    }
+    # Protect from DummyEffect
+    if virtual.active_effect and not isinstance(
+        virtual.active_effect, DummyEffect
+    ):
+        effect_response = {}
+        effect_response["config"] = virtual.active_effect.config
+        effect_response["name"] = virtual.active_effect.name
+        effect_response["type"] = virtual.active_effect.type
+        virtual_response["effect"] = effect_response
+    return virtual_response
+
 
 class VirtualEndpoint(RestEndpoint):
     """REST end-point for querying and managing virtuals"""
@@ -27,25 +50,8 @@ class VirtualEndpoint(RestEndpoint):
             )
 
         response = {"status": "success"}
-        response[virtual.id] = {
-            "config": virtual.config,
-            "id": virtual.id,
-            "is_device": virtual.is_device,
-            "auto_generated": virtual.auto_generated,
-            "segments": virtual.segments,
-            "pixel_count": virtual.pixel_count,
-            "active": virtual.active,
-            "effect": {},
-        }
-        # Protect from DummyEffect
-        if virtual.active_effect and not isinstance(
-            virtual.active_effect, DummyEffect
-        ):
-            effect_response = {}
-            effect_response["config"] = virtual.active_effect.config
-            effect_response["name"] = virtual.active_effect.name
-            effect_response["type"] = virtual.active_effect.type
-            response[virtual.id]["effect"] = effect_response
+        response[virtual.id] = make_virtual_response(virtual)
+        
         return await self.bare_request_success(response)
 
     async def put(self, virtual_id, request) -> web.Response:

--- a/ledfx/api/virtual.py
+++ b/ledfx/api/virtual.py
@@ -10,6 +10,7 @@ from ledfx.effects import DummyEffect
 
 _LOGGER = logging.getLogger(__name__)
 
+
 def make_virtual_response(virtual):
     virtual_response = {
         "config": virtual.config,
@@ -51,7 +52,7 @@ class VirtualEndpoint(RestEndpoint):
 
         response = {"status": "success"}
         response[virtual.id] = make_virtual_response(virtual)
-        
+
         return await self.bare_request_success(response)
 
     async def put(self, virtual_id, request) -> web.Response:

--- a/ledfx/api/virtual_effects.py
+++ b/ledfx/api/virtual_effects.py
@@ -138,7 +138,9 @@ class EffectsEndpoint(RestEndpoint):
         fallback = process_fallback(data.get("fallback", None))
 
         if fallback is not None and virtual.streaming:
-            error_message = f"Unable to set effect: Virtual {virtual_id} being streamed to"
+            error_message = (
+                f"Unable to set effect: Virtual {virtual_id} being streamed to"
+            )
             _LOGGER.warning(error_message)
             return await self.invalid_request(
                 error_message, "error", resp_code=409

--- a/ledfx/api/virtual_effects.py
+++ b/ledfx/api/virtual_effects.py
@@ -137,8 +137,8 @@ class EffectsEndpoint(RestEndpoint):
 
         fallback = process_fallback(data.get("fallback", None))
 
-        if fallback is not None and not virtual.active:
-            error_message = f"Unable to set effect: Virtual {virtual_id} is off or being streamed to"
+        if fallback is not None and virtual.streaming:
+            error_message = f"Unable to set effect: Virtual {virtual_id} being streamed to"
             _LOGGER.warning(error_message)
             return await self.invalid_request(
                 error_message, "error", resp_code=409
@@ -289,8 +289,8 @@ class EffectsEndpoint(RestEndpoint):
 
         fallback = process_fallback(data.get("fallback", None))
 
-        if fallback is not None and not virtual.active:
-            error_message = f"Unable to set effect: Virtual {virtual_id} is off or being streamed to"
+        if fallback is not None and virtual.streaming:
+            error_message = f"Unable to set effect: Virtual {virtual_id} is being streamed to"
             _LOGGER.warning(error_message)
             return await self.invalid_request(
                 error_message, "error", resp_code=409

--- a/ledfx/api/virtual_effects_fallback.py
+++ b/ledfx/api/virtual_effects_fallback.py
@@ -28,6 +28,6 @@ class EffectsEndpoint(RestEndpoint):
 
         _LOGGER.info(f"Fire fallback for virtual {virtual_id}")
 
-        virtual.fallback_fire_set()
+        virtual.fallback_fire_set_with_lock()
         response = {"status": "success"}
         return await self.bare_request_success(response)

--- a/ledfx/api/virtuals.py
+++ b/ledfx/api/virtuals.py
@@ -6,7 +6,6 @@ from aiohttp import web
 from ledfx.api import RestEndpoint
 from ledfx.api.virtual import make_virtual_response
 from ledfx.config import save_config
-from ledfx.effects import DummyEffect
 from ledfx.utils import generate_id
 
 _LOGGER = logging.getLogger(__name__)

--- a/ledfx/api/virtuals.py
+++ b/ledfx/api/virtuals.py
@@ -7,6 +7,7 @@ from ledfx.api import RestEndpoint
 from ledfx.config import save_config
 from ledfx.effects import DummyEffect
 from ledfx.utils import generate_id
+from ledfx.api.virtual import make_virtual_response
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,25 +27,7 @@ class VirtualsEndpoint(RestEndpoint):
         response = {"status": "success", "virtuals": {}}
         response["paused"] = self._ledfx.virtuals._paused
         for virtual in self._ledfx.virtuals.values():
-            response["virtuals"][virtual.id] = {
-                "config": virtual.config,
-                "id": virtual.id,
-                "is_device": virtual.is_device,
-                "auto_generated": virtual.auto_generated,
-                "segments": virtual.segments,
-                "pixel_count": virtual.pixel_count,
-                "active": virtual.active,
-                "effect": {},
-            }
-            # Protect from DummyEffect
-            if virtual.active_effect and not isinstance(
-                virtual.active_effect, DummyEffect
-            ):
-                effect_response = {}
-                effect_response["config"] = virtual.active_effect.config
-                effect_response["name"] = virtual.active_effect.name
-                effect_response["type"] = virtual.active_effect.type
-                response["virtuals"][virtual.id]["effect"] = effect_response
+            response["virtuals"][virtual.id] = make_virtual_response(virtual)
 
         return web.json_response(data=response, status=200)
 

--- a/ledfx/api/virtuals.py
+++ b/ledfx/api/virtuals.py
@@ -4,10 +4,10 @@ from json import JSONDecodeError
 from aiohttp import web
 
 from ledfx.api import RestEndpoint
+from ledfx.api.virtual import make_virtual_response
 from ledfx.config import save_config
 from ledfx.effects import DummyEffect
 from ledfx.utils import generate_id
-from ledfx.api.virtual import make_virtual_response
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -29,7 +29,6 @@ from ledfx.events import (
     VirtualPauseEvent,
     VirtualUpdateEvent,
 )
-
 from ledfx.transitions import Transitions
 from ledfx.utils import fps_to_sleep_interval
 
@@ -539,8 +538,14 @@ class Virtual:
 
             self.flush_pending_clear_frame()
 
-            delay = 0 if self.fallback_suppress_transition else self._config["transition_time"]
-            self.clear_handle = self._ledfx.loop.call_later(delay, self.clear_frame)
+            delay = (
+                0
+                if self.fallback_suppress_transition
+                else self._config["transition_time"]
+            )
+            self.clear_handle = self._ledfx.loop.call_later(
+                delay, self.clear_frame
+            )
 
     def flush_pending_clear_frame(self):
         if self.clear_handle is not None:

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -969,7 +969,7 @@ class Virtual:
     @property
     def streaming(self):
         return self._streaming
-    
+
     @active.setter
     def active(self, active):
         active = bool(active)
@@ -1370,28 +1370,38 @@ class Virtuals:
             if virtual.active:
                 for device_id, _, _, _ in virtual.segments:
                     active_devices.add(device_id)
-        
+
         for device in self._ledfx.devices.values():
             if device.id not in active_devices and device.is_active():
                 _LOGGER.info(
                     f"Deactivating device {device.id} as it is not in use by any active virtuals"
                 )
                 device.deactivate()
-        
+
         # go through each device in the registry and work out its streaming state
         # if it has segments, but its paired virtual is not active, then it should it must be streaming
-        _LOGGER.warning("-------------------------------------------------------------------------------")
-        _LOGGER.warning("Virtual                       is_device                    Active    Streaming ")
-        _LOGGER.warning("-------------------------------------------------------------------------------")
+        _LOGGER.warning(
+            "-------------------------------------------------------------------------------"
+        )
+        _LOGGER.warning(
+            "Virtual                       is_device                    Active    Streaming "
+        )
+        _LOGGER.warning(
+            "-------------------------------------------------------------------------------"
+        )
 
         for virtual_id in self._ledfx.virtuals:
             virtual = self._ledfx.virtuals.get(virtual_id)
-            
-            virtual._streaming = (virtual_id in active_devices and not virtual.active)
-            
-            _LOGGER.warning(f"{virtual_id:<29} {str(virtual.is_device):<29}{str(virtual.active):<10}{str(virtual.streaming):<10}")
+
+            virtual._streaming = (
+                virtual_id in active_devices and not virtual.active
+            )
+
+            _LOGGER.warning(
+                f"{virtual_id:<29} {str(virtual.is_device):<29}{str(virtual.active):<10}{str(virtual.streaming):<10}"
+            )
         _LOGGER.warning(f"Active Devices: {active_devices}")
-           
+
 
 def update_effect_config(config, virtual_id, effect):
     """

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -410,14 +410,18 @@ class Virtual:
         self.fallback_timer = threading.Timer(fallback, self.fallback_fire_set)
         self.fallback_timer.start()
 
-    def fallback_fire_set(self):
-        """clear fallback timers and trigger the fallback to enact
-        Called from api context and effects so protect with lock"""
+    def fallback_fire_set_with_lock(self):
+        """Use this function to trigger a fallback from an external source such as api calls"""
         with self.lock:
+            self.fallback_fire_set()
+
+    def fallback_fire_set(self):
+        """clear fallback timers and trigger the fallback to enact"""
+        if self.fallback_timer is not None:
+            self.fallback_timer.cancel()
+            self.fallback_timer = None
+        if self.fallback_effect_type is not None:
             _LOGGER.info(f"{self.name} fallback_fire_set")
-            if self.fallback_timer is not None:
-                self.fallback_timer.cancel()
-                self.fallback_timer = None
             self.fallback_fire = True
 
     def set_effect(self, effect, fallback: Optional[float] = None):


### PR DESCRIPTION
Fallback will now work for non active devices
Fallback will still reject for streaming devices

Resolve streaming state during any segment, activation or deactivation for all virtuals.

Refactor API virtual reporting to a common function

Add streaming element to virtual stansa in 

post /api/devices/{device_id}"
get /api/virtuals/{virtual_id}
get /api/virtuals


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to streamline the creation of virtual entity responses.
	- Added a property to track the streaming state of virtual devices.

- **Bug Fixes**
	- Enhanced error handling and logging for virtual device management.

- **Refactor**
	- Simplified response construction for virtual entities and improved code readability.
	- Updated logic to prevent setting effects when the virtual is actively streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->