### PR TITLE
fix: prevent device error creation on assumed keys

### DIFF
--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -669,7 +669,10 @@ class Devices(RegistryLoader):
                     existing_device.config["ip_address"] == device_ip
                     or existing_device.config["ip_address"] == resolved_dest
                 ):
-                    if device_type in ["e131", "artnet"] and existing_device.type in ["e131", "artnet"]:
+                    if device_type in [
+                        "e131",
+                        "artnet",
+                    ] and existing_device.type in ["e131", "artnet"]:
                         # check the universes for e131 and artnet, it might still be okay at a shared ip_address
                         # eg. for multi output controllers
                         if (
@@ -679,7 +682,10 @@ class Devices(RegistryLoader):
                             msg = f"Ignoring {device_ip}: Shares IP and starting universe with existing device {existing_device.name}"
                             _LOGGER.info(msg)
                             raise ValueError(msg)
-                    elif device_type == "openrgb" and existing_device.type == "openrgb":
+                    elif (
+                        device_type == "openrgb"
+                        and existing_device.type == "openrgb"
+                    ):
                         # check the OpenRGB ID for OpenRGB device, it might still be okay at a shared ip_address
                         # eg. for multi OpenRGB devices
                         if (
@@ -689,7 +695,9 @@ class Devices(RegistryLoader):
                             msg = f"Ignoring {device_ip}: Shares IP and OpenRGB ID with existing device {existing_device.name}"
                             _LOGGER.info(msg)
                             raise ValueError(msg)
-                    elif device_type == "osc" and existing_device.type == "osc":
+                    elif (
+                        device_type == "osc" and existing_device.type == "osc"
+                    ):
                         # Allow multiple OSC Server devices, but not on the same path + starting_addr combination
                         if (
                             device_config["path"]

--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -669,7 +669,7 @@ class Devices(RegistryLoader):
                     existing_device.config["ip_address"] == device_ip
                     or existing_device.config["ip_address"] == resolved_dest
                 ):
-                    if device_type in ["e131", "artnet"]:
+                    if device_type in ["e131", "artnet"] and existing_device.type in ["e131", "artnet"]:
                         # check the universes for e131 and artnet, it might still be okay at a shared ip_address
                         # eg. for multi output controllers
                         if (
@@ -679,7 +679,7 @@ class Devices(RegistryLoader):
                             msg = f"Ignoring {device_ip}: Shares IP and starting universe with existing device {existing_device.name}"
                             _LOGGER.info(msg)
                             raise ValueError(msg)
-                    elif device_type == "openrgb":
+                    elif device_type == "openrgb" and existing_device.type == "openrgb":
                         # check the OpenRGB ID for OpenRGB device, it might still be okay at a shared ip_address
                         # eg. for multi OpenRGB devices
                         if (
@@ -689,7 +689,7 @@ class Devices(RegistryLoader):
                             msg = f"Ignoring {device_ip}: Shares IP and OpenRGB ID with existing device {existing_device.name}"
                             _LOGGER.info(msg)
                             raise ValueError(msg)
-                    elif device_type == "osc":
+                    elif device_type == "osc" and existing_device.type == "osc":
                         # Allow multiple OSC Server devices, but not on the same path + starting_addr combination
                         if (
                             device_config["path"]


### PR DESCRIPTION
code intended to test for allowed devices sharing ip addresses, assumes key field existence and will except when comparing different device types that do not have the assumed key.

This code ensures we only compare like for like, but the following issue is if we are excluding devices sharing ip addresses that we should not.

The error string will now be explicit rather than for example just "universe" as reported in 

https://github.com/LedFx/LedFx/issues/1348

But it remains a question if we should allow "most" combinations of shared ip or reject them as currently implied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device conflict detection by ensuring that device type matches are required before comparing device-specific properties. This reduces false conflict alerts when adding or updating devices of different types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->