### PR TITLE
Docs: Tweak docs build documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,10 +19,18 @@ This is most simply built via VScode tasks as per [Docs in VScode](#docs-in-vsco
 ::::
 
 The docs dependancies are managed in the `pyproject.toml`
-file. To install the docs dependancies, run the following command:
+file. Run the following command in the LedFx source directory where pyproject.toml resides.
+
+To install the docs dependancies on top of the dev dependancies:
 
 ``` console
 uv sync --group docs
+```
+
+If you only want the docs dependancies then instead use:
+
+``` console
+uv sync --only-group docs
 ```
 
 To build the documentation, run the following commands


### PR DESCRIPTION
Provide clear instruction for docs only dependencies for docs build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated installation instructions to ensure commands are run in the correct source directory.
	- Introduced clear guidance for installing documentation dependencies alongside or separately from development dependencies, with additional commands for each approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->