### PR TITLE
Updated the way osc device parses colors

### DIFF
--- a/ledfx/devices/osc.py
+++ b/ledfx/devices/osc.py
@@ -92,7 +92,7 @@ class OSCServerDevice(NetworkedDevice):
         starting_addr = self._config["starting_addr"]
 
         # Convert data to rgb tuple
-        colors = data.astype(int).clip(0, 255)
+        colors = data.astype(int)
 
         # Create array for messages
         messages = []


### PR DESCRIPTION
Updated the way osc device parses colors, to mimic the rest of the existing devices.


I had made this change a while ago, but never commited it...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved processing of color data to ensure RGB values are correctly formatted and within valid ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->