### PR TITLE
Dev: Refactored oneshot REST API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -721,6 +721,45 @@ Clear effect of a virtual
 
 Extensible support for general tools towards ALL virtuals in one call
 
+**POST**
+
+Supports addition of oneshots to all virtuals.
+
+### oneshot
+
+Fill all active virtuals with a single color in a defined envelope of timing
+
+Intended to allow integration of instantaneous game effects over all active virtual
+
+Repeated oneshot will overwrite the previous oneshot if has not finished
+
+- color: The color to which we wish to fill the virtual, any format supported, default is white
+- ramp: The time in ms over which to ramp the color from zero to full weight over the active  effect
+- hold: The time in ms to hold the color to full weight over the active effect
+- fade: The time in ms to fade the color from full weight to zero over the active effect
+- brightness: The brightness of the oneshot at the beginning. Defaults to 1.0 which is maximum brightness
+
+
+``` json
+{
+    "tool":"oneshot",
+    "color":"white",
+    "ramp":10,
+    "hold":200,
+    "fade":2000,
+    "brightness":1
+}
+```
+
+returns
+
+``` json
+{
+    "status": "success",
+    "tool": "oneshot"
+}
+```
+
 **PUT**
 
 Supports tool instances of currently only force_color and oneshot,
@@ -756,23 +795,44 @@ returns
 
 ### oneshot
 
-Fill all active virtuals with a single color in a defined envelope of timing
+Disables all oneshots on all virtuals. Returns success if at least one oneshot is found.
 
-Intended to allow integration of instantaneous game effects over all active virtual
+``` json
+{
+    "tool":"oneshot"
+}
+```
 
-Repeated oneshot will overwrite the previous oneshot if has not finished
+returns
+
+``` json
+{
+    "status": "success",
+    "tool": "oneshot"
+}
+```
+
+## /api/virtuals_tools/\<virtual_id\>
+
+Extensible support for general tools towards a specified virtual
+
+**POST**
+
+Supports addition of oneshots to all virtuals.
+
+### oneshot
+
+Fill the specified virtual with a single color in a defined envelope of timing
+
+Intended to allow integration of instantaneous game effects over any active virtual
+
+Repeated oneshot to a virtual will add an extra oneshot if the previous ones have not finished
 
 - color: The color to which we wish to fill the virtual, any format supported, default is white
-- ramp: The time in ms over which to ramp the color from zero to full weight over the active  effect
+- ramp: The time in ms over which to ramp the color from zero to full weight over the active effect
 - hold: The time in ms to hold the color to full weight over the active effect
 - fade: The time in ms to fade the color from full weight to zero over the active effect
 - brightness: The brightness of the oneshot at the beginning. Defaults to 1.0 which is maximum brightness
-
-If all values for ramp, hold and fade are zero, which is default, any
-exisiting oneshot will be cleared
-
-A bare call to onsshot will result in a hard disable of any existing
-oneshot that is executing
 
 ``` json
 {
@@ -794,9 +854,14 @@ returns
 }
 ```
 
-## /api/virtuals_tools/\<virtual_id\>
+The virtual must be active or an error will be returned
 
-Extensible support for general tools towards a specified virtual
+``` json
+{
+    "status": "failed",
+    "reason": "virtual falcon1 is not active"
+}
+```
 
 **PUT**
 
@@ -911,21 +976,7 @@ returns
 
 ### oneshot
 
