### PR TITLE
Feat: Improve WLED diag in event

### DIFF
--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -230,13 +230,13 @@ The `virtual_diag` WebSocket event is emitted when a virtual's diagnostics are u
   "r_max": 0.022345,
   "cycle": 16.67,
   "sleep": 0.014232,
-  "phy": 
+  "phy":
   {
-    "f": 55, 
-    "ver": "0.14.4", 
-    "n": 1024, 
-    "name": "32x32", 
-    "rssi": -45, 
+    "f": 55,
+    "ver": "0.14.4",
+    "n": 1024,
+    "name": "32x32",
+    "rssi": -45,
     "qual": 100
   }
 }

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -182,7 +182,7 @@ The example given in the following sequence diagram for general_diag is a trivia
     LS->>LS: Check if second boundary crossed
     alt Second boundary crossed & diag enabled
         LS->>ES: fire_event(VirtualDiagEvent)
-        Note right of LS: Contains: virtual_id, fps, r_avg, <br/>f_phy, r_min, r_max, cycle, sleep
+        Note right of LS: Contains: virtual_id, fps, r_avg, <br/>r_min, r_max, cycle, sleep, phy
         ES->>WS: notify_websocket(event)
         WS->>FE: send_event(virtual_diag)
         Note right of FE: Real-time performance metrics
@@ -228,9 +228,17 @@ The `virtual_diag` WebSocket event is emitted when a virtual's diagnostics are u
   "r_avg": 0.017432,
   "r_min": 0.008123,
   "r_max": 0.022345,
-  "f_phy": 47,
   "cycle": 16.67,
