### PR TITLE
Dev: Add grouping to dependabot and run daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,29 @@
 
 version: 2
 updates:
-  - package-ecosystem: "uv" # See documentation for possible values
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions" # GHA updates
-    directory: "/.github/workflows/" # Location of GHA
+      interval: "daily"
+      time: "06:00"
+      timezone: "America/New_York"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+      time: "06:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        update-types:
+          - "major"


### PR DESCRIPTION
This will have it group minor & patches together in to a single PR which should make it cleaner/easier to merge them in.  Also have them run daily.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated dependency update configuration into root blocks for GitHub Actions and UV.
  * Switched update schedules to daily at 06:00 America/New_York.
  * Expanded update targeting from workflow-only to repository-wide.
  * Added grouping for GitHub Actions updates.
  * Introduced UV groups for minor/patch and major updates, and capped open update pull requests at 5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->