### PR TITLE
Safe import_registry

### DIFF
--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -1052,7 +1052,12 @@ class RegistryLoader:
         found = self.discover_modules(package)
         _LOGGER.debug(f"Importing {found} from {package}")
         for name in found:
-            importlib.import_module(name)
+            try:
+                importlib.import_module(name)
+            except ModuleNotFoundError as e:
+                _LOGGER.warning(
+                    f"Failed to import {name} from {package}: {e}"
+                )
 
     def discover_modules(self, package):
         """Discovers all modules in the package"""

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -1055,9 +1055,7 @@ class RegistryLoader:
             try:
                 importlib.import_module(name)
             except ModuleNotFoundError as e:
-                _LOGGER.warning(
-                    f"Failed to import {name} from {package}: {e}"
-                )
+                _LOGGER.warning(f"Failed to import {name} from {package}: {e}")
 
     def discover_modules(self, package):
         """Discovers all modules in the package"""


### PR DESCRIPTION
This avoids crash when libs are missing from python env, primarily to make my [android port](https://github.com/broccoliboy/ledfx-android) work without mock libraries. Example:

a) Normal installation with mss and python-rtmidi installed. Device dropdown shows "launchpad" option. Effects dropdown shows "Clone" option.

<img width="536" alt="Screenshot 2025-06-02 at 9 48 40 PM" src="https://github.com/user-attachments/assets/41dcaece-f6fa-422a-ab2e-a63e9588d7a1" />

<img width="341" alt="Screenshot 2025-06-02 at 9 49 21 PM" src="https://github.com/user-attachments/assets/116551d8-803f-4810-9edc-63e974c0deb3" />

b) Uninstall mss and python-rtmidi from python env. Without any change, LedFx crashes on start with ModuleNotFoundError due to failed imports. With this PR, LedFx starts up and logs warning about missing imports but still runs without issue. Only difference is the "launchpad" device and "Clone" effect do not appear in dropdowns.

<img width="536" alt="Screenshot 2025-06-02 at 9 46 47 PM" src="https://github.com/user-attachments/assets/7557e474-3aa3-46d4-8ac7-86db3ed429d9" />

<img width="338" alt="Screenshot 2025-06-02 at 9 50 28 PM" src="https://github.com/user-attachments/assets/2c4ee0f2-a0e1-454c-91b5-b71800ac47a9" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling during module imports to prevent failures if a module is missing. A warning will now be logged, and the import process will continue for other modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->