### PR TITLE
Fix: none event in socket close race condition

### DIFF
--- a/ledfx/dedupequeue.py
+++ b/ledfx/dedupequeue.py
@@ -51,8 +51,14 @@ class VisDeduplicateQ(asyncio.Queue):
     def is_similar(self, new, queued):
         # We know we are already one of the correct types, but is it the same as queued
         # then check if it is for the same device
+        
+        # Protect against None events
+        if new is None or queued is None:
+            return False
+        
         if new.get("event_type") == queued.get("event_type") and new.get(
             "vis_id"
         ) == queued.get("vis_id"):
             return True
+        
         return False

--- a/ledfx/dedupequeue.py
+++ b/ledfx/dedupequeue.py
@@ -51,14 +51,14 @@ class VisDeduplicateQ(asyncio.Queue):
     def is_similar(self, new, queued):
         # We know we are already one of the correct types, but is it the same as queued
         # then check if it is for the same device
-        
+
         # Protect against None events
         if new is None or queued is None:
             return False
-        
+
         if new.get("event_type") == queued.get("event_type") and new.get(
             "vis_id"
         ) == queued.get("vis_id"):
             return True
-        
+
         return False


### PR DESCRIPTION
Did not cause a user facing crash

Protect against race condition on socket close, where a visualisation update arrives as closure is in progress and a none event is in the queue

Seen in sentry post socket fix in 2.0.107

https://ledfx-org.sentry.io/issues/6218228195/?project=4506350233321472&referrer=github-pr-bot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling in queue processing to prevent potential crashes.
	- Added robust checks to handle `None` values during item comparison and queuing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->