### PR TITLE
TypeScript Generator Endpoint

### DIFF
--- a/docs/launch.md
+++ b/docs/launch.md
@@ -15,6 +15,7 @@ When launching LedFx from the command line, or by editing properties of a deskto
 - `--offline`: Disable crash logger and auto update checks.
 - `--sentry-crash-test`: Crash LedFx to test the sentry crash logger.
 - `--ci-smoke-test`: Launch LedFx and then exit after 5 seconds to sanity check the install.
+- `--generate-typescript-types`: Generate TypeScript types for the API and exit.
 - `--clear-config`: Launch LedFx, backup the config, clear the config, and continue with a clean startup.
 - `--clear-effects`: Launch LedFx, load the config, clear all active effects on all virtuals. Effect configurations are persisted, just turned off.
 - `--pause-all`: Start LedFx with all virtuals paused. This is a global pause and can be toggled via the UI, or via a rest PUT to /api/virtuals

--- a/ledfx/__main__.py
+++ b/ledfx/__main__.py
@@ -204,6 +204,13 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--generate-typescript-types",
+        dest="generate_typescript_types",
+        action="store_true",
+        help="Generate TypeScript types for the API and exit",
+    )
+
+    parser.add_argument(
         "--clear-config",
         dest="clear_config",
         action="store_true",
@@ -316,6 +323,7 @@ def entry_point(icon=None):
             clear_config=args.clear_config,
             clear_effects=args.clear_effects,
             offline_mode=args.offline_mode,
+            generate_typescript_types=args.generate_typescript_types,
         )
 
         exit_code = ledfx.start(open_ui=args.open_ui, pause_all=args.pause_all)

--- a/ledfx/api/generate_ts_types.py
+++ b/ledfx/api/generate_ts_types.py
@@ -1,0 +1,45 @@
+import logging
+import traceback
+
+from aiohttp import web
+
+from ledfx.api import RestEndpoint
+from ledfx.tools.ts_generator import generate_all_types_string_dual_effect
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class GenerateTypesEndpoint(RestEndpoint):
+    ENDPOINT_PATH = "/api/generate_ts_types"
+
+    async def get(self) -> web.Response:
+
+        _LOGGER.info("Received request to generate TypeScript types.")
+
+        try:
+            ts_code = generate_all_types_string_dual_effect()
+
+            headers = {
+                "Content-Disposition": 'attachment; filename="ledfx.types.ts"'
+            }
+            _LOGGER.info(
+                "TypeScript generation processing successful. Returning code."
+            )
+            return web.Response(
+                text=ts_code,
+                content_type="application/typescript",
+                charset="utf-8",
+                headers=headers,
+            )
+
+        except Exception as e:
+            _LOGGER.exception(
+                "CRITICAL Error occurred during TypeScript generation via API."
+            )
+            error_body = f"// Generation Error!\n// {type(e).__name__}: {e}\n// Traceback:\n"
+            error_body += "\n".join(
+                [f"// {line}" for line in traceback.format_exc().splitlines()]
+            )
+            return web.Response(
+                text=error_body, content_type="text/plain", status=500
+            )

--- a/ledfx/tools/ts_generator.py
+++ b/ledfx/tools/ts_generator.py
@@ -352,14 +352,22 @@ def generate_specific_api_response_types(
     device_type_literal_union: str,
 ) -> str:
     """Generates TS definitions for API responses."""
-    segment_item_type = "[string, number, number, boolean]"
+    segment_type_alias = """
+// Represents a segment mapping [deviceId, startPixel, endPixel, isReversed]
+export type Segment = [
+  device: string,
+  start: number,
+  end: number,
+  reverse: boolean
+];"""
     active_effect_type_str = f"\nexport interface ActiveEffectInVirtual {{\n  config: {specific_effect_config_union_name};\n  name: string;\n  type: {effect_type_literal_union};\n}}"
-    virtual_api_item_type_str = f"\n// Represents a single Virtual object\nexport interface VirtualApiResponseItem {{\n  config: {virtual_config_type_name};\n  id: string;\n  is_device: string | boolean; \n  auto_generated: boolean;\n  segments: {segment_item_type}[];\n  pixel_count: number;\n  active: boolean;\n  streaming: boolean;\n  last_effect?: {effect_type_literal_union} | null;\n  effect: Partial<ActiveEffectInVirtual>; \n}}"
+    virtual_api_item_type_str = f"\n// Represents a single Virtual object\nexport interface VirtualApiResponseItem {{\n  config: {virtual_config_type_name};\n  id: string;\n  is_device: string | boolean; \n  auto_generated: boolean;\n  segments: Segment[];\n  pixel_count: number;\n  active: boolean;\n  streaming: boolean;\n  last_effect?: {effect_type_literal_union} | null;\n  effect: Partial<ActiveEffectInVirtual>; \n}}"  # Changed segments type
     get_virtuals_response_type_str = '\n// Response for GET /api/virtuals\nexport interface GetVirtualsApiResponse {\n  status: "success" | "error";\n  virtuals: Record<string, VirtualApiResponseItem>;\n  paused: boolean;\n  message?: string;\n}'
     get_single_virtual_response_type_str = '\n// Raw response for GET /api/virtuals/{{virtual_id}}\nexport interface GetSingleVirtualApiResponse {\n  status: "success" | "error";\n  [virtualId: string]: VirtualApiResponseItem | string | undefined; \n  message?: string;\n}\n\n// Transformed type for GET /api/virtuals/{virtual_id}\nexport type FetchedVirtualResult = \n  | { status: "success"; data: VirtualApiResponseItem }\n  | { status: "error"; message: string };\n'
