### PR TITLE
Dev: fix sentry deprecation warning

### DIFF
--- a/.github/workflows/test-build-binaries.yml
+++ b/.github/workflows/test-build-binaries.yml
@@ -546,4 +546,4 @@ jobs:
           SENTRY_PROJECT: ledfx-v2-rel
         with:
           environment: production
-          version: ledfx@${{ steps.ledfx-version.outputs.ledfx-version }}
+          release: ledfx@${{ steps.ledfx-version.outputs.ledfx-version }}


### PR DESCRIPTION
As per https://github.com/LedFx/LedFx/actions/runs/15525468698

[Notify Sentry of Release](https://github.com/LedFx/LedFx/actions/runs/15525468698/job/43705280617#step:11:1)
Input 'version' has been deprecated with message: Deprecated: Use "release" instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated internal workflow configuration for release management. No impact on user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->