### PR TITLE
Allowing ArtNet broadcast for broadcast addresses

### DIFF
--- a/ledfx/devices/artnet.py
+++ b/ledfx/devices/artnet.py
@@ -7,7 +7,7 @@ from stupidArtnet import StupidArtnet
 
 from ledfx.devices import NetworkedDevice
 from ledfx.devices.utils.rgbw_conversion import OutputMode, rgb_to_output_mode
-from ledfx.utils import extract_uint8_seq
+from ledfx.utils import extract_uint8_seq, check_if_ip_is_broadcast
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -134,13 +134,17 @@ class ArtNetDevice(NetworkedDevice):
             _LOGGER.warning(
                 f"Art-Net sender already started for device {self.config['name']}"
             )
+
+        # check if provided address is a broadcast address
+        broadcast = check_if_ip_is_broadcast(self._config["ip_address"])
+
         self._artnet = StupidArtnet(
             target_ip=self._config["ip_address"],
             universe=self._config["universe"],
             packet_size=self.packet_size,
             fps=self._config["refresh_rate"],
             even_packet_size=self._config["even_packet_size"],
-            broadcast=False,
+            broadcast=broadcast,
             port=self._config["port"],
         )
         # Don't use start for stupidArtnet - we handle fps locally, and it spawns hundreds of threads

--- a/ledfx/utils.py
+++ b/ledfx/utils.py
@@ -5,6 +5,7 @@ import datetime
 import importlib
 import inspect
 import ipaddress
+import netifaces
 import logging
 import math
 import os
@@ -222,6 +223,19 @@ def get_local_ip():
     finally:
         sock.close()
 
+def check_if_ip_is_broadcast(thisip):
+    # iterate over all interfaces
+    for iface in netifaces.interfaces():
+        iface = netifaces.ifaddresses(iface)
+        # iterate over all ipv4 address (if available) for this interface
+        if netifaces.AF_INET in iface:
+            for ip in iface[netifaces.AF_INET]:
+                # check if a broadcast address is set and compare
+                if "broadcast" in ip and ip["broadcast"] == thisip:
+                    return True
+
+    # no matching broadcast address found
+    return False
 
 def async_fire_and_return(coro, callback, timeout=10):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "stupidartnet>=1.6.0,<2.0.0",
     "python-dotenv>=1.0.0,<2.0.0",
     "vnoise>=0.1.0,<1.0.0",
+    "netifaces>=0.11.0",
 ]
 name = "LedFx"
 version = "2.0.109"


### PR DESCRIPTION
ArtNet and underlying SimpleArtNet library should allow users to provide a broadcast ip address as a target.
But using a broadcast address (like 192.168.0.255) as ArtNet target IP for a device raise errors on linux because UDP socket SO_BROADCAST flag is not set.

SimpleArtNet allow this flag to be set by setting broadcast=True in the constructor.

This PR check if provided target address match the broadcast address of one of the network interfaces and set SimpleArtNet broadcast flag accordingly.

Only tested on debian/linux for now but libraries and code should be cross-platform.

Dependency to python package netifaces introduced.