-    device_api_item_type_str = f"\n// Represents a single Device object\nexport interface Device {{\n  config: {specific_device_config_union_name};\n  id: string;\n  type: {device_type_literal_union};\n  online: boolean;\n  virtuals: string[]; \n  active_virtuals: string[]; \n}}"  # <-- Use DeviceType Union
+    device_api_item_type_str = f"\n// Represents a single Device object\nexport interface Device {{\n  config: {specific_device_config_union_name};\n  id: string;\n  type: {device_type_literal_union};\n  online: boolean;\n  virtuals: string[]; \n  active_virtuals: string[]; \n}}"
     get_devices_response_type_str = '\n// Response for GET /api/devices\nexport interface GetDevicesApiResponse {\n  status: "success" | "error";\n  devices: Record<string, Device>;\n  message?: string;\n}'
     return (
+        f"{segment_type_alias}\n\n"
         f"{active_effect_type_str}\n\n{virtual_api_item_type_str}\n\n"
         f"{get_virtuals_response_type_str}\n\n{get_single_virtual_response_type_str}\n\n"
         f"{device_api_item_type_str}\n\n{get_devices_response_type_str}\n\n"

--- a/ledfx/tools/ts_generator.py
+++ b/ledfx/tools/ts_generator.py
@@ -135,25 +135,24 @@ def voluptuous_validator_to_ts_type(validator, for_universal=False) -> str:
             return "number /* FPS */"
 
     # Standard Types
-    if validator == str:
+    if validator is str:
         return "string"
-    elif validator == int:
+    elif validator is int:
         return "number"
-    elif validator == float:
+    elif validator is float:
         return "number"
-    elif validator == bool:
+    elif validator is bool:
         return "boolean"
     elif isinstance(validator, vol.Coerce):
-        if validator.type == int:
+        if validator.type is int:
             return "number"
-        if validator.type == float:
+        if validator.type is float:
             return "number"
-        if validator.type == str:
+        if validator.type is str:
             return "string"
         return "any"
     elif isinstance(validator, vol.In):
         if for_universal:
-            types = {type(opt) for opt in validator.container}
             possible_types = []
             if any(isinstance(opt, str) for opt in validator.container):
                 possible_types.append("string")

--- a/ledfx/tools/ts_generator.py
+++ b/ledfx/tools/ts_generator.py
@@ -355,10 +355,10 @@ def generate_specific_api_response_types(
     segment_item_type = "[string, number, number, boolean]"
     active_effect_type_str = f"\nexport interface ActiveEffectInVirtual {{\n  config: {specific_effect_config_union_name};\n  name: string;\n  type: {effect_type_literal_union};\n}}"
     virtual_api_item_type_str = f"\n// Represents a single Virtual object\nexport interface VirtualApiResponseItem {{\n  config: {virtual_config_type_name};\n  id: string;\n  is_device: string | boolean; \n  auto_generated: boolean;\n  segments: {segment_item_type}[];\n  pixel_count: number;\n  active: boolean;\n  streaming: boolean;\n  last_effect?: {effect_type_literal_union} | null;\n  effect: Partial<ActiveEffectInVirtual>; \n}}"
-    get_virtuals_response_type_str = '\n// Response for GET /api/virtuals\nexport interface GetVirtualsApiResponse {{\n  status: "success" | "error";\n  virtuals: Record<string, VirtualApiResponseItem>;\n  paused: boolean;\n  message?: string;\n}}'
-    get_single_virtual_response_type_str = '\n// Raw response for GET /api/virtuals/{{virtual_id}}\nexport interface GetSingleVirtualApiResponse {{\n  status: "success" | "error";\n  [virtualId: string]: VirtualApiResponseItem | string | undefined; \n  message?: string;\n}}\n\n// Transformed type for GET /api/virtuals/{{virtual_id}}\nexport type FetchedVirtualResult = \n  | {{ status: "success"; data: VirtualApiResponseItem }}\n  | {{ status: "error"; message: string }};\n'
+    get_virtuals_response_type_str = '\n// Response for GET /api/virtuals\nexport interface GetVirtualsApiResponse {\n  status: "success" | "error";\n  virtuals: Record<string, VirtualApiResponseItem>;\n  paused: boolean;\n  message?: string;\n}'
+    get_single_virtual_response_type_str = '\n// Raw response for GET /api/virtuals/{{virtual_id}}\nexport interface GetSingleVirtualApiResponse {\n  status: "success" | "error";\n  [virtualId: string]: VirtualApiResponseItem | string | undefined; \n  message?: string;\n}\n\n// Transformed type for GET /api/virtuals/{virtual_id}\nexport type FetchedVirtualResult = \n  | { status: "success"; data: VirtualApiResponseItem }\n  | { status: "error"; message: string };\n'
     device_api_item_type_str = f"\n// Represents a single Device object\nexport interface Device {{\n  config: {specific_device_config_union_name};\n  id: string;\n  type: {device_type_literal_union};\n  online: boolean;\n  virtuals: string[]; \n  active_virtuals: string[]; \n}}"  # <-- Use DeviceType Union
-    get_devices_response_type_str = '\n// Response for GET /api/devices\nexport interface GetDevicesApiResponse {{\n  status: "success" | "error";\n  devices: Record<string, Device>;\n  message?: string;\n}}'
+    get_devices_response_type_str = '\n// Response for GET /api/devices\nexport interface GetDevicesApiResponse {\n  status: "success" | "error";\n  devices: Record<string, Device>;\n  message?: string;\n}'
     return (
         f"{active_effect_type_str}\n\n{virtual_api_item_type_str}\n\n"
         f"{get_virtuals_response_type_str}\n\n{get_single_virtual_response_type_str}\n\n"
@@ -659,7 +659,7 @@ def generate_all_types_string_dual_effect() -> str:
     for prop_name in sorted(all_effect_properties.keys()):
         ts_type = all_effect_properties[prop_name]
         output_ts_string += f"  {prop_name}?: {ts_type};\n"
-    output_ts_string += "}}\n\n"
+    output_ts_string += "}\n\n"
 
     # --- 6. Generate API Response specific types ---
     virtual_config_name_to_use = (
@@ -680,16 +680,16 @@ def generate_all_types_string_dual_effect() -> str:
         specific_effect_config_union_name,
         device_union_name_to_use,
         effect_type_literal_union,
-        device_type_literal_union,  # Pass the device type union
+        device_type_literal_union,
     )
 
     # --- 7. Generate Convenience Type Aliases ---
     output_ts_string += (
         "// Convenience Type Aliases using the Universal Effect Config\n"
     )
-    output_ts_string += f"export type Effect = Omit<Omit<ActiveEffectInVirtual, 'config'> & {{ config: {universal_effect_config_name} }}, 'type'> & {{ type?: {effect_type_literal_union} | null }};\n"
-    output_ts_string += f"export type Virtual = Omit<VirtualApiResponseItem, 'effect' | 'last_effect'> & {{ effect: Partial<Effect>; last_effect?: {effect_type_literal_union} | null }};\n"
-    output_ts_string += "export type Virtuals = Omit<GetVirtualsApiResponse, 'virtuals'> & {{ virtuals: Record<string, Virtual> }};\n"
+    output_ts_string += f"export type Effect = Omit<Omit<ActiveEffectInVirtual, 'config'> & {{ config: {universal_effect_config_name} }}, 'type'> & {{ type?: {effect_type_literal_union} }};\n"
+    output_ts_string += f"export type Virtual = Omit<VirtualApiResponseItem, 'effect' | 'last_effect'> & {{ effect: Partial<Effect>; last_effect?: {effect_type_literal_union} }};\n"
+    output_ts_string += "export type Virtuals = Omit<GetVirtualsApiResponse, 'virtuals'> & { virtuals: Record<string, Virtual> };\n"
     output_ts_string += "\n"
 
     script_logger.info("TypeScript generation finished.")

--- a/ledfx/tools/ts_generator.py
+++ b/ledfx/tools/ts_generator.py
@@ -652,7 +652,6 @@ def generate_all_types_string_dual_effect() -> str:
         if prop_name == "type":
             continue
         ts_type = all_device_properties[prop_name]
-        output_ts_string += "  /** Property from the universal set. */\n"
         output_ts_string += (
             f"  {prop_name}?: {ts_type};\n"  # snake_case, optional
         )

--- a/ledfx/tools/ts_generator.py
+++ b/ledfx/tools/ts_generator.py
@@ -746,7 +746,7 @@ def generate_all_types_string_dual_effect() -> str:
                 lines = interface_str.splitlines()
                 if len(lines) > 1:
                     lines.insert(1, type_literal_line)
-                output_ts_string += f"/**\n * Specific configuration for the '{effect_type_str}' effect.\n * @category EffectSpecificConfiga\n */\n"
+                output_ts_string += f"/**\n * Specific configuration for the '{effect_type_str}' effect.\n * @category EffectSpecificConfigs\n */\n"
                 output_ts_string += "\n".join(lines) + "\n\n"
             except Exception as e:
                 script_logger.error(


### PR DESCRIPTION
### New Endpoint:
`/api/generate_ts_types`

returns a dynamically created typescript file, with interfaces and types for Device, Virtual, Effect, and Universals.

Consuming these in a client, will bring perfect typing and autocompletion, without the need to manually recreate anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint to download TypeScript type definitions for LedFx schemas.
  - Added automatic generation of comprehensive TypeScript interfaces and types from LedFx device and effect schemas, including detailed documentation and support for configuration unions.
  - Added a command-line option to generate TypeScript types and exit.
  - Enabled automatic TypeScript type generation during startup with output to a file for easier integration with frontend and API clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->