### PR TITLE
Feat: Keybeat suppress frame progress when below audio cutoff

### DIFF
--- a/ledfx/effects/keybeat2d.py
+++ b/ledfx/effects/keybeat2d.py
@@ -8,8 +8,7 @@ import voluptuous as vol
 from ledfx.consts import LEDFX_ASSETS_PATH
 from ledfx.effects.gifbase import GifBase
 from ledfx.effects.twod import Twod
-from ledfx.utils import (
-#    Teleplot,
+from ledfx.utils import (  # Teleplot,
     clip_at_limit,
     extract_positive_integers,
     get_mono_font,
@@ -483,7 +482,7 @@ class Keybeat2d(Twod, GifBase):
             self.last_beat_t = self.current_time
 
         self.last_beat = self.beat
-        
+
         # latch if we find a min vol in the beat window
         if self.above_min_vol:
             self.min_vol_found_in_last_beat = True

--- a/ledfx/effects/keybeat2d.py
+++ b/ledfx/effects/keybeat2d.py
@@ -9,11 +9,11 @@ from ledfx.consts import LEDFX_ASSETS_PATH
 from ledfx.effects.gifbase import GifBase
 from ledfx.effects.twod import Twod
 from ledfx.utils import (
+    Teleplot,
     clip_at_limit,
     extract_positive_integers,
     get_mono_font,
     open_gif,
-    Teleplot
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -361,7 +361,6 @@ class Keybeat2d(Twod, GifBase):
         self.last_beat_t = self.current_time
         self.min_vol = self.audio._config["min_volume"]
 
-
     def audio_data_updated(self, data):
         if self.half_beat:
             self.beat = (data.bar_oscillator() % 2) / 2
@@ -373,7 +372,6 @@ class Keybeat2d(Twod, GifBase):
         Teleplot.send(f"beatnow:{1 if data.bpm_beat_now() else 0}")
         self.below_min_vol = True if vol < self.min_vol else False
         Teleplot.send(f"suppress:{1 if self.suppress_beat else 0}")
-
 
     def overlay(self, beat_kick, skip_beat):
         # add beat timestamps to the rolling window beat_list
@@ -468,7 +466,9 @@ class Keybeat2d(Twod, GifBase):
                             self.frame_c + 1
                         ) % self.framecount
                     else:
-                        self.beat_idx = (self.beat_idx + 1) % self.num_beat_frames
+                        self.beat_idx = (
+                            self.beat_idx + 1
+                        ) % self.num_beat_frames
 
             self.last_beat_t = self.current_time
 

--- a/ledfx/effects/keybeat2d.py
+++ b/ledfx/effects/keybeat2d.py
@@ -370,7 +370,7 @@ class Keybeat2d(Twod, GifBase):
         else:
             self.beat = data.beat_oscillator()
         vol = max(0, min(1, self.audio.volume(filtered=False)))
-        self.above_min_vol = True if vol >= self.min_vol else False
+        self.above_min_vol = vol >= self.min_vol
 
         # Teleplot.send(f"beat:{self.beat}")
         # Teleplot.send(f"vol:{vol}")

--- a/ledfx/effects/keybeat2d.py
+++ b/ledfx/effects/keybeat2d.py
@@ -118,6 +118,7 @@ class Keybeat2d(Twod, GifBase):
         super().__init__(ledfx, config)
         self.min_vol = 0
         self.min_vol_found_in_last_beat = False
+        self.above_min_vol = False
 
     def config_updated(self, config):
         super().config_updated(config)


### PR DESCRIPTION
Teleplot instrumentation has been commented out.

Now looks for any audio above minimum volume in the last beat cycle to avoid suppression.

Works well now with metronome tests.

This can go in without an extra switch, it should just be default behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced audio beat detection with volume-based progression control
	- Added more sophisticated volume threshold management for beat effects

- **Improvements**
	- Improved audio responsiveness in beat visualization
	- More nuanced beat suppression based on audio volume levels
<!-- end of auto-generated comment: release notes by coderabbit.ai -->