### PR TITLE
Fix: Save active effect to config on virtual put

### DIFF
--- a/ledfx/api/virtual.py
+++ b/ledfx/api/virtual.py
@@ -93,6 +93,7 @@ class VirtualEndpoint(RestEndpoint):
                             config=effect_config,
                         )
                         virtual.set_effect(effect)
+                        virtual.update_effect_config(effect)
         try:
             virtual.active = active
         except ValueError as msg:


### PR DESCRIPTION
Issue would lead to effects started from the devices play  button would not be persisted as active, so on a restart, they would be back in stop state.

Forcing the effect stansa to be added to the config ensures that effect is started on a restart.

Prior to fix could reproduce issue by starting last effect from devices view play button. 
Post fix, cannot reproduce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced virtual effect handling so that effect configurations update automatically when a new effect is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->