### PR TITLE
Fix: bleep effect start race condition

### DIFF
--- a/ledfx/effects/bleep.py
+++ b/ledfx/effects/bleep.py
@@ -327,7 +327,8 @@ class Bleep(Twod, GradientEffect):
 
     def audio_data_updated(self, data):
         self.power = getattr(data, self.power_func)()
-        self.bleeper.update(self.power)
+        if not self.init:
+            self.bleeper.update(self.power)
 
     def draw(self):
         # self.matrix is the Image object


### PR DESCRIPTION
Dont update bleeper audio power if we have not run init

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the audio effect’s behavior by ensuring the bleep effect only updates once the system setup is complete. This adjustment prevents premature updates during initialization, leading to a more stable and consistent audio response during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->