### PR TITLE
Dev: Update aubio to latest github commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "wheel>=0.36.2",
     "aiohttp>=3.9.1,<4.0.0",
     "aiohttp-cors>=0.7.0",
-    "aubio>=0.4.9",
+    "aubio @ git+https://github.com/aubio/aubio.git@5461304a598952ffdca78f90cef5b6c82475ec4a",
     "cython>=3.0.7",
     "certifi>=2023.11.17",
     "multidict>=6.0.4",


### PR DESCRIPTION
# Pin aubio to specific commit from GitHub repository

This PR updates the aubio dependency to use the latest development version from GitHub instead of the outdated PyPI release.

## Motivation

The last official aubio release on PyPI is **0.4.9 from 6 years ago** (2018). The aubio project has continued active development on GitHub with numerous bug fixes, improvements, and platform compatibility updates that are not available in the PyPI release.

Installing from PyPI can cause build issues on modern systems due to:
- Outdated build system compatibility
- Missing fixes for newer Python versions (3.10+)
- Platform-specific issues that have been resolved upstream

## Changes

**Dependency Source:**
- Removed PyPI version constraint `aubio>=0.4.9` from dependencies
- Pinned aubio to GitHub commit `5461304a598952ffdca78f90cef5b6c82475ec4a`
- This is the latest commit on the master branch as of this PR

**Why pin to a specific commit instead of branch?**
- Ensures reproducible builds across all environments
- Prevents unexpected breakage from future upstream changes
- Allows controlled updates by explicitly bumping the commit hash
- Follows best practices for dependency management with unreleased packages

## Testing

- Install dependencies with `uv sync` to verify aubio builds from the pinned commit
- Run audio-reactive effects to confirm aubio functionality
- Verify no regression in audio processing and beat detection

## Impact

**Benefits:**
- Access to 6 years of bug fixes and improvements not in PyPI release
- Better compatibility with modern Python versions and build systems
- More reliable builds on Windows, macOS, and Linux

**Migration:**
- Existing installations will automatically use the GitHub version on next `uv sync`
- No code changes required - aubio API remains compatible

## Future Considerations

When aubio releases a new version to PyPI (if ever), we can evaluate switching back to PyPI releases. Until then, this pinned commit approach provides stability and access to modern fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched a dependency to be resolved from a VCS/git source instead of a published version.
  * Updated package configuration to reflect the new source mapping for that dependency.
  * No changes to exported APIs or user-facing features.
  * Application behavior remains unchanged for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->