### PR TITLE
fix: add scene_id vs scene_name with duplicate protection

### DIFF
--- a/ledfx/api/scenes.py
+++ b/ledfx/api/scenes.py
@@ -202,7 +202,19 @@ class ScenesEndpoint(RestEndpoint):
 
             return await self.invalid_request(error_message)
 
-        scene_id = generate_id(scene_name)
+        scene_id = data.get("id")
+
+        if not scene_id:
+            # this is a create, make sure it is deduped
+            dupe_id = generate_id(scene_name)
+            dupe_index = 1
+            scene_id = dupe_id
+            while scene_id in self._ledfx.config["scenes"].keys():
+                scene_id = f"{dupe_id}-{dupe_index}"
+                dupe_index = dupe_index + 1
+        else:
+            # this is an overwrite scenario, just sanitize scene_id
+            scene_id = generate_id(scene_id)
 
         scene_config = {}
         scene_config["name"] = scene_name

--- a/ledfx/api/scenes.py
+++ b/ledfx/api/scenes.py
@@ -37,7 +37,7 @@ class ScenesEndpoint(RestEndpoint):
         except JSONDecodeError:
             return await self.json_decode_error()
 
-        scene_id = data.get("id")
+        scene_id = generate_id(data.get("id"))
         if scene_id is None:
             return await self.invalid_request(
                 'Required attribute "id" was not provided'
@@ -83,7 +83,7 @@ class ScenesEndpoint(RestEndpoint):
         if action not in ["activate", "activate_in", "deactivate", "rename"]:
             return await self.invalid_request(f'Invalid action "{action}"')
 
-        scene_id = data.get("id")
+        scene_id = generate_id(data.get("id"))
         if scene_id is None:
             return await self.invalid_request(
                 'Required attribute "id" was not provided'

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -713,7 +713,10 @@ def generate_id(name):
             str: The converted ID.
     """
     part1 = re.sub("[^a-zA-Z0-9]", " ", name).lower()
-    return re.sub(" +", " ", part1).strip().replace(" ", "-")
+    result = re.sub(" +", " ", part1).strip().replace(" ", "-")
+    if result == "":
+        result = "default"
+    return result
 
 
 def generate_title(id):


### PR DESCRIPTION
Expanding scope for proper scene_id duplication protection and create / edit

Add dedupe support for scene_id based on name as per existing virtuals implementation

Sanitise id field before use

Needs front end changes to leverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the way scene identifiers are handled during creation, updating, and deletion, ensuring more consistent and reliable scene operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->