### PR TITLE
Docs: Automagical year in copyright

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,4 +18,6 @@ Developers:
 
 * `Chris Reese <https://github.com/THATDONFC>`_
 
+* `bigredfrog <https://github.com/bigredfrog>`
+
 Special thanks to our `community developers! <https://github.com/LedFx/LedFx/graphs/contributors>`_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@ import os
 import sys
 
 import sphinx_rtd_theme
+import datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -25,7 +26,7 @@ from ledfx.consts import PROJECT_AUTHOR, PROJECT_NAME, PROJECT_VERSION
 
 PROJECT_PACKAGE_NAME = PROJECT_NAME
 PROJECT_AUTHOR = PROJECT_AUTHOR
-PROJECT_COPYRIGHT = f" 2018-2023, {PROJECT_AUTHOR}"
+PROJECT_COPYRIGHT = f" 2018-{datetime.datetime.now().year}, {PROJECT_AUTHOR}"
 PROJECT_SHORT_DESCRIPTION = "LedFx is an open-source effect controller"
 PROJECT_LONG_DESCRIPTION = (
     "LedFx is an open-source effect controller "

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,11 +7,11 @@
 
 # -- Path setup --------------------------------------------------------------
 
+import datetime
 import os
 import sys
 
 import sphinx_rtd_theme
-import datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the


### PR DESCRIPTION
and adding bigredfrog to authors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added new contributor `bigredfrog` to the project's authors list
	- Updated documentation configuration to dynamically generate current year in copyright statement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->