### PR TITLE
Fix: Support single frame images in gifplayer and keybeat

### DIFF
--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -1432,7 +1432,8 @@ def open_gif(gif_path):
 
     Args:
         gif_path: str
-            path to gif file or url
+            path to gif, webp, png or jpg file or url
+            Can handle any image source that PIL is capable of, not just gif
     Returns:
         Image: PIL Image object or None if failed to open
     """
@@ -1441,13 +1442,17 @@ def open_gif(gif_path):
         if gif_path.startswith("http://") or gif_path.startswith("https://"):
             with urllib.request.urlopen(gif_path) as url:
                 gif = Image.open(url)
-                _LOGGER.debug("Remote GIF downloaded and opened.")
-                return gif
-
+                _LOGGER.debug("Remote image source downloaded and opened.")
         else:
             gif = Image.open(gif_path)  # Directly open for local files
-            _LOGGER.debug("Local GIF opened.")
-            return gif
+            _LOGGER.debug("Local image source opened.")
+        
+        # protect against single frame image like png, jpg
+        if not hasattr(gif, "n_frames"):
+            gif.n_frames = 1
+
+        return gif
+    
     except Exception as e:
         _LOGGER.warning(f"Failed to open gif : {gif_path} : {e}")
         return None

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -1446,13 +1446,13 @@ def open_gif(gif_path):
         else:
             gif = Image.open(gif_path)  # Directly open for local files
             _LOGGER.debug("Local image source opened.")
-        
+
         # protect against single frame image like png, jpg
         if not hasattr(gif, "n_frames"):
             gif.n_frames = 1
 
         return gif
-    
+
     except Exception as e:
         _LOGGER.warning(f"Failed to open gif : {gif_path} : {e}")
         return None


### PR DESCRIPTION
PIL image open does not have a n_frame member var for single frame image types like png and jpg

WHY?

Just hack one in, then everything just works.

Now Gifplayer and keybeat can handle png and jpg sources directly!

Tested with flag png and jpg sources. Would previously crash the effect, now, everything is fine...

![image](https://github.com/user-attachments/assets/b0d1c872-7a1c-4ffc-93df-cab30335619c)

Common PIL image formats

Common Image Formats Supported:
BMP: Bitmap Image File (.bmp, .dib)
EPS: Encapsulated PostScript (.eps)
GIF: Graphics Interchange Format (.gif)
ICNS: Apple Icon Image (.icns)
ICO: Icon format (.ico)
JPEG/JPG: Joint Photographic Experts Group (.jpeg, .jpg)
PNG: Portable Network Graphics (.png)
PPM/PGM/PBM: Portable Image Formats (.ppm, .pgm, .pbm)
TIFF: Tagged Image File Format (.tif, .tiff)
WebP: Web Picture Format (.webp)
XBM: X Bitmap Format (.xbm)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved image handling to support multiple formats (webp, png, jpg) in addition to gif
	- Enhanced image processing to correctly handle single-frame images

<!-- end of auto-generated comment: release notes by coderabbit.ai -->