### PR TITLE
fix: symmetry in mirror on effects

### DIFF
--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -458,10 +458,17 @@ class Effect(BaseRegistry):
                     # Apply some of the base output filters if necessary
                     if self.flip:
                         pixels = np.flipud(pixels)
+
                     if self.mirror:
-                        pixels = np.concatenate(
-                            (pixels[-1 + len(pixels) % -2 :: -2], pixels[::2])
-                        )
+                        # different composition for odd vs even which is not easy to formulate so, just if else...
+                        # preserver symetrical mirroring so 
+                        # [1,2,3,4,5,6] becomes [5,3,1,1,3,5]
+                        # [1,2,3,4,5] becomes [5,3,1,3,4]
+                        if self.pixel_count % 2 == 0:
+                            pixels = np.concatenate((pixels[-2 :: -2], pixels[::2]))
+                        else:
+                            pixels = np.concatenate((pixels[-1 :1: -2], pixels[::2]))
+                        
                     if self.bg_color_use:
                         pixels += self._bg_color
                     if self.brightness is not None:

--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -461,14 +461,18 @@ class Effect(BaseRegistry):
 
                     if self.mirror:
                         # different composition for odd vs even which is not easy to formulate so, just if else...
-                        # preserver symetrical mirroring so 
+                        # preserver symetrical mirroring so
                         # [1,2,3,4,5,6] becomes [5,3,1,1,3,5]
                         # [1,2,3,4,5] becomes [5,3,1,3,4]
                         if self.pixel_count % 2 == 0:
-                            pixels = np.concatenate((pixels[-2 :: -2], pixels[::2]))
+                            pixels = np.concatenate(
+                                (pixels[-2::-2], pixels[::2])
+                            )
                         else:
-                            pixels = np.concatenate((pixels[-1 :1: -2], pixels[::2]))
-                        
+                            pixels = np.concatenate(
+                                (pixels[-1:1:-2], pixels[::2])
+                            )
+
                     if self.bg_color_use:
                         pixels += self._bg_color
                     if self.brightness is not None:

--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -461,7 +461,7 @@ class Effect(BaseRegistry):
 
                     if self.mirror:
                         # different composition for odd vs even which is not easy to formulate so, just if else...
-                        # preserver symetrical mirroring so
+                        # preserve symmetrical mirroring so
                         # [1,2,3,4,5,6] becomes [5,3,1,1,3,5]
                         # [1,2,3,4,5] becomes [5,3,1,3,4]
                         if self.pixel_count % 2 == 0:


### PR DESCRIPTION
Old code would use every other pixel, but offsets, so

[1,2,3,4,5,6] became

[6,4,2,1,3,5]

and 

[1,2,3,4,5]

became 

[5,3,1,2,4]

So effects at low pixels counts would obviously flicker left and right non symmetrical

This is exasperated by the current algorithm for skipping every other pixel, so scrolling effects can have pixels flicker in and out of existence every other frame of movement, this is very visible on lower pixel count strips. This fix ONLY addresses symmetry

Testing on 15 and 16 pixel dummy devices, with scroll effect. 

Removes obvious left right jumping.

Also debug via injection of array values indexed from 1 and checking post mirror ordering.

Using effect configuration to intentionally amplify the problem. You can still see the aliasing issue, but the left right jump is addressed, shows both odd and even devices

This is before fix

https://github.com/user-attachments/assets/8b5e9f27-9738-461a-9fbe-f2c5132f7583

This is after fix

https://github.com/user-attachments/assets/b6dce6e8-16d6-4e12-8075-9bc3b07c6b1e

Partly addresses complaint in https://github.com/LedFx/LedFx/issues/1005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the mirroring effect for improved visual output by refining pixel arrangement logic.

- **Bug Fixes**
	- Corrected the handling of pixel counts to ensure symmetrical mirroring for both even and odd counts.

- **Documentation**
	- Updated comments for clarity on the new logic implemented in the mirroring effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->