### PR TITLE
Add EffectUpdatedEvent and update other events to include relevent state

### DIFF
--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -11,6 +11,7 @@ from numpy.typing import NDArray
 
 from ledfx.color import LEDFX_COLORS, hsv_to_rgb, parse_color, validate_color
 from ledfx.effects.utils.logsec_helper import LogSecHelper
+from ledfx.events import EffectUpdatedEvent
 from ledfx.utils import BaseRegistry, RegistryLoader
 
 _LOGGER = logging.getLogger(__name__)
@@ -428,6 +429,9 @@ class Effect(BaseRegistry):
             _LOGGER.debug(
                 f"Effect {self.NAME} config updated to {validated_config}."
             )
+
+            if self._virtual:
+                self._ledfx.events.fire_event(EffectUpdatedEvent(self._virtual.id))
 
     def config_updated(self, config):
         """

--- a/ledfx/events.py
+++ b/ledfx/events.py
@@ -235,8 +235,9 @@ class EffectSetEvent(Event):
 class EffectClearedEvent(Event):
     """Event emitted when an effect is cleared"""
 
-    def __init__(self):
+    def __init__(self, virtual_id):
         super().__init__(Event.EFFECT_CLEARED)
+        self.virtual_id = virtual_id
 
 
 class SceneActivatedEvent(Event):

--- a/ledfx/events.py
+++ b/ledfx/events.py
@@ -18,6 +18,7 @@ class Event:
     VISUALISATION_UPDATE = "visualisation_update"
     GRAPH_UPDATE = "graph_update"
     EFFECT_SET = "effect_set"
+    EFFECT_UPDATED = "effect_updated"
     EFFECT_CLEARED = "effect_cleared"
     SCENE_ACTIVATED = "scene_activated"
     SCENE_DELETED = "scene_deleted"
@@ -229,6 +230,14 @@ class EffectSetEvent(Event):
         self.effect_name = effect_name
         self.effect_id = effect_id
         self.effect_config = effect_config
+        self.virtual_id = virtual_id
+
+
+class EffectUpdatedEvent(Event):
+    """Event emitted when an effect is updated"""
+
+    def __init__(self, virtual_id):
+        super().__init__(Event.EFFECT_UPDATED)
         self.virtual_id = virtual_id
 
 

--- a/ledfx/events.py
+++ b/ledfx/events.py
@@ -169,8 +169,9 @@ class VirtualUpdateEvent(Event):
 class GlobalPauseEvent(Event):
     """Event emitted when all virtuals are paused"""
 
-    def __init__(self):
+    def __init__(self, paused: bool):
         super().__init__(Event.GLOBAL_PAUSE)
+        self.paused = paused
 
 
 class VirtualPauseEvent(Event):

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -511,7 +511,7 @@ class Virtual:
 
     def clear_effect(self):
         with self.lock:
-            self._ledfx.events.fire_event(EffectClearedEvent())
+            self._ledfx.events.fire_event(EffectClearedEvent(self.id))
             self.clear_transition_effect()
 
             if (

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -1411,7 +1411,7 @@ class Virtuals:
         self._paused = not self._paused
         for virtual in self.values():
             virtual._paused = self._paused
-        self._ledfx.events.fire_event(GlobalPauseEvent())
+        self._ledfx.events.fire_event(GlobalPauseEvent(self._paused))
 
     def get(self, *args):
         return self._virtuals.get(*args)


### PR DESCRIPTION
This PR adds a new `EffectUpdatedEvent` and improves the existing `GlobalPauseEven`t and `EffectClearedEvent`.

`EffectUpdatedEvent` allows integrations to be notified when the active event configuration is updated, but doesn't trigger a full `EffectSetEvent`. e.g. changes to brightness, sensitivity, flip, mirror, etc.

`GlobalPauseEvent` was updated to include the current state. Otherwise, integrations have to poke into the internals and access the `_paused` attributes which is not ideal.

`EffectClearedEvent` was updated to include the ID of the virtual the effect was cleared on. I'm not certain the use of this event, but it's certainly beneficial to know the source of it.