### PR TITLE
mqtt-hass: fix if scene id is a number

### DIFF
--- a/ledfx/integrations/mqtt_hass.py
+++ b/ledfx/integrations/mqtt_hass.py
@@ -513,7 +513,7 @@ class MQTT_HASS(Integration):
 
         # React to Scene-Selector
         elif virtualid == "ledfxsceneselect":
-            self._ledfx.scenes.activate(payload)
+            self._ledfx.scenes.activate(str(payload))
 
         # React to Audio-Selector
         elif virtualid == "ledfxaudio":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scene activation by ensuring payload is converted to a string type
  - Enhanced compatibility with MQTT scene activation mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->