### PR TITLE
fix: oneshot add brightness cap and hard off

### DIFF
--- a/ledfx/api/virtual_tools.py
+++ b/ledfx/api/virtual_tools.py
@@ -53,7 +53,7 @@ class VirtualToolsEndpoint(RestEndpoint):
             ramp = data.get("ramp", 0)
             hold = data.get("hold", 0)
             fade = data.get("fade", 0)
-            brightness = data.get("brightness", 1)
+            brightness = min(1, max(0, data.get("brightness", 1)))
 
             # if all values are zero, we will now just ensure any current
             # oneshot are cancelled

--- a/ledfx/api/virtuals_tools.py
+++ b/ledfx/api/virtuals_tools.py
@@ -106,7 +106,7 @@ class VirtualsToolsEndpoint(RestEndpoint):
             ramp = data.get("ramp", 0)
             hold = data.get("hold", 0)
             fade = data.get("fade", 0)
-            brightness = data.get("brightness", 1)
+            brightness = min(1, max(0, data.get("brightness", 1)))
 
             # if all values are zero, we will now just ensure any current
             # oneshot are cancelled

--- a/ledfx/effects/oneshots/oneshot.py
+++ b/ledfx/effects/oneshots/oneshot.py
@@ -14,6 +14,7 @@ class Oneshot(ABC):
     def __init__(self):
         self._active: bool = True
         self._pixel_count: int = 0
+        self._total_time: int = 0
 
     @abstractmethod
     def init(self):
@@ -34,6 +35,10 @@ class Oneshot(ABC):
     @property
     def pixel_count(self):
         return self._pixel_count
+
+    @property
+    def total_time(self):
+        return self._total_time
 
     @pixel_count.setter
     def pixel_count(self, pixel_count):
@@ -64,6 +69,7 @@ class Flash(Oneshot):
         self._hold_end = self._ramp + self._hold
         self._fade_end = self._ramp + self._hold + self._fade
         self._weight = 0.0
+        self._total_time = self._fade_end
 
     def init(self):
         return

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -925,21 +925,21 @@ class Virtual:
     def add_oneshot(self, oneshot: Oneshot):
         if not self._active:
             return False
-        
+
         # a oneshot intialised with zero time is used to clear ALL active oneshots
         if oneshot.total_time == 0:
             self.cancel_oneshot()
             return False
-        
+
         oneshot.pixel_count = self.pixel_count
         oneshot.init()
         with self.lock:
             self._oneshots.append(oneshot)
         return True
-    
+
     def cancel_oneshot(self):
         # simply clearing the list will prevent any further oneshot processing
-        with self.lock:        
+        with self.lock:
             self._oneshots = []
 
     @property

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -886,8 +886,8 @@ class Virtual:
                             seg = self._effective_to_physical_pixels(
                                 seg, target_physical_len
                             )
-                            if self._os_active:
-                                self.oneshot_apply(seg)
+                            for oneshot in self._oneshots:
+                                oneshot.apply(seg, start, stop)
                             data.append((seg, device_start, device_end))
                     device.update_pixels(self.id, data)
 
@@ -925,10 +925,22 @@ class Virtual:
     def add_oneshot(self, oneshot: Oneshot):
         if not self._active:
             return False
+        
+        # a oneshot intialised with zero time is used to clear ALL active oneshots
+        if oneshot.total_time == 0:
+            self.cancel_oneshot()
+            return False
+        
         oneshot.pixel_count = self.pixel_count
         oneshot.init()
-        self._oneshots.append(oneshot)
+        with self.lock:
+            self._oneshots.append(oneshot)
         return True
+    
+    def cancel_oneshot(self):
+        # simply clearing the list will prevent any further oneshot processing
+        with self.lock:        
+            self._oneshots = []
 
     @property
     def name(self):

--- a/tests/scripts/oneshot.py
+++ b/tests/scripts/oneshot.py
@@ -7,6 +7,7 @@ except ImportError as e:
     print(f"Required package not found: {e}")
     print("Please install required packages: pip install keyboard requests")
     exit(1)
+
 # this test script will on the pressing of the space bar send a request to the ledfx server
 # to Fire onshot on a profile across all virtuals
 # multiple presses will override any active oneshot
@@ -104,6 +105,9 @@ def main():
     keyboard.add_hotkey("x", lambda: press_x())
     keyboard.add_hotkey("X", lambda: press_x())
 
+    print("press SPACE for stobe white with no hard off on release")
+    print("press V for long red ramp, hold, fade, hard off on release")
+    print("press B for long blue ramp, hold, fade, no hard off on release")
     # Block the program and keep it running
     keyboard.wait()
 


### PR DESCRIPTION
Added 0 to 1 range cap for brightness

refactored oneshot stansa for virtual copy mode, original PR only addressed span mode

Protect oneshot list manipulation from concurrency so we don't yoink during a running render / flush

Add a hard off implementation that is backward compatible with the original, cancels all oneshots when _total_time is zero

New oneshot class instances will need to likewise set _total_time

Tested with tests/scripts/oneshot.py for fast strobe, and hard offs with long running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Brightness adjustments now automatically remain within the valid range for consistent visual output.

- **New Features**
  - Flash effect performance is enhanced with new duration tracking.
  - Oneshoot effects now support multiple simultaneous applications with smooth cancellation.
  - On-screen instructions have been updated to clearly guide key controls for triggering strobe and ramp effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->