### PR TITLE
Limit edge and cache to commits to main, tagged version and not PR.

### DIFF
--- a/.github/workflows/test-build-binaries.yml
+++ b/.github/workflows/test-build-binaries.yml
@@ -303,6 +303,8 @@ jobs:
       - name: Run test container
         run: |
           docker run --rm ${{ env.GHCR_IMAGE }}:edge-${{ env.ARCH }}-${{ github.sha }} --ci-smoke-test -vv --offline
+      - name: Get LedFx Version
+        run: |
           docker run --rm --entrypoint ledfx ${{ env.GHCR_IMAGE }}:edge-${{ env.ARCH }}-${{ github.sha }} --version | sed 's/LedFx //' > ledfx_version_docker.txt
       - name: Upload image artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Changed github action to:

1. Upload cache and edge image only on commits to main, tagged version and not PR.
2. Use artifacts to move image from build stage to test stage.
3. Still allows using docker cache image from last successful image for speeding things up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced automated smoke testing of Docker images as part of the build process.
  * Added artifact saving and reuse for Docker images and version information to improve workflow efficiency.

* **Improvements**
  * Enhanced Docker image publishing with more robust multi-architecture support and additional image tags, including SHA-specific tags.
  * Optimized caching and image pushing to occur only on main branch or version tags, reducing unnecessary operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->