### PR TITLE
Fix: global transition bug when there are empty virtuals

### DIFF
--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -1140,16 +1140,18 @@ class Virtual:
                         if virtual_id == self.id:
                             continue
                         virtual = self._ledfx.virtuals.get(virtual_id)
-                        virtual.frame_transitions = virtual.transitions[
-                            _config["transition_mode"]
-                        ]
-                        virtual._config["transition_time"] = _config[
-                            "transition_time"
-                        ]
-                        virtual._config["transition_mode"] = _config[
-                            "transition_mode"
-                        ]
-
+                        if hasattr(virtual, "frame_transitions"):
+                            virtual.frame_transitions = virtual.transitions[
+                                _config["transition_mode"]
+                            ]
+                            virtual._config["transition_time"] = _config[
+                                "transition_time"
+                            ]
+                            virtual._config["transition_mode"] = _config[
+                                "transition_mode"
+                            ]
+                        else:
+                            _LOGGER.info(f"virtual of {virtual_id} has no transitions")
             if (
                 "frequency_min" in _config.keys()
                 or "frequency_max" in _config.keys()

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -1151,7 +1151,9 @@ class Virtual:
                                 "transition_mode"
                             ]
                         else:
-                            _LOGGER.info(f"virtual of {virtual_id} has no transitions")
+                            _LOGGER.info(
+                                f"virtual of {virtual_id} has no transitions"
+                            )
             if (
                 "frequency_min" in _config.keys()
                 or "frequency_max" in _config.keys()


### PR DESCRIPTION
Virtuals with no segments have no transitions
If transitions is set to global then virtuals posts would fail due to attempting to access transitions of all virtuals
Only attempt setting transitions if member is present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved system stability by adding safeguards during configuration updates, ensuring that settings are only applied when applicable. This prevents potential runtime issues and results in a smoother, more reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->