-Fill the specified virtual with a single color in a defined envelope of timing
-
-Intended to allow integration of instantaneous game effects over any active virtual
-
-Repeated oneshot to a virtual will overwrite the previous oneshot if has not finished
-
-- color: The color to which we wish to fill the virtual, any format supported, default is white
-- ramp: The time in ms over which to ramp the color from zero to full weight over the active effect
-- hold: The time in ms to hold the color to full weight over the active effect
-- fade: The time in ms to fade the color from full weight to zero over the active effect
-- brightness: The brightness of the oneshot at the beginning. Defaults to 1.0 which is maximum brightness
-
-If all values for ramp, hold and fade are zero, which is default, any exisiting oneshot will be cleared
-
-A bare call to onsshot will result in a hard disable of any existing oneshot that is executing
+Disables all oneshots on the specified virtual. Returns success if at least one oneshot is found.
 
 ``` json
 {
@@ -952,7 +1003,7 @@ The virtual must be active or an error will be returned
 ``` json
 {
     "status": "failed",
-    "reason": "virtual falcon1 is not active"
+    "reason": "oneshot was not found"
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -731,7 +731,7 @@ Fill all active virtuals with a single color in a defined envelope of timing
 
 Intended to allow integration of instantaneous game effects over all active virtual
 
-Repeated oneshot will overwrite the previous oneshot if has not finished
+Repeated oneshot to a virtual will add an extra oneshot if the previous ones have not finished
 
 - color: The color to which we wish to fill the virtual, any format supported, default is white
 - ramp: The time in ms over which to ramp the color from zero to full weight over the active  effect

--- a/ledfx/api/virtual_tools.py
+++ b/ledfx/api/virtual_tools.py
@@ -19,6 +19,53 @@ class VirtualToolsEndpoint(RestEndpoint):
     async def get(self) -> web.Response:
         return await self.request_success("info", f"Available tools: {TOOLS}")
 
+    async def post(self, request: web.Request) -> web.Response:
+        """
+        Uses the specified virtual tool on all virtuals.
+
+        Args:
+            request (web.Request): The request object containing the `tool` to use.
+
+        Returns:
+            web.Response: The HTTP response object.
+        """
+
+        try:
+            data = await request.json()
+        except JSONDecodeError:
+            return await self.json_decode_error()
+
+        tool = data.get("tool")
+
+        if tool is None:
+            return await self.invalid_request(
+                'Required attribute "tool" was not provided'
+            )
+
+        if tool not in TOOLS:
+            return await self.invalid_request(f"Tool {tool} is not in {TOOLS}")
+
+        if tool == "oneshot":
+            color = parse_color(validate_color(data.get("color", "white")))
+            ramp = data.get("ramp", 0)
+            hold = data.get("hold", 0)
+            fade = data.get("fade", 0)
+            brightness = min(1, max(0, data.get("brightness", 1)))
+
+            # iterate through all virtuals and apply oneshot
+            for virtual_id in self._ledfx.virtuals:
+                virtual = self._ledfx.virtuals.get(virtual_id)
+                if virtual is not None:
+                    virtual.add_oneshot(
+                        Flash(color, ramp, hold, fade, brightness)
+                    )
+
+        effect_response = {}
+        effect_response["tool"] = tool
+
+        response = {"status": "success", "tool": tool}
+        return await self.bare_request_success(response)
+
     async def put(self, request: web.Request) -> web.Response:
         """Extensible tools support"""
 

--- a/ledfx/api/virtual_tools.py
+++ b/ledfx/api/virtual_tools.py
@@ -104,7 +104,7 @@ class VirtualToolsEndpoint(RestEndpoint):
                     for oneshot in virtual.oneshots:
                         if type(oneshot) == Flash:
                             oneshot.active = False
-                            result = True # return True if there was at least one oneshot Flash to disable
+                            result = True  # return True if there was at least one oneshot Flash to disable
 
             if result is False:
                 return await self.invalid_request("oneshot was not found")

--- a/ledfx/api/virtual_tools.py
+++ b/ledfx/api/virtual_tools.py
@@ -102,7 +102,7 @@ class VirtualToolsEndpoint(RestEndpoint):
                 virtual = self._ledfx.virtuals.get(virtual_id)
                 if virtual is not None:
                     for oneshot in virtual.oneshots:
-                        if type(oneshot) == Flash:
+                        if isinstance(oneshot, Flash):
                             oneshot.active = False
                             result = True  # return True if there was at least one oneshot Flash to disable
 

--- a/ledfx/api/virtuals_tools.py
+++ b/ledfx/api/virtuals_tools.py
@@ -152,21 +152,14 @@ class VirtualsToolsEndpoint(RestEndpoint):
                 )
 
         if tool == "oneshot":
-            color = parse_color(validate_color(data.get("color", "white")))
-            ramp = data.get("ramp", 0)
-            hold = data.get("hold", 0)
-            fade = data.get("fade", 0)
-            brightness = min(1, max(0, data.get("brightness", 1)))
-
-            # if all values are zero, we will now just ensure any current
-            # oneshot are cancelled
-
-            result = virtual.add_oneshot(
-                Flash(color, ramp, hold, fade, brightness)
-            )
+            result = False
+            for oneshot in virtual.oneshots:
+                if type(oneshot) == Flash:
+                    oneshot.active = False
+                    result = True  # return True if there was at least one oneshot Flash to disable
 
             if result is False:
-                return await self.invalid_request("oneshot failed")
+                return await self.invalid_request("oneshot was not found")
 
         if tool == "copy":
             # copy the config of the specified virtual instance to all virtuals listed in the target payload

--- a/ledfx/api/virtuals_tools.py
+++ b/ledfx/api/virtuals_tools.py
@@ -153,7 +153,7 @@ class VirtualsToolsEndpoint(RestEndpoint):
         if tool == "oneshot":
             result = False
             for oneshot in virtual.oneshots:
-                if type(oneshot) == Flash:
+                if isinstance(oneshot, Flash):
                     oneshot.active = False
                     result = True  # return True if there was at least one oneshot Flash to disable
 

