### PR TITLE
fix: better mirror algorithm

### DIFF
--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -463,8 +463,12 @@ class Effect(BaseRegistry):
                         # concatenate the pixels for mirror, then take the max of adjacent pixels
                         # prevents average dimming and is best compromise, removes flicker
                         # inherently symetrical
-                        mirrored_pixels = np.concatenate((pixels[::-1], pixels))                            
-                        pixels = np.maximum(mirrored_pixels[::2], mirrored_pixels[1::2])
+                        mirrored_pixels = np.concatenate(
+                            (pixels[::-1], pixels)
+                        )
+                        pixels = np.maximum(
+                            mirrored_pixels[::2], mirrored_pixels[1::2]
+                        )
 
                     if self.bg_color_use:
                         pixels += self._bg_color

--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -460,18 +460,11 @@ class Effect(BaseRegistry):
                         pixels = np.flipud(pixels)
 
                     if self.mirror:
-                        # different composition for odd vs even which is not easy to formulate so, just if else...
-                        # preserve symmetrical mirroring so
-                        # [1,2,3,4,5,6] becomes [5,3,1,1,3,5]
-                        # [1,2,3,4,5] becomes [5,3,1,3,4]
-                        if self.pixel_count % 2 == 0:
-                            pixels = np.concatenate(
-                                (pixels[-2::-2], pixels[::2])
-                            )
-                        else:
-                            pixels = np.concatenate(
-                                (pixels[-1:1:-2], pixels[::2])
-                            )
+                        # concatenate the pixels for mirror, then take the max of adjacent pixels
+                        # prevents average dimming and is best compromise, removes flicker
+                        # inherently symetrical
+                        mirrored_pixels = np.concatenate((pixels[::-1], pixels))                            
+                        pixels = np.maximum(mirrored_pixels[::2], mirrored_pixels[1::2])
 
                     if self.bg_color_use:
                         pixels += self._bg_color


### PR DESCRIPTION
Yet another mirror algorithm

Is ~3x slower than the previous implementation, cost is relative to pixel count.

for a 16K strip processing time is ~180 us vs ~60 us but that is a very small frame cost.

HOWEVER

Symmetry is inherent.

Concatenates the mirror of the full pixel array and then resamples back down to original length by taking the highest value pixel from every pair of pixels.

This prevents very obvious dimming caused by trying to take the average. When there effects that have every other pixel black, then the brightness of the overall effect would be halved by turning on mirror.

Far more efficient than linear interpolation

Has a slight crawl effect if you know what to look for, as bright pixels jump between pairs, but is FAR less noticeable than prior implementation.

I don't think there is a better compromise for low count strips, which will be the majority of users.

Fully addresses https://github.com/LedFx/LedFx/issues/1005 as much as is reasonable

see https://discord.com/channels/469985374052286474/1320851506588811304/1321907106512896143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the mirror functionality in pixel output to reduce dimming and flickering.
- **Documentation**
	- Updated comments for clarity regarding the changes made to the pixel handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->