### PR TITLE
dev: Add keyrest.py script for fallback testing

### DIFF
--- a/tests/scripts/keyrest.py
+++ b/tests/scripts/keyrest.py
@@ -2,6 +2,10 @@ import keyboard
 import requests
 import os
 
+# this test script will on the pressing of the space bar send a request to the ledfx server 
+# to change the effect of a virtual to my_effect with the fallback value of 20 seconds
+# On release of the space bar it will cancel the effect and fallback to the previous effect
+# exit by pressing X. the terminal does not need to be in focus for this to work
 
 my_virtual = "wled19-32x32"
 my_effect = "noise2d"

--- a/tests/scripts/keyrest.py
+++ b/tests/scripts/keyrest.py
@@ -1,8 +1,9 @@
-import keyboard
-import requests
 import os
 
-# this test script will on the pressing of the space bar send a request to the ledfx server 
+import keyboard
+import requests
+
+# this test script will on the pressing of the space bar send a request to the ledfx server
 # to change the effect of a virtual to my_effect with the fallback value of 20 seconds
 # On release of the space bar it will cancel the effect and fallback to the previous effect
 # exit by pressing X. the terminal does not need to be in focus for this to work
@@ -17,7 +18,10 @@ def on_space_press():
     if not was_pressed:
         print("Space bar pressed")
         payload = {"type": my_effect, "fallback": 20}
-        response = requests.post(f'http://127.0.0.1:8888/api/virtuals/{my_virtual}/effects', json=payload)
+        response = requests.post(
+            f"http://127.0.0.1:8888/api/virtuals/{my_virtual}/effects",
+            json=payload,
+        )
         print(f"Response: {response.status_code} - {response.text}")
         was_pressed = True
 
@@ -25,25 +29,27 @@ def on_space_press():
 def on_space_release():
     global was_pressed
     print("Space bar released")
-    response = requests.get(f'http://127.0.0.1:8888/api/virtuals/{my_virtual}/fallback')
+    response = requests.get(
+        f"http://127.0.0.1:8888/api/virtuals/{my_virtual}/fallback"
+    )
     print(f"Response: {response.status_code} - {response.text}")
 
     was_pressed = False
 
 
 def press_x():
-    print('X key pressed, everyone out of the sewers...')
+    print("X key pressed, everyone out of the sewers...")
     os._exit(0)
 
 
 def main():
     # Register event handlers for space bar press and release
-    keyboard.on_press_key('space', lambda _: on_space_press())
-    keyboard.on_release_key('space', lambda _: on_space_release())
+    keyboard.on_press_key("space", lambda _: on_space_press())
+    keyboard.on_release_key("space", lambda _: on_space_release())
 
     # Monitor for 'X' or 'x' key press to exit the program
-    keyboard.add_hotkey('x', lambda: press_x())
-    keyboard.add_hotkey('X', lambda: press_x())
+    keyboard.add_hotkey("x", lambda: press_x())
+    keyboard.add_hotkey("X", lambda: press_x())
 
     # Block the program and keep it running
     keyboard.wait()

--- a/tests/scripts/keyrest.py
+++ b/tests/scripts/keyrest.py
@@ -1,0 +1,49 @@
+import keyboard
+import requests
+import os
+
+
+my_virtual = "wled19-32x32"
+my_effect = "noise2d"
+was_pressed = False
+
+
+def on_space_press():
+    global was_pressed
+    if not was_pressed:
+        print("Space bar pressed")
+        payload = {"type": my_effect, "fallback": 20}
+        response = requests.post(f'http://127.0.0.1:8888/api/virtuals/{my_virtual}/effects', json=payload)
+        print(f"Response: {response.status_code} - {response.text}")
+        was_pressed = True
+
+
+def on_space_release():
+    global was_pressed
+    print("Space bar released")
+    response = requests.get(f'http://127.0.0.1:8888/api/virtuals/{my_virtual}/fallback')
+    print(f"Response: {response.status_code} - {response.text}")
+
+    was_pressed = False
+
+
+def press_x():
+    print('X key pressed, everyone out of the sewers...')
+    os._exit(0)
+
+
+def main():
+    # Register event handlers for space bar press and release
+    keyboard.on_press_key('space', lambda _: on_space_press())
+    keyboard.on_release_key('space', lambda _: on_space_release())
+
+    # Monitor for 'X' or 'x' key press to exit the program
+    keyboard.add_hotkey('x', lambda: press_x())
+    keyboard.add_hotkey('X', lambda: press_x())
+
+    # Block the program and keep it running
+    keyboard.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/keyrest.py
+++ b/tests/scripts/keyrest.py
@@ -1,8 +1,12 @@
 import os
 
-import keyboard
-import requests
-
+try:
+    import keyboard
+    import requests
+except ImportError as e:
+    print(f"Required package not found: {e}")
+    print("Please install required packages: pip install keyboard requests")
+    exit(1)
 # this test script will on the pressing of the space bar send a request to the ledfx server
 # to change the effect of a virtual to my_effect with the fallback value of 20 seconds
 # On release of the space bar it will cancel the effect and fallback to the previous effect


### PR DESCRIPTION
this test script will on the pressing of the space bar send a request to the ledfx server 
to change the effect of a virtual to my_effect with the fallback value of 20 seconds
On release of the space bar it will cancel the effect and fallback to the previous effect
exit by pressing X. the terminal does not need to be in focus for this to work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a script for interacting with a LED effects server using keyboard events.
	- Allows users to change LED effects with space bar presses and revert effects on release.
	- Includes functionality to exit the program with the 'X' key.
	- Handles missing library imports by prompting users to install necessary packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->