--- a/ledfx/api/virtuals_tools.py
+++ b/ledfx/api/virtuals_tools.py
@@ -30,6 +30,56 @@ class VirtualsToolsEndpoint(RestEndpoint):
         """
         return await self.request_success("info", f"Available tools: {TOOLS}")
 
+    async def post(self, virtual_id, request) -> web.Response:
+        """
+        Uses the specified virtual tool on the virtual.
+
+        Args:
+            virtual_id (str): The ID of the virtual.
+            request (web.Request): The request object containing the `tool` to use.
+
+        Returns:
+            web.Response: The HTTP response object.
+        """
+        virtual = self._ledfx.virtuals.get(virtual_id)
+        if virtual is None:
+            return await self.invalid_request(
+                f"Virtual with ID {virtual_id} not found"
+            )
+
+        try:
+            data = await request.json()
+        except JSONDecodeError:
+            return await self.json_decode_error()
+
+        tool = data.get("tool")
+
+        if tool is None:
+            return await self.invalid_request(
+                'Required attribute "tool" was not provided'
+            )
+
+        if tool not in TOOLS:
+            return await self.invalid_request(f"Tool {tool} is not in {TOOLS}")
+
+        if tool == "oneshot":
+            color = parse_color(validate_color(data.get("color", "white")))
+            ramp = data.get("ramp", 0)
+            hold = data.get("hold", 0)
+            fade = data.get("fade", 0)
+            brightness = min(1, max(0, data.get("brightness", 1)))
+
+            result = virtual.add_oneshot(
+                Flash(color, ramp, hold, fade, brightness)
+            )
+
+            if result is False:
+                return await self.invalid_request("oneshot failed")
+
+
+        response = {"status": "success", "tool": tool}
+        return await self.bare_request_success(response)
+
     async def put(self, virtual_id, request) -> web.Response:
         """
         Uses the specified virtual tool on the virtual.

--- a/ledfx/api/virtuals_tools.py
+++ b/ledfx/api/virtuals_tools.py
@@ -76,7 +76,6 @@ class VirtualsToolsEndpoint(RestEndpoint):
             if result is False:
                 return await self.invalid_request("oneshot failed")
 
-
         response = {"status": "success", "tool": tool}
         return await self.bare_request_success(response)
 

--- a/ledfx/effects/oneshots/oneshot.py
+++ b/ledfx/effects/oneshots/oneshot.py
@@ -32,6 +32,10 @@ class Oneshot(ABC):
     def active(self):
         return self._active
 
+    @active.setter
+    def active(self, active):
+        self._active = active
+
     @property
     def pixel_count(self):
         return self._pixel_count

--- a/ledfx/effects/oneshots/oneshot.py
+++ b/ledfx/effects/oneshots/oneshot.py
@@ -14,7 +14,6 @@ class Oneshot(ABC):
     def __init__(self):
         self._active: bool = True
         self._pixel_count: int = 0
-        self._total_time: int = 0
 
     @abstractmethod
     def init(self):
@@ -39,10 +38,6 @@ class Oneshot(ABC):
     @property
     def pixel_count(self):
         return self._pixel_count
-
-    @property
-    def total_time(self):
-        return self._total_time
 
     @pixel_count.setter
     def pixel_count(self, pixel_count):

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -926,21 +926,11 @@ class Virtual:
         if not self._active:
             return False
 
-        # a oneshot intialised with zero time is used to clear ALL active oneshots
-        if oneshot.total_time == 0:
-            self.cancel_oneshot()
-            return False
-
         oneshot.pixel_count = self.pixel_count
         oneshot.init()
         with self.lock:
             self._oneshots.append(oneshot)
         return True
-
-    def cancel_oneshot(self):
-        # simply clearing the list will prevent any further oneshot processing
-        with self.lock:
-            self._oneshots = []
 
     @property
     def name(self):


### PR DESCRIPTION
What has been done:

- Moved PUT REST API for oneshot into POST implementation
- Changed PUT rest API to support disabling oneshots (feature that was present before)
- Updated the docs
- Removed the `total_time==0` removal now that we have API call to remove oneshots.

Reason:

Well the definition of POST for REST API is to add things and PUT to modify things that are already there. So this just made more sense to me. In the future PR, I will add oneshots such as _firework_ that use POST to launch a firework and PUT to cause it to "explode", hence I require this separation of functionalities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint to enable oneshot effects across all virtual devices with customizable parameters.
  - Enhanced individual device controls to support multiple oneshot activations if previous effects remain active.
  - Enabled external control for toggling the oneshot activation state.

- **Bug Fixes**
  - Improved error responses to offer clearer feedback when oneshot effects cannot be applied.
  - Clarified error handling for cases where oneshot effects are not found.

- **Documentation**
  - Updated API documentation to clearly outline the new oneshot parameters and responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->