### PR TITLE
Fix: Reset default gradient for pre defined

### DIFF
--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -41,10 +41,9 @@ import requests
 import voluptuous as vol
 from dotenv import load_dotenv
 
+from ledfx.color import LEDFX_GRADIENTS
 from ledfx.config import save_config
 from ledfx.consts import LEDFX_ASSETS_PATH, PROJECT_VERSION
-from ledfx.color import LEDFX_GRADIENTS
-
 
 # from asyncio import coroutines, ensure_future
 

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -43,6 +43,8 @@ from dotenv import load_dotenv
 
 from ledfx.config import save_config
 from ledfx.consts import LEDFX_ASSETS_PATH, PROJECT_VERSION
+from ledfx.color import LEDFX_GRADIENTS
+
 
 # from asyncio import coroutines, ensure_future
 
@@ -1535,7 +1537,18 @@ def get_font(font_list, size):
 
 
 def generate_default_config(ledfx_effects, effect_id):
-    return ledfx_effects.get_class(effect_id).get_combined_default_schema()
+    """
+    Generate config out of the schema for an effect to use as a defualt
+
+    Any manipulations must be made in here, such as expanding gradient strings to fully defined gradients
+    """
+    config = ledfx_effects.get_class(effect_id).get_combined_default_schema()
+    gradient = config.get("gradient", None)
+    gradient_str = LEDFX_GRADIENTS.get(gradient, None)
+    if gradient_str:
+        config["gradient"] = gradient_str
+        config["gradient_name"] = gradient
+    return config
 
 
 def inject_missing_default_keys(presets, defaults):


### PR DESCRIPTION
Pass the fully expanding string for default gradients where ledfx predefined names are used.

Extends the auto generation of the effect config default values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added detailed docstring to configuration generation function
- **Improvements**
	- Enhanced gradient configuration handling in effect settings
	- Improved configuration generation process with more comprehensive gradient support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->