### PR TITLE
Dev: Fix pytest poll exit logic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,5 +74,5 @@ def pytest_sessionfinish(session, exitstatus):
     except Exception as e:
         pytest.fail(f"An error occurred while shutting down LedFx: {str(e)}")
     # Wait for LedFx to terminate
-    while ledfx.poll() is not None:
+    while ledfx.poll() is None:
         time.sleep(0.5)


### PR DESCRIPTION
Existing code would loop forever if an exit code was available.

Would always impact when Failures in tests.

Assumption is for the non failure case, that ledfx had not quite reached exit code on first pass and therefore would incorrectly exit

Simple inversion problem with a race condition happy path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the shutdown process to ensure the application waits for the subprocess to finish correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->