### PR TITLE
Dev: Use VIRTUAL_ENV for loopback installer path and add uv run prefix to install docs.

### DIFF
--- a/docs/developer/developer.md
+++ b/docs/developer/developer.md
@@ -45,7 +45,7 @@ Warning
 aubio lib which is a critical part of the audio processing for LedFX is in need of a new release
 and can fail to build in many ways.
 
-One common problem for example is if you windows language is not english and uses non standard characters
+One common problem for example is if your Windows language is not English and uses non standard characters
 
 In that case, reach out in the LedFX discord dev_chat channel and ask for an aubio wheel for the version of python you are developing on. 3.12 is preferred!
 ::::

--- a/docs/developer/developer.md
+++ b/docs/developer/developer.md
@@ -70,7 +70,7 @@ In that case, reach out in the LedFX discord dev_chat channel and ask for an aub
 3. Enable audio loopback which is default for a user install, but needs a manual step for dev builds, by calling once
 
     ``` console
-    $  ledfx-loopback-install
+    $ uv run ledfx-loopback-install
     ```
 
 ### Linux Specific Steps {#linux-dev}
@@ -116,7 +116,7 @@ To run these local and / or develop more tests
 1) Ensure you have local loopback installed, or you may hit failures once audio effects are under test
 
     ``` console
-    $  ledfx-loopback-install
+    $ uv run ledfx-loopback-install
     ```
 
 2) launch the suite of tests with uv which will ensure dependancies are installed

--- a/loopback/__main__.py
+++ b/loopback/__main__.py
@@ -28,9 +28,7 @@ def copy_lib():
     # If not in site-packages, means it's a development environment, so get env path from the .venv
     if not lib_path:
         # Default to .venv, but if VIRTUAL_ENV is set (venv does this for you), use that instead
-        venv_path = ".venv"
-        if "VIRTUAL_ENV" in os.environ:
-            venv_path = os.environ["VIRTUAL_ENV"]
+        venv_path = os.path.abspath(os.environ.get("VIRTUAL_ENV", ".venv"))
 
         lib_path = os.path.join(
             venv_path,

--- a/loopback/__main__.py
+++ b/loopback/__main__.py
@@ -27,8 +27,13 @@ def copy_lib():
 
     # If not in site-packages, means it's a development environment, so get env path from the .venv
     if not lib_path:
+        # Default to .venv, but if VIRTUAL_ENV is set (venv does this for you), use that instead
+        venv_path = ".venv"
+        if "VIRTUAL_ENV" in os.environ:
+            venv_path = os.environ["VIRTUAL_ENV"]
+
         lib_path = os.path.join(
-            ".venv",
+            venv_path,
             "Lib",
             "site-packages",
             "_sounddevice_data",


### PR DESCRIPTION
Changes:
- Docs: Added `uv run` in front of loopback install command inside docs
- Code: Made loopback main look for the venv by checking VIRTUAL_ENV variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Windows audio loopback setup now respects the active virtual environment when locating required libraries, reducing setup failures and improving installation reliability.

- Documentation
  - Clarified wording and capitalization in Windows notes.
  - Updated Windows and Linux audio loopback installation instructions to use "uv run ledfx-loopback-install" for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->