### PR TITLE
Feat: add virtuals filter to global api

### DIFF
--- a/docs/global.md
+++ b/docs/global.md
@@ -18,6 +18,7 @@ This operation is exposed as a bulk action on the existing **effects collection*
 - **Persistence:** Each updated effect is merged via `effect.update_config({keys})` and saved through `virtual.update_effect_config(effect)`.
 - **Color handling:** Individual effect colors except background_color which must be explicitly configured, will be extracted from the gradient and mapped accordingly. Rough mapping into gradient of Low = 0.0, Mid = 0.5, High = 1.0.
 - **Idempotent:** Reapplying the same configuration results in no effective change (except for toggle operations which always flip state).
+- **Virtual filter:** You may provide a `virtuals` field (list of virtual ids). When present the operation is restricted to only those virtuals; if omitted the operation works across all active effects.
 
 ---
 
@@ -38,6 +39,7 @@ This operation is exposed as a bulk action on the existing **effects collection*
 | `brightness`             | number            | no       | Main brightness value between 0.0 and 1.0. |
 | `flip`                   | boolean or string | no       | `true`, `false`, or `"toggle"` to flip the current state. |
 | `mirror`                 | boolean or string | no       | `true`, `false`, or `"toggle"` to flip the current state. |
+| `virtuals`               | array of strings  | no       | Optional list of virtual ids to restrict the operation to. When present only virtuals with matching `virtual.id` values will be updated. |
 
 **Notes**
 
@@ -59,6 +61,17 @@ curl -X PUT http://localhost:8888/api/effects \
   -d '{
     "action": "apply_global",
     "gradient": "Viridis"
+  }'
+```
+
+### Apply a gradient only to a specific list of virtuals
+```bash
+curl -X PUT http://localhost:8888/api/effects \
+  -H "Content-Type: application/json" \
+  -d '{
+    "action": "apply_global",
+    "gradient": "Viridis",
+    "virtuals": ["virtual-1-id", "virtual-2-id"]
   }'
 ```
 

--- a/ledfx/api/effects.py
+++ b/ledfx/api/effects.py
@@ -211,10 +211,23 @@ class EffectsEndpoint(RestEndpoint):
                     )
 
             # Apply updates to all compatible effects
+            # Optional filter: a list of virtual ids to restrict the update to
+            virtuals_filter = None
+            if "virtuals" in data:
+                vlist = data["virtuals"]
+                if not isinstance(vlist, list):
+                    return await self.invalid_request(
+                        'Invalid value for "virtuals": must be a list of virtual ids'
+                    )
+                virtuals_filter = set(str(v) for v in vlist)
+
             updated = 0
             skipped = 0
 
             for virtual in self._ledfx.virtuals.values():
+                # If a virtuals filter was provided, skip non-matching virtuals
+                if virtuals_filter is not None and virtual.id not in virtuals_filter:
+                    continue
                 eff = getattr(virtual, "active_effect", None)
                 if eff is None or isinstance(eff, DummyEffect):
                     continue

--- a/ledfx/api/effects.py
+++ b/ledfx/api/effects.py
@@ -219,14 +219,17 @@ class EffectsEndpoint(RestEndpoint):
                     return await self.invalid_request(
                         'Invalid value for "virtuals": must be a list of virtual ids'
                     )
-                virtuals_filter = set(str(v) for v in vlist)
+                virtuals_filter = {str(v) for v in vlist}
 
             updated = 0
             skipped = 0
 
             for virtual in self._ledfx.virtuals.values():
                 # If a virtuals filter was provided, skip non-matching virtuals
-                if virtuals_filter is not None and virtual.id not in virtuals_filter:
+                if (
+                    virtuals_filter is not None
+                    and virtual.id not in virtuals_filter
+                ):
                     continue
                 eff = getattr(virtual, "active_effect", None)
                 if eff is None or isinstance(eff, DummyEffect):


### PR DESCRIPTION
Tested with restricted list while pushing various gradients

See virtuals references in updated docs

https://ledfx--1477.org.readthedocs.build/en/1477/global.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now target specific virtuals when performing global effect updates by sending an optional virtuals array (list of virtual IDs) in the API request. When omitted, updates continue to apply to all applicable effects.

* **Documentation**
  * Public API docs updated to include the virtuals field in the request body and its behavior.
  * Added a usage example demonstrating applying a gradient to a selected set of virtuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->