### PR TITLE
Fix: 0,0 wrap artifact in Radial effect

### DIFF
--- a/ledfx/effects/radial.py
+++ b/ledfx/effects/radial.py
@@ -121,7 +121,9 @@ class Radial2d(Twod):
         self.radius_base = np.sqrt(self.dx**2 + self.dy**2)
 
         # Compute maximum radius (used for normalization)
-        self.max_radius = np.max(self.radius_base)
+        # Add a small epsilon to avoid division by zero or crossing zero artifacts
+        radius_stretch = 1.0 + epsilon
+        self.max_radius = np.max(self.radius_base) * radius_stretch
 
     def draw(self):
 


### PR DESCRIPTION
stretch radius to avoid division by zero or crossing zero artifacts

Was leading to a single pixel at 0,0 where the radius mapping was getting rounded up to 1, and therefore wrapping back to pixel 0 from the source.

Stretching radius by 1e-6 prevents this, 

On a 256 pixels source strip that means we stretch things by 0.000256 pixels :-)

And magic does the rest...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability in radial effects to prevent visual artifacts and potential errors during rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->