### PR TITLE
Feat: add startup_scene_id support

### DIFF
--- a/ledfx/api/utils.py
+++ b/ledfx/api/utils.py
@@ -54,6 +54,7 @@ PERMITTED_KEYS = {
         "melbank_collection",
         "flush_on_deactivate",
         "ui_brightness_boost",
+        "startup_scene_id",
     ),
 }
 

--- a/ledfx/config.py
+++ b/ledfx/config.py
@@ -45,6 +45,7 @@ CORE_CONFIG_KEYS_NO_RESTART = [
     "visualisation_fps",
     "flush_on_deactivate",
     "ui_brightness_boost",
+    "startup_scene_id",
 ]
 # Collection of keys that are used for visualisation configuration - used to check if we need to restart the visualisation event listeners
 VISUALISATION_CONFIG_KEYS = [
@@ -147,6 +148,7 @@ CORE_CONFIG_SCHEMA = vol.Schema(
         vol.Optional("ui_brightness_boost", default=0.0): vol.All(
             vol.Coerce(float), vol.Range(0, 1.0)
         ),
+        vol.Optional("startup_scene_id", default=""): str,
     },
     extra=vol.ALLOW_EXTRA,
 )

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -438,7 +438,7 @@ class LedFxCore:
                 _LOGGER.warning(
                     f"startup_scene_id: {self.config['startup_scene_id']} not found."
                 )
-                
+
         if pause_all:
             # pause at the virtuals level
             self.virtuals.pause_all()

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -429,6 +429,16 @@ class LedFxCore:
         if not self.offline_mode:
             self.check_and_notify_updates()
 
+        if self.config["startup_scene_id"] != "":
+            if self.scenes.activate(self.config["startup_scene_id"]):
+                _LOGGER.info(
+                    f"startup_scene_id; {self.config['startup_scene_id']} activated."
+                )
+            else:
+                _LOGGER.warning(
+                    f"startup_scene_id: {self.config['startup_scene_id']} not found."
+                )
+                
         if pause_all:
             # pause at the virtuals level
             self.virtuals.pause_all()

--- a/ledfx/scenes.py
+++ b/ledfx/scenes.py
@@ -94,7 +94,7 @@ class Scenes:
         scene = self.get(scene_id)
         if not scene:
             _LOGGER.error(f"No scene found with id: {scene_id}")
-            return
+            return False
 
         for virtual_id in scene["virtuals"]:
             virtual = self._ledfx.virtuals.get(virtual_id)
@@ -115,6 +115,7 @@ class Scenes:
             else:
                 virtual.clear_effect()
         self._ledfx.events.fire_event(SceneActivatedEvent(scene_id))
+        return True
 
     def destroy(self, scene_id):
         """Deletes a scene"""

--- a/ledfx/scenes.py
+++ b/ledfx/scenes.py
@@ -121,7 +121,7 @@ class Scenes:
         """Deletes a scene"""
 
         if not self._scenes.pop(scene_id, None):
-            _LOGGER.error("Cannot delete non-existent scene id: {scene_id}")
+            _LOGGER.error(f"Cannot delete non-existent scene id: {scene_id}")
         self._ledfx.events.fire_event(SceneDeletedEvent(scene_id))
         self.save_to_config()
 


### PR DESCRIPTION
The key startup_scene_id has been added to the core config
It is trapped as a key not requiring a restart on change
It is defaulted to empty string
None is NOT a valid value
There is no enforcement of startup_scene_id as an existant scene_id except at scene activation
On startup after the ui is launched, which implies all other configuration is in place and before a global pause is triggered if configured, it will attempt to activate the scene id stored in startup_scene_id
If that scene does not exist a warning will be generated in the log, but otherwise everything will continue

As you could configure a startup scene and then go and delete it from the configured scenes, it feels like an unnceassary complication to try to enforce scene_id as existing that can be easily bypassed.

The front end can enforce selection of a scene_id from available configured scene_ids, but otherwise its just a string...

Tested with empty scene_id
Tested with manually entered non existant scene_id into config.json
Tested with manually entered scene_id into config.json ensuring that the scene is established

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable startup scene option, allowing users to set a scene that automatically becomes active when the application starts.
  - Expanded permitted configuration keys to include the new startup scene identifier.
  - Improved feedback during startup: the application now clearly indicates whether the specified scene has been activated or if it could not be found.

- **Bug Fixes**
  - Enhanced the return behavior of the scene activation method to indicate success or failure more clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->