### PR TITLE
Dev: Bump to 2.1.0

### DIFF
--- a/ledfx/consts.py
+++ b/ledfx/consts.py
@@ -1,7 +1,7 @@
 import ledfx_assets
 
 # TODO: Bump pyproject.toml if you bump this!
-PROJECT_VERSION = "2.0.111"
+PROJECT_VERSION = "2.1.0"
 PROJECT_NAME = "LedFx"
 PROJECT_AUTHOR = "LedFx Developers"
 PROJECT_LICENSE = "GPL-3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "packaging>=21.0",
 ]
 name = "LedFx"
-version = "2.0.111"
+version = "2.1.0"
 description = "A network based light effect controller"
 readme = "README.rst"
 


### PR DESCRIPTION
due to deprecation of python 3.9, bumping to 2.1.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Version updated to 2.1.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->