### PR TITLE
Fix: osx build on 3.9/3.10 with CMake 4.x

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -153,6 +153,10 @@ jobs:
         run: |
           brew install portaudio mbedtls@2
 
+      # NEW step to fix samplerate build on Python 3.9/3.10 with CMake 4.x
+      - name: Set CMake policy minimum
+        run: echo "CMAKE_POLICY_VERSION_MINIMUM=3.5" >> "$GITHUB_ENV"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/test-build-binaries.yml
+++ b/.github/workflows/test-build-binaries.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install build dependencies
         run: |
           brew install portaudio
-      
+
       # Fix samplerate build on Python 3.9/3.10 with CMake 4.x
       - name: Set CMake policy minimum
         run: echo "CMAKE_POLICY_VERSION_MINIMUM=3.5" >> "$GITHUB_ENV"

--- a/.github/workflows/test-build-binaries.yml
+++ b/.github/workflows/test-build-binaries.yml
@@ -82,6 +82,10 @@ jobs:
       - name: Install build dependencies
         run: |
           brew install portaudio
+      
+      # Fix samplerate build on Python 3.9/3.10 with CMake 4.x
+      - name: Set CMake policy minimum
+        run: echo "CMAKE_POLICY_VERSION_MINIMUM=3.5" >> "$GITHUB_ENV"
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
@@ -130,6 +134,10 @@ jobs:
       - name: Install build dependencies
         run: |
           brew install portaudio mbedtls@2
+
+      # Fix samplerate build on Python 3.9/3.10 with CMake 4.x
+      - name: Set CMake policy minimum
+        run: echo "CMAKE_POLICY_VERSION_MINIMUM=3.5" >> "$GITHUB_ENV"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of macOS builds (Apple Silicon and Intel), resolving samplerate build failures affecting Python 3.9/3.10 with newer CMake versions.

- Chores
  - Updated CI workflows to enforce a compatible CMake policy on macOS jobs, ensuring consistent, reproducible binary builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->