-  "sleep": 0.014232
+  "sleep": 0.014232,
+  "phy": 
+  {
+    "f": 55, 
+    "ver": "0.14.4", 
+    "n": 1024, 
+    "name": "32x32", 
+    "rssi": -45, 
+    "qual": 100
+  }
 }
 ```
 
@@ -241,14 +249,21 @@ The `virtual_diag` WebSocket event is emitted when a virtual's diagnostics are u
 - `r_avg`: Average render time.
 - `r_min`: Minimum render time.
 - `r_max`: Maximum render time.
-- `f_phy`: FPS physical if available, currently WLED only.
 - `cycle`: Cycle time for the virtual's update loop.
 - `sleep`: Sleep time between cycles.
+- `phy`: A dictionary containing physical device information:
+  - `f`: Frames per second reported by the physical device.
+  - `ver`: Firmware version of the device.
+  - `n`: Number of LEDs or pixels in the device.
+  - `name`: Name or identifier of the device.
+  - `rssi`: Signal strength (RSSI) of the device's connection.
+  - `qual`: Connection quality percentage.
+
 
 **Usage:**
 Subscribe to this event to monitor the performance and timing of virtual devices for diagnostics and optimization.
 
-If a virtual is mapped directly to a device and that device is WLED, then an attempt to read the FPS will be made once per second asynchronously via the /json/info api call and returned on f_phy, else the value will be -1
+If a virtual is mapped directly to a device and that device is WLED, then an attempt to read the WLED info and extra key details will be made once per second asynchronously via the /json/info api call and returned on phy, unavailable values will be None or -1.
 
 ---
 

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -232,7 +232,7 @@ The `virtual_diag` WebSocket event is emitted when a virtual's diagnostics are u
   "sleep": 0.014232,
   "phy":
   {
-    "f": 55,
+    "fps": 55,
     "ver": "0.14.4",
     "n": 1024,
     "name": "32x32",
@@ -252,7 +252,7 @@ The `virtual_diag` WebSocket event is emitted when a virtual's diagnostics are u
 - `cycle`: Cycle time for the virtual's update loop.
 - `sleep`: Sleep time between cycles.
 - `phy`: A dictionary containing physical device information:
-  - `f`: Frames per second reported by the physical device.
+  - `fps`: Frames per second reported by the physical device.
   - `ver`: Firmware version of the device.
   - `n`: Number of LEDs or pixels in the device.
   - `name`: Name or identifier of the device.
@@ -263,7 +263,7 @@ The `virtual_diag` WebSocket event is emitted when a virtual's diagnostics are u
 **Usage:**
 Subscribe to this event to monitor the performance and timing of virtual devices for diagnostics and optimization.
 
-If a virtual is mapped directly to a device and that device is WLED, then an attempt to read the WLED info and extra key details will be made once per second asynchronously via the /json/info api call and returned on phy, unavailable values will be None or -1.
+If a virtual is mapped directly to a device and that device is WLED, then an attempt to read the WLED info and extra key details will be made once per second asynchronously via the /json/info api call and returned on phy, unavailable values will be None.
 
 ---
 

--- a/ledfx/effects/utils/logsec_helper.py
+++ b/ledfx/effects/utils/logsec_helper.py
@@ -8,15 +8,16 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Phy:
-    def __init__(self, f=-1, ver=None, n=-1, name=None, rssi=-1, qual=-1):
+    def __init__(self, fps=None, ver=None, n=None, name=None, rssi=None, qual=None):
         """
-        ver: Version of the physical device, if applicable.
-        n: Number of physical LEDs, -1 if not applicable.
-        name: Name of the physical device, if applicable.
-        rssi: RSSI of the physical device, -1 if not applicable.
-        qual: Signal quality of the physical device, -1 if not applicable."""
-
-        self.f = f
+        fps: fps of physical device
+        ver: Version of the physical device
+        n: Number of physical LEDs
+        name: Name of the physical device
+        rssi: RSSI of the physical device
+        qual: Signal quality of the physical device
+        """
+        self.fps = fps
         self.ver = ver
         self.n = n
         self.name = name
@@ -46,12 +47,12 @@ class LogSecHelper:
         self.lasttime = int(self.current_time)
 
     def handle_info_response(self, data):
-        self.phy.f = data.get("leds", {}).get("fps", -1)
-        self.phy.ver = data.get("ver", None)
-        self.phy.n = data.get("leds", {}).get("count", -1)
-        self.phy.name = data.get("name", None)
-        self.phy.rssi = data.get("wifi", {}).get("rssi", -1)
-        self.phy.qual = data.get("wifi", {}).get("signal", -1)
+        self.phy.fps = data.get("leds", {}).get("fps")
+        self.phy.ver = data.get("ver")
+        self.phy.n = data.get("leds", {}).get("count")
+        self.phy.name = data.get("name")
+        self.phy.rssi = data.get("wifi", {}).get("rssi")
+        self.phy.qual = data.get("wifi", {}).get("signal")
 
         _LOGGER.info(
             f"{self.effect._virtual.name}:{self.effect.name} wled info: {self.phy}"

--- a/ledfx/effects/utils/logsec_helper.py
+++ b/ledfx/effects/utils/logsec_helper.py
@@ -20,6 +20,11 @@ class LogSecHelper:
         self.r_min = 1.0
         self.r_max = 0.0
         self.f_phy = -1
+        self.ver_phy = None
+        self.n_phy = -1
+        self.name_phy = None
+        self.rssi_phy = -1
+        self.qual_phy = -1
         self.log = False
         self.diag = False
         self.current_time = timeit.default_timer()
@@ -27,8 +32,14 @@ class LogSecHelper:
 
     def handle_info_response(self, data):
         self.f_phy = data.get("leds", {}).get("fps", -1)
+        self.ver_phy = data.get("ver", None)
+        self.n_phy = data.get("leds", {}).get("count", -1)
+        self.name_phy = data.get("name", None)
+        self.rssi_phy = data.get("wifi", {}).get("rssi", -1)
+        self.qual_phy = data.get("wifi", {}).get("signal", -1)
+
         _LOGGER.info(
-            f"{self.effect._virtual.name}:{self.effect.name} fps from wled info: {self.f_phy}"
+            f"{self.effect._virtual.name}:{self.effect.name} wled info: {data}"
         )
 
     def log_sec(self, current_time):
@@ -82,6 +93,11 @@ class LogSecHelper:
                         self.f_phy,
                         cycle,
                         sleep,
+                        self.ver_phy,
+                        self.n_phy,
+                        self.name_phy,
+                        self.rssi_phy,
+                        self.qual_phy,
                     )
                 )
                 self.r_min = 1.0

--- a/ledfx/effects/utils/logsec_helper.py
+++ b/ledfx/effects/utils/logsec_helper.py
@@ -8,7 +8,9 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Phy:
-    def __init__(self, fps=None, ver=None, n=None, name=None, rssi=None, qual=None):
+    def __init__(
+        self, fps=None, ver=None, n=None, name=None, rssi=None, qual=None
+    ):
         """
         fps: fps of physical device
         ver: Version of the physical device

--- a/ledfx/effects/utils/logsec_helper.py
+++ b/ledfx/effects/utils/logsec_helper.py
@@ -6,7 +6,25 @@ from ledfx.events import VirtualDiagEvent
 
 _LOGGER = logging.getLogger(__name__)
 
+class Phy:
+    def __init__(self, f=-1, ver=None, n=-1, name=None, rssi=-1, qual=-1):
+        """ 
+        ver: Version of the physical device, if applicable.
+        n: Number of physical LEDs, -1 if not applicable.
+        name: Name of the physical device, if applicable.
+        rssi: RSSI of the physical device, -1 if not applicable.
+        qual: Signal quality of the physical device, -1 if not applicable."""
 
+        self.f = f
+        self.ver = ver
+        self.n = n
+        self.name = name
+        self.rssi = rssi
+        self.qual = qual
+
+    def __repr__(self):
+        return repr(self.__dict__)
+    
 class LogSecHelper:
     def __init__(self, effect):
         self.effect = effect
@@ -19,27 +37,22 @@ class LogSecHelper:
         self.r_total = 0.0
         self.r_min = 1.0
         self.r_max = 0.0
-        self.f_phy = -1
-        self.ver_phy = None
-        self.n_phy = -1
-        self.name_phy = None
-        self.rssi_phy = -1
-        self.qual_phy = -1
+        self.phy = Phy()
         self.log = False
         self.diag = False
         self.current_time = timeit.default_timer()
         self.lasttime = int(self.current_time)
 
     def handle_info_response(self, data):
-        self.f_phy = data.get("leds", {}).get("fps", -1)
-        self.ver_phy = data.get("ver", None)
-        self.n_phy = data.get("leds", {}).get("count", -1)
-        self.name_phy = data.get("name", None)
-        self.rssi_phy = data.get("wifi", {}).get("rssi", -1)
-        self.qual_phy = data.get("wifi", {}).get("signal", -1)
+        self.phy.f = data.get("leds", {}).get("fps", -1)
+        self.phy.ver = data.get("ver", None)
+        self.phy.n = data.get("leds", {}).get("count", -1)
+        self.phy.name = data.get("name", None)
+        self.phy.rssi = data.get("wifi", {}).get("rssi", -1)
+        self.phy.qual = data.get("wifi", {}).get("signal", -1)
 
         _LOGGER.info(
-            f"{self.effect._virtual.name}:{self.effect.name} wled info: {data}"
+            f"{self.effect._virtual.name}:{self.effect.name} wled info: {self.phy}"
         )
 
     def log_sec(self, current_time):
@@ -90,14 +103,9 @@ class LogSecHelper:
                         r_avg,
                         self.r_min,
                         self.r_max,
-                        self.f_phy,
                         cycle,
                         sleep,
-                        self.ver_phy,
-                        self.n_phy,
-                        self.name_phy,
-                        self.rssi_phy,
-                        self.qual_phy,
+                        self.phy.__dict__,
                     )
                 )
                 self.r_min = 1.0

--- a/ledfx/events.py
+++ b/ledfx/events.py
@@ -111,10 +111,10 @@ class VirtualDiagEvent(Event):
         self.cycle = cycle
         self.sleep = sleep
         self.ver_phy = ver_phy
-        self.n_phy = n_phy 
+        self.n_phy = n_phy
         self.name_phy = name_phy
         self.rssi_phy = rssi_phy
-        self.qual_phy = qual_phy   
+        self.qual_phy = qual_phy
 
 
 class ClientConnectedEvent(Event):

--- a/ledfx/events.py
+++ b/ledfx/events.py
@@ -77,6 +77,11 @@ class VirtualDiagEvent(Event):
         f_phy: int,
         cycle: float,
         sleep: float,
+        ver_phy: str = None,
+        n_phy: int = -1,
+        name_phy: str = None,
+        rssi_phy: int = -1,
+        qual_phy: int = -1,
     ):
         """
         Initializes a VirtualDiagEvent with diagnostic metrics for a virtual entity.
@@ -90,6 +95,11 @@ class VirtualDiagEvent(Event):
             f_phy: wled physical frames per second, -1 if not applicable.
             cycle: Cycle time.
             sleep: Sleep time.
+            ver_phy: Version of the physical device, if applicable.
+            n_phy: Number of physical LEDs, -1 if not applicable.
+            name_phy: Name of the physical device, if applicable.
+            rssi_phy: RSSI of the physical device, -1 if not applicable.
+            qual_phy: Signal quality of the physical device, -1 if not applicable.
         """
         super().__init__(Event.VIRTUAL_DIAG)
         self.virtual_id = virtual_id
@@ -100,6 +110,11 @@ class VirtualDiagEvent(Event):
         self.f_phy = f_phy
         self.cycle = cycle
         self.sleep = sleep
+        self.ver_phy = ver_phy
+        self.n_phy = n_phy 
+        self.name_phy = name_phy
+        self.rssi_phy = rssi_phy
+        self.qual_phy = qual_phy   
 
 
 class ClientConnectedEvent(Event):

--- a/ledfx/events.py
+++ b/ledfx/events.py
@@ -74,14 +74,9 @@ class VirtualDiagEvent(Event):
         r_avg: float,
         r_min: float,
         r_max: float,
-        f_phy: int,
         cycle: float,
         sleep: float,
-        ver_phy: str = None,
-        n_phy: int = -1,
-        name_phy: str = None,
-        rssi_phy: int = -1,
-        qual_phy: int = -1,
+        phy: dict
     ):
         """
         Initializes a VirtualDiagEvent with diagnostic metrics for a virtual entity.
@@ -92,14 +87,9 @@ class VirtualDiagEvent(Event):
             r_avg: Average response time.
             r_min: Minimum response time.
             r_max: Maximum response time.
-            f_phy: wled physical frames per second, -1 if not applicable.
             cycle: Cycle time.
             sleep: Sleep time.
-            ver_phy: Version of the physical device, if applicable.
-            n_phy: Number of physical LEDs, -1 if not applicable.
-            name_phy: Name of the physical device, if applicable.
-            rssi_phy: RSSI of the physical device, -1 if not applicable.
-            qual_phy: Signal quality of the physical device, -1 if not applicable.
+            phy: Phy dict containing physical device information.
         """
         super().__init__(Event.VIRTUAL_DIAG)
         self.virtual_id = virtual_id
@@ -107,14 +97,9 @@ class VirtualDiagEvent(Event):
         self.r_avg = r_avg
         self.r_min = r_min
         self.r_max = r_max
-        self.f_phy = f_phy
         self.cycle = cycle
         self.sleep = sleep
-        self.ver_phy = ver_phy
-        self.n_phy = n_phy
-        self.name_phy = name_phy
-        self.rssi_phy = rssi_phy
-        self.qual_phy = qual_phy
+        self.phy = phy
 
 
 class ClientConnectedEvent(Event):


### PR DESCRIPTION
Add the following into a decdicate phy class structure instead of just fps

fps
WLED version
pixel count
rssi
sign qual
name

Docs updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the WebSocket event documentation to detail a new structure for physical device information, now provided as a comprehensive dictionary with additional device attributes.

* **New Features**
  * Expanded physical device diagnostics to include more detailed information such as firmware version, LED count, device name, signal strength, and connection quality.

* **Refactor**
  * Replaced the single frames-per-second field with a structured dictionary for physical device data in diagnostic events and related logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->