### PR TITLE
Artnet: start dmx address config

### DIFF
--- a/ledfx/devices/artnet.py
+++ b/ledfx/devices/artnet.py
@@ -100,20 +100,17 @@ class ArtNetDevice(NetworkedDevice):
         self.num_devices = self.pixel_count // self.pixels_per_device
         self.data_max = self.num_devices * self.pixels_per_device
 
+        total_pixels_per_device = (
+            self.pre_amble.size
+            + (self.pixels_per_device * 3)
+            + self.post_amble.size
+        )
         self.channel_count = (
-            self.dmx_start_address
-            + (
-                self.pre_amble.size
-                + (self.pixels_per_device * 3)
-                + self.post_amble.size
-            )
-            * self.num_devices
+            self.dmx_start_address + total_pixels_per_device * self.num_devices
         )
 
         self.packet_size = self._config["packet_size"]
-        self.universe_count = math.ceil(
-            (self.channel_count) / self.packet_size
-        )
+        self.universe_count = math.ceil(self.channel_count / self.packet_size)
 
     def activate(self):
         if self._artnet:


### PR DESCRIPTION
"Depends" on https://github.com/LedFx/LedFx/pull/1323. Relevant changes: https://github.com/LedFx/LedFx/pull/1325/commits/7c0d380c2858a73096b7ebde8a32ac5e7b46ba4a

Allows to set a start dmx address. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable DMX start address option, allowing users to set a custom channel offset.
  - Enhanced channel allocation and universe grouping for improved pixel management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->