### PR TITLE
dev: add explicit enable-cache:false where needed

### DIFF
--- a/.github/workflows/test-build-binaries.yml
+++ b/.github/workflows/test-build-binaries.yml
@@ -434,6 +434,8 @@ jobs:
           name: LedFx-${{ steps.ledfx-version.outputs.ledfx-version }}-wheel
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: false
       - name: Install build dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y portaudio19-dev
@@ -466,6 +468,8 @@ jobs:
           name: LedFx-${{ steps.ledfx-version.outputs.ledfx-version }}-sdist
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: false
       - name: Install build dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y portaudio19-dev


### PR DESCRIPTION
Prevent warning on sdist and pypi wheel install and tests

[Test LedFx (PyPi sdist)](https://github.com/LedFx/LedFx/actions/runs/15525468698/job/43704536868#step:5:34)
No file matched to [**/*requirements*.txt,**/*requirements*.in,**/*constraints*.txt,**/*constraints*.in,**/pyproject.toml,**/uv.lock]. The cache will never get invalidated. Make sure you have checked out the target repository and configured the cache-dependency-glob input correctly.


[Test LedFx (PyPi wheel)](https://github.com/LedFx/LedFx/actions/runs/15525468698/job/43704536864#step:5:34)
No file matched to [**/*requirements*.txt,**/*requirements*.in,**/*constraints*.txt,**/*constraints*.in,**/pyproject.toml,**/uv.lock]. The cache will never get invalidated. Make sure you have checked out the target repository and configured the cache-dependency-glob input correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow configuration to explicitly disable caching during certain installation steps in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->