### PR TITLE
Feat: add port param for artnet device

### DIFF
--- a/ledfx/devices/artnet.py
+++ b/ledfx/devices/artnet.py
@@ -50,6 +50,11 @@ class ArtNetDevice(NetworkedDevice):
                 description="Whether to use even packet size",
                 default=True,
             ): bool,
+            vol.Optional(
+                "port", 
+                description="port", 
+                default=6454
+            ): int,
         }
     )
 
@@ -111,6 +116,7 @@ class ArtNetDevice(NetworkedDevice):
             fps=self._config["refresh_rate"],
             even_packet_size=self._config["even_packet_size"],
             broadcast=False,
+            port=self._config["port"],
         )
         # Don't use start for stupidArtnet - we handle fps locally, and it spawns hundreds of threads
 

--- a/ledfx/devices/artnet.py
+++ b/ledfx/devices/artnet.py
@@ -50,11 +50,7 @@ class ArtNetDevice(NetworkedDevice):
                 description="Whether to use even packet size",
                 default=True,
             ): bool,
-            vol.Optional(
-                "port", 
-                description="port", 
-                default=6454
-            ): int,
+            vol.Optional("port", description="port", default=6454): int,
         }
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "setuptools~=75.6.0",
     "uvloop>=0.16.0; sys_platform != \"win32\"",
     "rpi-ws281x>=4.3.0; sys_platform == \"linux\"",
-    "stupidartnet>=1.4.0,<2.0.0",
+    "stupidartnet>=1.6.0,<2.0.0",
     "python-dotenv>=1.0.0,<2.0.0",
     "vnoise>=0.1.0,<1.0.0",
 ]


### PR DESCRIPTION
artnet 1.6.0 supports port param

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an optional configuration parameter that lets users specify the network port for the Art-Net device, with a default setting of 6454. This enhancement provides improved flexibility for network setups.

- **Chores**
  - Updated the dependency version requirement for the core network protocol package to a minimum of 1.6.0, ensuring enhanced compatibility, stability, and smoother integration with external components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->