### PR TITLE
Fix preset name

### DIFF
--- a/ledfx/presets.py
+++ b/ledfx/presets.py
@@ -2352,7 +2352,7 @@ ledfx_presets = {
                 "speed": 5,
                 "threshold": 0.7,
             },
-            "name": "#ff00b2",
+            "name": "Pink",
         },
         "red": {
             "config": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the single-color preset’s display name from the hex code “#ff00b2” to the human-friendly “Pink,” improving readability and recognition in preset lists, dropdowns, and selection dialogs.
  - Aligns the preset naming with other color presets for a more consistent browsing experience and reduces confusion when selecting colors.
  - No changes to functionality or behavior; only the visible name is updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->