### PR TITLE
Fix: Protect against odd shapes

### DIFF
--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -1897,7 +1897,11 @@ def resize_pixels(pixels, old_shape, new_shape):
 
 
 def shape_to_fit_len(max_len, shape, pixels_len):
-    """_summary_
+    """Converts the shape of a visualisation to obey constraints
+       The max_len pixels which is a system variable a user can change
+       Additionally a max dimension of 64 in rows or columns is enforced
+       As the shape has already been reduced to max pixels, both CANNOT 
+       be greate than 64
 
     Args:
         max_len : The maximum number of pixels allowed in the final visualisation
@@ -1916,11 +1920,22 @@ def shape_to_fit_len(max_len, shape, pixels_len):
         new_rows = shape[0] / reduction_ratio
         new_cols = shape[1] / reduction_ratio
 
+        # protect against extreme shapes
+        # see function description for magic number 64
+        if new_rows > 64:
+            reduction_ratio = 64 / new_rows
+            new_rows = 64
+            new_cols =  new_cols * reduction_ratio
+        elif new_cols > 64:
+            reduction_ratio = 64 / new_cols
+            new_cols = 64
+            new_rows = new_rows * reduction_ratio
+        
         # protect from less than 1 values
         if new_rows < 1.0:
-            new_shape = (1, max_len)
+            new_shape = (1, new_cols)
         elif new_cols < 1.0:
-            new_shape = (max_len, 1)
+            new_shape = (new_rows, 1)
         else:
             new_shape = (
                 int(new_rows),

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -1900,7 +1900,7 @@ def shape_to_fit_len(max_len, shape, pixels_len):
     """Converts the shape of a visualisation to obey constraints
        The max_len pixels which is a system variable a user can change
        Additionally a max dimension of 64 in rows or columns is enforced
-       As the shape has already been reduced to max pixels, both CANNOT 
+       As the shape has already been reduced to max pixels, both CANNOT
        be greate than 64
 
     Args:
@@ -1925,12 +1925,12 @@ def shape_to_fit_len(max_len, shape, pixels_len):
         if new_rows > 64:
             reduction_ratio = 64 / new_rows
             new_rows = 64
-            new_cols =  new_cols * reduction_ratio
+            new_cols = new_cols * reduction_ratio
         elif new_cols > 64:
             reduction_ratio = 64 / new_cols
             new_cols = 64
             new_rows = new_rows * reduction_ratio
-        
+
         # protect from less than 1 values
         if new_rows < 1.0:
             new_shape = (1, new_cols)


### PR DESCRIPTION
Limited visualization updates to max height and width of 64 pixels, as well as max_pixels

Prevents crazy long visualizations on extreme aspect ratios.

See 

https://discord.com/channels/469985374052286474/1321869046668328971/1322251020889227386

Front end needs to deal better with very tall matrix, but wide matrix now get rendered well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced dimension validation for visualizations to prevent exceeding maximum limits.
	- Adjusted handling of cases for invalid new dimensions to ensure valid output.

- **Documentation**
	- Updated docstring for the function to clarify its purpose and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->