### PR TITLE
Fix: Socket closure on client closure

### DIFF
--- a/ledfx/api/websocket.py
+++ b/ledfx/api/websocket.py
@@ -295,7 +295,9 @@ class WebsocketConnection:
         if subscription_id in self._listeners:
             self._listeners.pop(subscription_id)()
         else:
-            _LOGGER.warning(f"Unsubscibe unknown subscription ID {subscription_id}")
+            _LOGGER.warning(
+                f"Unsubscibe unknown subscription ID {subscription_id}"
+            )
 
     @websocket_handler("audio_stream_start")
     def audio_stream_start_handler(self, message):

--- a/ledfx/api/websocket.py
+++ b/ledfx/api/websocket.py
@@ -276,6 +276,7 @@ class WebsocketConnection:
             self.send_error(message["id"], msg)
             return
 
+        _LOGGER.debug(f"  sub Q: {hex(id(self))} {str(message)[:80]}")
         _LOGGER.debug(
             f"Websocket subscribing to event {message.get('event_type')} with filter {message.get('event_filter')}"
         )
@@ -287,11 +288,14 @@ class WebsocketConnection:
 
     @websocket_handler("unsubscribe_event")
     def unsubscribe_event_handler(self, message):
+        _LOGGER.debug(f"unsub Q: {hex(id(self))} {str(message)[:80]}")
         subscription_id = message["id"]
 
         _LOGGER.debug(f"Websocket unsubscribing event id {subscription_id}")
         if subscription_id in self._listeners:
             self._listeners.pop(subscription_id)()
+        else:
+            _LOGGER.warning(f"Unsubscibe unknown subscription ID {subscription_id}")
 
     @websocket_handler("audio_stream_start")
     def audio_stream_start_handler(self, message):

--- a/ledfx/dedupequeue.py
+++ b/ledfx/dedupequeue.py
@@ -32,7 +32,7 @@ class VisDeduplicateQ(asyncio.Queue):
 
         # protect against None item flushing during socket closure
         if item:
-            # Check if is a visualisation update message      
+            # Check if is a visualisation update message
             if (
                 item.get("event_type") == Event.DEVICE_UPDATE
                 or item.get("event_type") == Event.VISUALISATION_UPDATE


### PR DESCRIPTION
Changes in socket queue handling did not account for a flush send of item = None

Would leave sockets orphaned

Paired fix with enforcing unique ID's for front end event subscriptions

No hard dependency, but debug here helps confirm that fix.

Tested with the additional debug to watch sub / unsub against unique instances and through watching queue traffic with teleplot and ensuring no spam / orphaned queues

See https://discord.com/channels/469985374052286474/1328059079972880549


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced websocket connection logging for better debugging and traceability
	- Added more robust error handling in websocket event subscription and unsubscription processes
	- Improved queue management to prevent processing of invalid items during socket closure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->