### PR TITLE
Docs: MTU troubleshooting

### DIFF
--- a/docs/trouble.md
+++ b/docs/trouble.md
@@ -177,15 +177,15 @@ weaknesses in WiFi. To minimize this, we reccomend:
 All current builds should be able to be accessed from LAN - please
 ensure that you allow traffic from port 8888 from the host machine.
 
-## I only get something less that 480 leds in WLED
+## I only get something less than 480 LEDs in WLED
 
 With a long led strip, of greater than 480 pixels, ledfx only seems to drive 480 or less.
 
-### Maybe its the network interface MTU
+### Maybe it's the network interface MTU
 
 If the MTU of the networking interface on your host PC is not set to the common default 1500 bytes, fragmentation of the UDP packets that DDP is transported on, may cause issue with WLED at consumption of the DDP protocol
 
-By default ledfx splits up seperate DDP packets at 480 pixel boundaries. So for example in a 1024 pixels device, it will take 3 DDP over UDP packets to transmit a single frame of data. Each packet will have a max UDP size of 1492 bytes made up of headers plus 3 x 480 bytes for RGB data
+By default, LedFx splits up seperate DDP packets at 480 pixel boundaries. So for example in a 1024 pixels device, it will take 3 DDP over UDP packets to transmit a single frame of data. Each packet will have a max UDP size of 1492 bytes made up of headers plus 3 x 480 bytes for RGB data
 
 If the MTU of the network interface is less that 1500, the UDP packets will get fragmented, and its possible that WLED will only service the first fragment and ignore the remaining fragement and all folllowing DDP packets until the next frame cycle.
 
@@ -206,7 +206,7 @@ Get-NetIPInterface | Select-Object InterfaceAlias, AddressFamily, NlMtu
 ip link show
 ```
 
-#### On Mac OSX
+#### On macOS
 
 ```console
 ifconfig | grep mtu

--- a/docs/trouble.md
+++ b/docs/trouble.md
@@ -177,6 +177,41 @@ weaknesses in WiFi. To minimize this, we reccomend:
 All current builds should be able to be accessed from LAN - please
 ensure that you allow traffic from port 8888 from the host machine.
 
+## I only get something less that 480 leds in WLED
+
+With a long led strip, of greater than 480 pixels, ledfx only seems to drive 480 or less.
+
+### Maybe its the network interface MTU
+
+If the MTU of the networking interface on your host PC is not set to the common default 1500 bytes, fragmentation of the UDP packets that DDP is transported on, may cause issue with WLED at consumption of the DDP protocol
+
+By default ledfx splits up seperate DDP packets at 480 pixel boundaries. So for example in a 1024 pixels device, it will take 3 DDP over UDP packets to transmit a single frame of data. Each packet will have a max UDP size of 1492 bytes made up of headers plus 3 x 480 bytes for RGB data
+
+If the MTU of the network interface is less that 1500, the UDP packets will get fragmented, and its possible that WLED will only service the first fragment and ignore the remaining fragement and all folllowing DDP packets until the next frame cycle.
+
+If any interface has less that 1500 it is recommended to fix it to 1500. Use Chatgpt or other sources to resolve exact steps for your system.
+
+### Checking your MTU
+#### On Windows
+
+Open Powershell and run
+
+``` console
+Get-NetIPInterface | Select-Object InterfaceAlias, AddressFamily, NlMtu
+```
+
+#### On Linux
+
+```console
+ip link show
+```
+
+#### On Mac OSX
+
+```console
+ifconfig | grep mtu
+```
+
 ## Need more help?
 
 Reach out to the LedFx team through Discord. Preferably copy and paste


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new troubleshooting section for addressing issues with LED strips longer than 480 pixels in WLED.
  - Introduced a subsection on network interface MTU implications.
  - Included instructions for checking MTU on Windows, Linux, and macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->