### PR TITLE
Dev: demote ubuntu GCC14 pointer error

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Install LedFx
         run: |
+          export CFLAGS="-Wno-incompatible-function-pointer-types"
           uv sync --all-extras --dev
       - name: Setup CI sound system
         uses: LABSN/sound-ci-helpers@v1

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -64,7 +64,13 @@ Note
 This assumes an apt based system such as ubuntu. If your system uses another package manager you should be able use it to get the required packages.
 ::::
 
-1. Install system dependencies via `apt install`:
+1. Within the shell in which you intend to install / build establish the follow build flag to ensure that GCC 14 does not throw errors on pre-exisitng weaknesses in the aubio library during build time.
+
+    ```console
+    $ export CFLAGS="-Wno-incompatible-function-pointer-types"
+    ```
+    
+2. Install system dependencies via `apt install`:
 
     ```console
     $ sudo apt install libatlas3-base \

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -69,7 +69,7 @@ This assumes an apt based system such as ubuntu. If your system uses another pac
     ```console
     $ export CFLAGS="-Wno-incompatible-function-pointer-types"
     ```
-    
+
 2. Install system dependencies via `apt install`:
 
     ```console


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Ubuntu build process to improve compatibility during installation.
  - Added guidance for Linux developers to set an environment variable to prevent build warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->