### PR TITLE
Fix: Expose background_brightness for matrix now we have global api

### DIFF
--- a/ledfx/effects/twod.py
+++ b/ledfx/effects/twod.py
@@ -13,7 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 @Effect.no_registration
 class Twod(AudioReactiveEffect):
     # hiding dump by default, a dev can turn it on explicitily via removal
-    HIDDEN_KEYS = ["background_brightness", "mirror", "flip", "blur", "dump"]
+    HIDDEN_KEYS = ["mirror", "flip", "blur", "dump"]
     ADVANCED_KEYS = AudioReactiveEffect.ADVANCED_KEYS + [
         "dump",
         "test",


### PR DESCRIPTION
This was only hidden previously out of personal choice. With the introduction of global api consistent behavior becomes more important.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Background brightness control is now visible for 2D effects, allowing users to adjust the background intensity directly.
  - Improves customization and fine-tuning of visual output without workarounds.
- Documentation
  - Updated user-facing behavior: background brightness is no longer hidden in 2D effect settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->