### PR TITLE
Fix: Effect reactivation on virtual span / copy change

### DIFF
--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -1100,6 +1100,7 @@ class Virtual:
         if hasattr(self, "_config"):
             if _config["mapping"] != self._config["mapping"]:
                 self.invalidate_cached_props()
+                reactivate_effect = True
             if (
                 _config["transition_mode"] != self._config["transition_mode"]
                 or _config["transition_time"]
@@ -1171,7 +1172,7 @@ class Virtual:
                         # The effect needs to be reactivated later after the config has been applied
                         reactivate_effect = True
                         self.invalidate_cached_props()
-
+                    
         setattr(self, "_config", _config)
 
         self.frequency_range = FrequencyRange(

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -1172,7 +1172,7 @@ class Virtual:
                         # The effect needs to be reactivated later after the config has been applied
                         reactivate_effect = True
                         self.invalidate_cached_props()
-                    
+
         setattr(self, "_config", _config)
 
         self.frequency_range = FrequencyRange(


### PR DESCRIPTION
As changing between span and copy on a virtual changes the effective pixel count, if we dont restart the current effect it will be rendering to the pixel count of when last started, not the actual virtual to segment implications. 

On higher pixel count devices / virtuals, this is not apparent to the a user, but on very low pixel counts, it is obvious that something is wrong.

Note that a virtual with 4 segments of 1 pixel each will have pixel counts of 1 for copy, and 4 for span


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Effect will now automatically reactivate when the "mapping" configuration is changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->