### PR TITLE
Dev: bump to macos-15

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -102,7 +102,7 @@ jobs:
 
   build-ledfx-osx:
     name: Build LedFx (OS X)
-    runs-on: macos-13
+    runs-on: macos-15
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]

--- a/.github/workflows/test-build-binaries.yml
+++ b/.github/workflows/test-build-binaries.yml
@@ -95,7 +95,7 @@ jobs:
           path: ${{ github.workspace }}/installer/ledfx-setup-win-${{ steps.ledfx-version.outputs.ledfx-version }}.exe
   build-ledfx-osx-x64:
     name: Build LedFx (OS X [x64])
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4
@@ -394,7 +394,7 @@ jobs:
           LedFx/LedFx.exe -vv --ci-smoke-test --offline
   run-ledfx-osx-x64:
     name: Test LedFx (OS X [x64])
-    runs-on: macos-13
+    runs-on: macos-15
     needs: [build-ledfx-windows, build-ledfx-osx-x64]
     steps:
       - name: Download LedFx Version
@@ -440,7 +440,7 @@ jobs:
     name: Create GitHub Release
     if: startsWith(github.ref, 'refs/tags/')
     environment: production
-    runs-on: macos-13
+    runs-on: macos-15
     needs: [run-ledfx-windows, run-ledfx-osx-x64, run-ledfx-osx-arm64]
     steps:
       - name: Check out code from GitHub


### PR DESCRIPTION
Speculative bump in response to notice below.

Wondering why we have a mix of macos-13 and macos-latest

The macOS 13 runner image will be retired by December 4th, 2025. To raise awareness of the upcoming removal, jobs using macOS 13 will temporarily fail during the scheduled brownout time periods defined below:
November 4, 14:00 UTC - November 5, 00:00 UTC
November 11, 14:00 UTC - November 12, 00:00 UTC
November 18, 14:00 UTC - November 19, 00:00 UTC
November 25, 14:00 UTC - November 26, 00:00 UTC
This deprecation includes the following labels:
macos-13
macos-13-large
macos-13-xlarge
What you need to do
(Recommended) If your workflow is architecture agnostic, you can migrate to any of our arm64 labels:
macos-15 or macos-latest
macos-14
macos-14-xlarge
macos-latest-xlarge or macos-15-xlarge
For users that require the x86_64 (Intel) architecture, jobs can be migrated to one of the following labels:
macos-15-intel (new)
macos-14-large
macos-latest-large or macos-15-large
You can always get up-to-date information on our tools by reading about the software in the [runner images repository](https://app.github.media/e/er?s=88570519&lid=3455&elqTrackId=500bf75e7e794b73b89c2e3750c78c35&elq=5e3554795f8c4afc9640ff00afec3354&elqaid=4685&elqat=1&elqak=8AF5FA1A2064F14B0FEBF83A9BFBF1C15AFC79AD59D5151C9A41A4B8816A5732AE78). Please contact [GitHub Support](https://app.github.media/e/er?s=88570519&lid=3338&elqTrackId=fb60ba11ba7c4951815e3ab69913b8b7&elq=5e3554795f8c4afc9640ff00afec3354&elqaid=4685&elqat=1&elqak=8AF52094A179B394295FA0AE7A60B0CDFDEE79AD59D5151C9A41A4B8816A5732AE78) if you run into any problems or need help.

Notice of macOS x86_64 (Intel) architecture deprecation
Apple has discontinued support for the x86_64 (Intel) architecture going forward. GitHub will no longer support this architecture on macOS after the macOS 15 runner image is retired in Fall 2027. You should begin migrating your workloads to arm64-based (Apple Silicon) runners as soon as possible to prepare for this eventual deprecation.

Best,
The GitHub Team