### PR TITLE
Feat: add last_effect to virtual structure on api

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -152,6 +152,33 @@ packages.
 
 ------------------------------------------------------------------------
 
+### Local pytest
+
+There are a collection of system level tests run as a test clamp around the rest api's.
+
+These are run as part of the CI actions when raising a PR and must run clean green before a PR is merged.
+
+To run these local and / or develop more tests
+
+1) Ensure you have installed the developer tool dependancies with
+
+    ``` console
+    $ poetry install --with dev
+    ```
+
+2) Ensure you have local loopback installed, or you may hit failures once audio effects are under test
+
+    ``` console
+    $  ledfx-loopback-install
+    ```
+
+3) launch the suite of tests with
+
+
+    ``` console
+    $ poetry run pytest -vv
+    ```
+
 ## Frontend Development
 
 Building the LedFx frontend is different from how the core backend is

--- a/docs/howto/virtuals.md
+++ b/docs/howto/virtuals.md
@@ -100,9 +100,16 @@ lets go over them all anyway first.
         segment that makes up the virtual
 4.  **icon name** - This is the icon that will be displayed in the UI,
     select something that makes sense to you. It is a string entry
-    field, the mdi: or mui: prefix should be followed by the icon reference in kebab-case. Supported icons and their string mappings can be found at
-    -   [mdi: Material Design Icons](https://pictogrammers.com/library/mdi/)
-    -   [mui: Material UI Icons](https://mui.com/material-ui/material-icons/)
+    field, from MDI ( Material Design Icons ) or MUI ( Material UI Icons ) 
+
+    If using MDI the string should be preceeded by mdi:
+    -   "mdi: \<icon-name-in-kebab-case\>"
+    -   [Material Design Icons](https://pictogrammers.com/library/mdi/)
+
+    If using MUI the string should be just the icon name with out a prefix
+    -   "\<iconNameInCamelCase\>"
+    -   [Material UI Icons](https://mui.com/material-ui/material-icons/)
+
 5.  **Max Brightness** - This is the maximum brightness that the virtual
     will display at, from 0 to 1. Generally leave at 1
 6.  **Center Offset** - Pixel count by which to offset the center of the

--- a/docs/howto/virtuals.md
+++ b/docs/howto/virtuals.md
@@ -100,8 +100,9 @@ lets go over them all anyway first.
         segment that makes up the virtual
 4.  **icon name** - This is the icon that will be displayed in the UI,
     select something that makes sense to you. It is a string entry
-    field, supported icons and their string mappings can be found at
-    [Material Design Icons](https://pictogrammers.com/library/mdi/)
+    field, the mdi: or mui: prefix should be followed by the icon reference in kebab-case. Supported icons and their string mappings can be found at
+    -   [mdi: Material Design Icons](https://pictogrammers.com/library/mdi/)
+    -   [mui: Material UI Icons](https://mui.com/material-ui/material-icons/)
 5.  **Max Brightness** - This is the maximum brightness that the virtual
     will display at, from 0 to 1. Generally leave at 1
 6.  **Center Offset** - Pixel count by which to offset the center of the

--- a/docs/howto/virtuals.md
+++ b/docs/howto/virtuals.md
@@ -100,7 +100,7 @@ lets go over them all anyway first.
         segment that makes up the virtual
 4.  **icon name** - This is the icon that will be displayed in the UI,
     select something that makes sense to you. It is a string entry
-    field, from MDI ( Material Design Icons ) or MUI ( Material UI Icons ) 
+    field, from MDI ( Material Design Icons ) or MUI ( Material UI Icons )
 
     If using MDI the string should be preceeded by mdi:
     -   "mdi: \<icon-name-in-kebab-case\>"

--- a/ledfx/api/virtual.py
+++ b/ledfx/api/virtual.py
@@ -80,7 +80,7 @@ class VirtualEndpoint(RestEndpoint):
 
         # Update the virtual's configuration
         if active:
-            if not virtual._active_effect:
+            if not virtual._active_effect or isinstance(virtual.active_effect, DummyEffect):
                 last_effect = virtual.virtual_cfg.get("last_effect", None)
                 if last_effect:
                     effect_config = virtual.get_effects_config(last_effect)

--- a/ledfx/api/virtual.py
+++ b/ledfx/api/virtual.py
@@ -21,17 +21,20 @@ def make_virtual_response(virtual):
         "pixel_count": virtual.pixel_count,
         "active": virtual.active,
         "streaming": virtual.streaming,
+        "last_effect": virtual.virtual_cfg.get("last_effect", None),
         "effect": {},
     }
     # Protect from DummyEffect
     if virtual.active_effect and not isinstance(
         virtual.active_effect, DummyEffect
     ):
-        effect_response = {}
-        effect_response["config"] = virtual.active_effect.config
-        effect_response["name"] = virtual.active_effect.name
-        effect_response["type"] = virtual.active_effect.type
+        effect_response = {
+            "config": virtual.active_effect.config,
+            "name": virtual.active_effect.name,
+            "type": virtual.active_effect.type,
+        }
         virtual_response["effect"] = effect_response
+    
     return virtual_response
 
 

--- a/ledfx/api/virtual.py
+++ b/ledfx/api/virtual.py
@@ -80,7 +80,9 @@ class VirtualEndpoint(RestEndpoint):
 
         # Update the virtual's configuration
         if active:
-            if not virtual._active_effect or isinstance(virtual.active_effect, DummyEffect):
+            if not virtual._active_effect or isinstance(
+                virtual.active_effect, DummyEffect
+            ):
                 last_effect = virtual.virtual_cfg.get("last_effect", None)
                 if last_effect:
                     effect_config = virtual.get_effects_config(last_effect)

--- a/ledfx/api/virtual.py
+++ b/ledfx/api/virtual.py
@@ -34,7 +34,7 @@ def make_virtual_response(virtual):
             "type": virtual.active_effect.type,
         }
         virtual_response["effect"] = effect_response
-    
+
     return virtual_response
 
 

--- a/ledfx/api/virtual_effects.py
+++ b/ledfx/api/virtual_effects.py
@@ -7,6 +7,7 @@ from aiohttp import web
 
 from ledfx.api import RestEndpoint
 from ledfx.config import save_config
+from ledfx.effects import DummyEffect
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,14 +59,20 @@ class EffectsEndpoint(RestEndpoint):
                 f"Virtual with ID {virtual_id} not found"
             )
 
-        # Get the active effect
-        response = {"effect": {}}
-        if virtual.active_effect:
-            effect_response = {}
-            effect_response["config"] = virtual.active_effect.config
-            effect_response["name"] = virtual.active_effect.name
-            effect_response["type"] = virtual.active_effect.type
-            response = {"effect": effect_response}
+        # Protect from DummyEffect
+        if virtual.active_effect and not isinstance(
+            virtual.active_effect, DummyEffect
+        ):
+            response = {
+                "effect":{
+                    "config": virtual.active_effect.config,
+                    "name": virtual.active_effect.name,
+                    "type": virtual.active_effect.type,
+                }
+            }
+        else:
+            response = {"effect": {}}
+                    
         return await self.bare_request_success(response)
 
     async def put(self, virtual_id, request) -> web.Response:

--- a/tests/test_definitions/virtual_config.py
+++ b/tests/test_definitions/virtual_config.py
@@ -408,7 +408,7 @@ virtual_config_tests = {
         expected_response_keys=["status", "effect"],
         expected_response_values=[{"status": "success"}, {"effect": {}}],
         # explicity to test DummyEffect protection as a transition is playing out
-        sleep_after_test=0
+        sleep_after_test=0,
     ),
     # need to run this test before delete from effects, or will fail.
     "set_effect_to_last_active": APITestCase(
@@ -455,7 +455,7 @@ virtual_config_tests = {
         expected_response_keys=["status", "effect"],
         expected_response_values=[{"status": "success"}, {"effect": {}}],
         # explicity to ensure tranistion has completed to off
-        sleep_after_test=1.0
+        sleep_after_test=1.0,
     ),
     # need to run this test before delete from effects, or will fail.
     "set_effect_to_last_active_again": APITestCase(

--- a/tests/test_definitions/virtual_config.py
+++ b/tests/test_definitions/virtual_config.py
@@ -414,10 +414,7 @@ virtual_config_tests = {
         expected_return_code=200,
         payload_to_send={"active": True},
         expected_response_keys=["status", "active"],
-        expected_response_values=[
-            {"status": "success"},
-            {"active": True}
-        ],
+        expected_response_values=[{"status": "success"}, {"active": True}],
     ),
     "check_effect_is_last_effect": APITestCase(
         execution_order=16,
@@ -445,23 +442,21 @@ virtual_config_tests = {
             }
         ],
     ),
-
-#/api/effects
-                    # "effect": {
-                #     "config": {
-                #         "background_brightness": 1.0,
-                #         "background_color": "#000000",
-                #         "blur": 0.0,
-                #         "brightness": 1.0,
-                #         "flip": True,
-                #         "frequency": 1.0,
-                #         "mirror": True,
-                #         "speed": 3.0,
-                #     },
-                #     "name": "Rainbow",
-                #     "type": "rainbow",
-                # }
-
+    # /api/effects
+    # "effect": {
+    #     "config": {
+    #         "background_brightness": 1.0,
+    #         "background_color": "#000000",
+    #         "blur": 0.0,
+    #         "brightness": 1.0,
+    #         "flip": True,
+    #         "frequency": 1.0,
+    #         "mirror": True,
+    #         "speed": 3.0,
+    #     },
+    #     "name": "Rainbow",
+    #     "type": "rainbow",
+    # }
     "delete_effect_from_effects_from_virtual": APITestCase(
         execution_order=17,
         method="POST",

--- a/tests/test_definitions/virtual_config.py
+++ b/tests/test_definitions/virtual_config.py
@@ -308,6 +308,7 @@ virtual_config_tests = {
                         "pixel_count": 128,
                         "active": False,
                         "streaming": False,
+                        "last_effect": None,
                         "effect": {},
                     },
                     "first-virt": {
@@ -332,6 +333,7 @@ virtual_config_tests = {
                         "pixel_count": 122,
                         "active": False,
                         "streaming": False,
+                        "last_effect": None,
                         "effect": {},
                     },
                 }
@@ -407,33 +409,61 @@ virtual_config_tests = {
     # need to run this test before delete from effects, or will fail.
     "set_effect_to_last_active": APITestCase(
         execution_order=15,
-        method="POST",
-        api_endpoint="/api/virtuals/test-dummy-2/effects",
+        method="PUT",
+        api_endpoint="/api/virtuals/test-dummy-2",
         expected_return_code=200,
-        payload_to_send={"type": "rainbow"},
-        expected_response_keys=["status", "effect"],
+        payload_to_send={"active": True},
+        expected_response_keys=["status", "active"],
         expected_response_values=[
             {"status": "success"},
+            {"active": True}
+        ],
+    ),
+    "check_effect_is_last_effect": APITestCase(
+        execution_order=16,
+        method="GET",
+        api_endpoint="/api/virtuals/test-dummy-2/effects",
+        expected_return_code=200,
+        payload_to_send={},
+        expected_response_keys=["effect"],
+        expected_response_values=[
             {
                 "effect": {
                     "config": {
                         "background_brightness": 1.0,
                         "background_color": "#000000",
-                        "blur": 0.0,
+                        "blur": 7.7,
                         "brightness": 1.0,
-                        "flip": True,
-                        "frequency": 1.0,
+                        "flip": False,
+                        "frequency": 0.32,
                         "mirror": True,
-                        "speed": 3.0,
+                        "speed": 0.3,
                     },
                     "name": "Rainbow",
                     "type": "rainbow",
                 }
-            },
+            }
         ],
     ),
+
+#/api/effects
+                    # "effect": {
+                #     "config": {
+                #         "background_brightness": 1.0,
+                #         "background_color": "#000000",
+                #         "blur": 0.0,
+                #         "brightness": 1.0,
+                #         "flip": True,
+                #         "frequency": 1.0,
+                #         "mirror": True,
+                #         "speed": 3.0,
+                #     },
+                #     "name": "Rainbow",
+                #     "type": "rainbow",
+                # }
+
     "delete_effect_from_effects_from_virtual": APITestCase(
-        execution_order=16,
+        execution_order=17,
         method="POST",
         api_endpoint="/api/virtuals/test-dummy-2/effects/delete",
         expected_return_code=200,
@@ -444,7 +474,7 @@ virtual_config_tests = {
         ],
     ),
     "set_preset_effect_to_virtual": APITestCase(
-        execution_order=17,
+        execution_order=18,
         method="PUT",
         api_endpoint="/api/virtuals/test-dummy-2/presets",
         expected_return_code=200,
@@ -475,7 +505,7 @@ virtual_config_tests = {
         ],
     ),
     "set_user_preset_to_current": APITestCase(
-        execution_order=18,
+        execution_order=19,
         method="POST",
         api_endpoint="/api/virtuals/test-dummy-2/presets",
         expected_return_code=200,
@@ -503,7 +533,7 @@ virtual_config_tests = {
         ],
     ),
     "set_user_preset_effect_to_virtual": APITestCase(
-        execution_order=19,
+        execution_order=20,
         method="PUT",
         api_endpoint="/api/virtuals/test-dummy-2/presets",
         expected_return_code=200,
@@ -534,7 +564,7 @@ virtual_config_tests = {
         ],
     ),
     "set_effect_to_virtual_with_fallback": APITestCase(
-        execution_order=20,
+        execution_order=21,
         method="POST",
         api_endpoint="/api/virtuals/test-dummy-2/effects",
         expected_return_code=200,
@@ -568,7 +598,7 @@ virtual_config_tests = {
         sleep_after_test=1.0,
     ),
     "get_effect_from_virtual_before_fallback": APITestCase(
-        execution_order=21,
+        execution_order=22,
         method="GET",
         api_endpoint="/api/virtuals/test-dummy-2/effects",
         expected_return_code=200,
@@ -601,7 +631,7 @@ virtual_config_tests = {
         sleep_after_test=1.0,
     ),
     "get_effect_from_virtual_after_fallack": APITestCase(
-        execution_order=22,
+        execution_order=23,
         method="GET",
         api_endpoint="/api/virtuals/test-dummy-2/effects",
         expected_return_code=200,
@@ -627,7 +657,7 @@ virtual_config_tests = {
         ],
     ),
     "create_dummy_device_again": APITestCase(
-        execution_order=23,
+        execution_order=24,
         method="POST",
         api_endpoint="/api/devices",
         expected_return_code=200,
@@ -661,7 +691,7 @@ virtual_config_tests = {
         ],
     ),
     "create_dummy_device_3": APITestCase(
-        execution_order=24,
+        execution_order=25,
         method="POST",
         api_endpoint="/api/devices",
         expected_return_code=200,
@@ -695,7 +725,7 @@ virtual_config_tests = {
         ],
     ),
     "set_effect_to_virtual_again": APITestCase(
-        execution_order=25,
+        execution_order=26,
         method="POST",
         api_endpoint="/api/virtuals/test-dummy-2/effects",
         expected_return_code=200,
@@ -722,7 +752,7 @@ virtual_config_tests = {
         ],
     ),
     "copy_effects_to_virtuals": APITestCase(
-        execution_order=26,
+        execution_order=27,
         method="PUT",
         api_endpoint="/api/virtuals_tools/test-dummy-2",
         expected_return_code=200,
@@ -737,7 +767,7 @@ virtual_config_tests = {
         ],
     ),
     "get_effect_for_dummy_1": APITestCase(
-        execution_order=27,
+        execution_order=28,
         method="GET",
         api_endpoint="/api/virtuals/test-dummy/effects",
         expected_return_code=200,
@@ -763,7 +793,7 @@ virtual_config_tests = {
         ],
     ),
     "get_effect_for_dummy_2": APITestCase(
-        execution_order=28,
+        execution_order=29,
         method="GET",
         api_endpoint="/api/virtuals/test-dummy-2/effects",
         expected_return_code=200,
@@ -789,7 +819,7 @@ virtual_config_tests = {
         ],
     ),
     "get_effect_for_dummy_3": APITestCase(
-        execution_order=29,
+        execution_order=30,
         method="GET",
         api_endpoint="/api/virtuals/test-dummy-3/effects",
         expected_return_code=200,
@@ -815,7 +845,7 @@ virtual_config_tests = {
         ],
     ),
     "cleanup_dummy_device": APITestCase(
-        execution_order=30,
+        execution_order=31,
         method="DELETE",
         api_endpoint="/api/virtuals/test-dummy",
         expected_return_code=200,
@@ -825,7 +855,7 @@ virtual_config_tests = {
         sleep_after_test=1.0,
     ),
     "cleanup_dummy_device_2": APITestCase(
-        execution_order=31,
+        execution_order=32,
         method="DELETE",
         api_endpoint="/api/virtuals/test-dummy-2",
         expected_return_code=200,
@@ -835,7 +865,7 @@ virtual_config_tests = {
         sleep_after_test=1.0,
     ),
     "cleanup_dummy_device_3": APITestCase(
-        execution_order=32,
+        execution_order=33,
         method="DELETE",
         api_endpoint="/api/virtuals/test-dummy-3",
         expected_return_code=200,

--- a/tests/test_definitions/virtual_config.py
+++ b/tests/test_definitions/virtual_config.py
@@ -405,6 +405,7 @@ virtual_config_tests = {
         payload_to_send={},
         expected_response_keys=["status", "effect"],
         expected_response_values=[{"status": "success"}, {"effect": {}}],
+        sleep_after_test=1.0
     ),
     # need to run this test before delete from effects, or will fail.
     "set_effect_to_last_active": APITestCase(
@@ -429,12 +430,12 @@ virtual_config_tests = {
                     "config": {
                         "background_brightness": 1.0,
                         "background_color": "#000000",
-                        "blur": 7.7,
+                        "blur": 0.0,
                         "brightness": 1.0,
-                        "flip": False,
-                        "frequency": 0.32,
+                        "flip": True,
+                        "frequency": 1.0,
                         "mirror": True,
-                        "speed": 0.3,
+                        "speed": 3.0,
                     },
                     "name": "Rainbow",
                     "type": "rainbow",
@@ -442,21 +443,6 @@ virtual_config_tests = {
             }
         ],
     ),
-    # /api/effects
-    # "effect": {
-    #     "config": {
-    #         "background_brightness": 1.0,
-    #         "background_color": "#000000",
-    #         "blur": 0.0,
-    #         "brightness": 1.0,
-    #         "flip": True,
-    #         "frequency": 1.0,
-    #         "mirror": True,
-    #         "speed": 3.0,
-    #     },
-    #     "name": "Rainbow",
-    #     "type": "rainbow",
-    # }
     "delete_effect_from_effects_from_virtual": APITestCase(
         execution_order=17,
         method="POST",

--- a/tests/test_definitions/virtual_config.py
+++ b/tests/test_definitions/virtual_config.py
@@ -1,8 +1,10 @@
 from tests.test_utilities.test_utils import APITestCase, SystemInfo
 
+test_count = 1
+
 virtual_config_tests = {
     "cleanup_ci-test-device": APITestCase(
-        execution_order=1,
+        execution_order=(test_count := test_count + 1),
         method="DELETE",
         api_endpoint="/api/virtuals/ci-test-jig",
         expected_return_code=200,
@@ -11,7 +13,7 @@ virtual_config_tests = {
         payload_to_send={},
     ),
     "create_dummy_device": APITestCase(
-        execution_order=2,
+        execution_order=(test_count := test_count + 1),
         method="POST",
         api_endpoint="/api/devices",
         expected_return_code=200,
@@ -45,7 +47,7 @@ virtual_config_tests = {
         ],
     ),
     "create_dummy_device_2": APITestCase(
-        execution_order=3,
+        execution_order=(test_count := test_count + 1),
         method="POST",
         api_endpoint="/api/devices",
         expected_return_code=200,
@@ -79,7 +81,7 @@ virtual_config_tests = {
         ],
     ),
     "modify_dummy_device": APITestCase(
-        execution_order=4,
+        execution_order=(test_count := test_count + 1),
         method="PUT",
         api_endpoint="/api/devices/test-dummy",
         expected_return_code=200,
@@ -97,7 +99,7 @@ virtual_config_tests = {
         expected_response_values=[{"status": "success"}],
     ),
     "check_devices": APITestCase(
-        execution_order=5,
+        execution_order=(test_count := test_count + 1),
         method="GET",
         api_endpoint="/api/devices",
         expected_return_code=200,
@@ -140,7 +142,7 @@ virtual_config_tests = {
         ],
     ),
     "create_first_virtual": APITestCase(
-        execution_order=6,
+        execution_order=(test_count := test_count + 1),
         method="POST",
         api_endpoint="/api/virtuals",
         expected_return_code=200,
@@ -187,7 +189,7 @@ virtual_config_tests = {
         ],
     ),
     "modify_first_virtual": APITestCase(
-        execution_order=7,
+        execution_order=(test_count := test_count + 1),
         method="POST",
         api_endpoint="/api/virtuals",
         expected_return_code=200,
@@ -235,7 +237,7 @@ virtual_config_tests = {
         ],
     ),
     "add_first_segment": APITestCase(
-        execution_order=8,
+        execution_order=(test_count := test_count + 1),
         method="POST",
         api_endpoint="/api/virtuals/first-virt",
         expected_return_code=200,
@@ -246,7 +248,7 @@ virtual_config_tests = {
         ],
     ),
     "add_second_segment": APITestCase(
-        execution_order=9,
+        execution_order=(test_count := test_count + 1),
         method="POST",
         api_endpoint="/api/virtuals/first-virt",
         expected_return_code=200,
@@ -268,7 +270,7 @@ virtual_config_tests = {
         ],
     ),
     "delete_dummy_device": APITestCase(
-        execution_order=10,
+        execution_order=(test_count := test_count + 1),
         method="DELETE",
         api_endpoint="/api/virtuals/test-dummy",
         expected_return_code=200,
@@ -277,7 +279,7 @@ virtual_config_tests = {
         payload_to_send={},
     ),
     "check_segments_after_device_delete": APITestCase(
-        execution_order=11,
+        execution_order=(test_count := test_count + 1),
         method="GET",
         api_endpoint="/api/virtuals",
         expected_return_code=200,
@@ -341,7 +343,7 @@ virtual_config_tests = {
         ],
     ),
     "set_effect_to_virtual": APITestCase(
-        execution_order=12,
+        execution_order=(test_count := test_count + 1),
         method="POST",
         api_endpoint="/api/virtuals/test-dummy-2/effects",
         expected_return_code=200,
@@ -368,7 +370,7 @@ virtual_config_tests = {
         ],
     ),
     "modify_effect_to_virtual": APITestCase(
-        execution_order=13,
+        execution_order=(test_count := test_count + 1),
         method="PUT",
         api_endpoint="/api/virtuals/test-dummy-2/effects",
         expected_return_code=200,
@@ -398,18 +400,19 @@ virtual_config_tests = {
         ],
     ),
     "delete_effect_from_virtual": APITestCase(
-        execution_order=14,
+        execution_order=(test_count := test_count + 1),
         method="DELETE",
         api_endpoint="/api/virtuals/test-dummy-2/effects",
         expected_return_code=200,
         payload_to_send={},
         expected_response_keys=["status", "effect"],
         expected_response_values=[{"status": "success"}, {"effect": {}}],
-        sleep_after_test=1.0
+        # explicity to test DummyEffect protection as a transition is playing out
+        sleep_after_test=0
     ),
     # need to run this test before delete from effects, or will fail.
     "set_effect_to_last_active": APITestCase(
-        execution_order=15,
+        execution_order=(test_count := test_count + 1),
         method="PUT",
         api_endpoint="/api/virtuals/test-dummy-2",
         expected_return_code=200,
@@ -418,7 +421,54 @@ virtual_config_tests = {
         expected_response_values=[{"status": "success"}, {"active": True}],
     ),
     "check_effect_is_last_effect": APITestCase(
-        execution_order=16,
+        execution_order=(test_count := test_count + 1),
+        method="GET",
+        api_endpoint="/api/virtuals/test-dummy-2/effects",
+        expected_return_code=200,
+        payload_to_send={},
+        expected_response_keys=["effect"],
+        expected_response_values=[
+            {
+                "effect": {
+                    "config": {
+                        "background_brightness": 1.0,
+                        "background_color": "#000000",
+                        "blur": 0.0,
+                        "brightness": 1.0,
+                        "flip": True,
+                        "frequency": 1.0,
+                        "mirror": True,
+                        "speed": 3.0,
+                    },
+                    "name": "Rainbow",
+                    "type": "rainbow",
+                }
+            }
+        ],
+    ),
+    "delete_effect_from_virtual_again": APITestCase(
+        execution_order=(test_count := test_count + 1),
+        method="DELETE",
+        api_endpoint="/api/virtuals/test-dummy-2/effects",
+        expected_return_code=200,
+        payload_to_send={},
+        expected_response_keys=["status", "effect"],
+        expected_response_values=[{"status": "success"}, {"effect": {}}],
+        # explicity to ensure tranistion has completed to off
+        sleep_after_test=1.0
+    ),
+    # need to run this test before delete from effects, or will fail.
+    "set_effect_to_last_active_again": APITestCase(
+        execution_order=(test_count := test_count + 1),
+        method="PUT",
+        api_endpoint="/api/virtuals/test-dummy-2",
+        expected_return_code=200,
+        payload_to_send={"active": True},
+        expected_response_keys=["status", "active"],
+        expected_response_values=[{"status": "success"}, {"active": True}],
+    ),
+    "check_effect_is_last_effect_again": APITestCase(
+        execution_order=(test_count := test_count + 1),
         method="GET",
         api_endpoint="/api/virtuals/test-dummy-2/effects",
         expected_return_code=200,
@@ -444,7 +494,7 @@ virtual_config_tests = {
         ],
     ),
     "delete_effect_from_effects_from_virtual": APITestCase(
-        execution_order=17,
+        execution_order=(test_count := test_count + 1),
         method="POST",
         api_endpoint="/api/virtuals/test-dummy-2/effects/delete",
         expected_return_code=200,
@@ -455,7 +505,7 @@ virtual_config_tests = {
         ],
     ),
     "set_preset_effect_to_virtual": APITestCase(
-        execution_order=18,
+        execution_order=(test_count := test_count + 1),
         method="PUT",
         api_endpoint="/api/virtuals/test-dummy-2/presets",
         expected_return_code=200,
@@ -486,7 +536,7 @@ virtual_config_tests = {
         ],
     ),
     "set_user_preset_to_current": APITestCase(
-        execution_order=19,
+        execution_order=(test_count := test_count + 1),
         method="POST",
         api_endpoint="/api/virtuals/test-dummy-2/presets",
         expected_return_code=200,
@@ -514,7 +564,7 @@ virtual_config_tests = {
         ],
     ),
     "set_user_preset_effect_to_virtual": APITestCase(
-        execution_order=20,
+        execution_order=(test_count := test_count + 1),
         method="PUT",
         api_endpoint="/api/virtuals/test-dummy-2/presets",
         expected_return_code=200,
@@ -545,7 +595,7 @@ virtual_config_tests = {
         ],
     ),
     "set_effect_to_virtual_with_fallback": APITestCase(
-        execution_order=21,
+        execution_order=(test_count := test_count + 1),
         method="POST",
         api_endpoint="/api/virtuals/test-dummy-2/effects",
         expected_return_code=200,
@@ -579,7 +629,7 @@ virtual_config_tests = {
         sleep_after_test=1.0,
     ),
     "get_effect_from_virtual_before_fallback": APITestCase(
-        execution_order=22,
+        execution_order=(test_count := test_count + 1),
         method="GET",
         api_endpoint="/api/virtuals/test-dummy-2/effects",
         expected_return_code=200,
@@ -612,7 +662,7 @@ virtual_config_tests = {
         sleep_after_test=1.0,
     ),
     "get_effect_from_virtual_after_fallack": APITestCase(
-        execution_order=23,
+        execution_order=(test_count := test_count + 1),
         method="GET",
         api_endpoint="/api/virtuals/test-dummy-2/effects",
         expected_return_code=200,
@@ -638,7 +688,7 @@ virtual_config_tests = {
         ],
     ),
     "create_dummy_device_again": APITestCase(
-        execution_order=24,
+        execution_order=(test_count := test_count + 1),
         method="POST",
         api_endpoint="/api/devices",
         expected_return_code=200,
@@ -672,7 +722,7 @@ virtual_config_tests = {
         ],
     ),
     "create_dummy_device_3": APITestCase(
-        execution_order=25,
+        execution_order=(test_count := test_count + 1),
         method="POST",
         api_endpoint="/api/devices",
         expected_return_code=200,
@@ -706,7 +756,7 @@ virtual_config_tests = {
         ],
     ),
     "set_effect_to_virtual_again": APITestCase(
-        execution_order=26,
+        execution_order=(test_count := test_count + 1),
         method="POST",
         api_endpoint="/api/virtuals/test-dummy-2/effects",
         expected_return_code=200,
@@ -733,7 +783,7 @@ virtual_config_tests = {
         ],
     ),
     "copy_effects_to_virtuals": APITestCase(
-        execution_order=27,
+        execution_order=(test_count := test_count + 1),
         method="PUT",
         api_endpoint="/api/virtuals_tools/test-dummy-2",
         expected_return_code=200,
@@ -748,7 +798,7 @@ virtual_config_tests = {
         ],
     ),
     "get_effect_for_dummy_1": APITestCase(
-        execution_order=28,
+        execution_order=(test_count := test_count + 1),
         method="GET",
         api_endpoint="/api/virtuals/test-dummy/effects",
         expected_return_code=200,
@@ -774,7 +824,7 @@ virtual_config_tests = {
         ],
     ),
     "get_effect_for_dummy_2": APITestCase(
-        execution_order=29,
+        execution_order=(test_count := test_count + 1),
         method="GET",
         api_endpoint="/api/virtuals/test-dummy-2/effects",
         expected_return_code=200,
@@ -800,7 +850,7 @@ virtual_config_tests = {
         ],
     ),
     "get_effect_for_dummy_3": APITestCase(
-        execution_order=30,
+        execution_order=(test_count := test_count + 1),
         method="GET",
         api_endpoint="/api/virtuals/test-dummy-3/effects",
         expected_return_code=200,
@@ -826,7 +876,7 @@ virtual_config_tests = {
         ],
     ),
     "cleanup_dummy_device": APITestCase(
-        execution_order=31,
+        execution_order=(test_count := test_count + 1),
         method="DELETE",
         api_endpoint="/api/virtuals/test-dummy",
         expected_return_code=200,
@@ -836,7 +886,7 @@ virtual_config_tests = {
         sleep_after_test=1.0,
     ),
     "cleanup_dummy_device_2": APITestCase(
-        execution_order=32,
+        execution_order=(test_count := test_count + 1),
         method="DELETE",
         api_endpoint="/api/virtuals/test-dummy-2",
         expected_return_code=200,
@@ -846,7 +896,7 @@ virtual_config_tests = {
         sleep_after_test=1.0,
     ),
     "cleanup_dummy_device_3": APITestCase(
-        execution_order=33,
+        execution_order=(test_count := test_count + 1),
         method="DELETE",
         api_endpoint="/api/virtuals/test-dummy-3",
         expected_return_code=200,


### PR DESCRIPTION
Added last_effect to the common constructor used to report virtuals configuration

Protect from DummyEffect crash weakness in GET api/virtuals/{virtual_id}/effects

Add dev docs for pytest

Tweak virtuals docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new key, "last_effect", in the virtual response, enhancing the response structure.
	- Updated handling of the `active` attribute to consider the "last_effect" when activating virtual entities.
	- Added a new section on running local system-level tests in the developer documentation.
	- Enhanced guidance on using virtuals in the how-to documentation, including clearer instructions and visual aids.

- **Bug Fixes**
	- Maintained existing error handling for setting active status and updating segments, ensuring stability during operations.

- **Tests**
	- Added new test cases and modified existing ones to improve coverage and functionality related to virtual devices and effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->