### PR TITLE
Dev: Split dev and build dependencies

### DIFF
--- a/.github/workflows/test-build-binaries.yml
+++ b/.github/workflows/test-build-binaries.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install LedFx
         run: |
-          uv sync --python ${{ env.DEFAULT_PYTHON }} --extra hue --dev
+          uv sync --python ${{ env.DEFAULT_PYTHON }} --extra hue --group build
 
       - name: Get LedFx Version and Upload to Artifacts for later use
         id: ledfx-version
@@ -119,7 +119,7 @@ jobs:
       - name: Install LedFx
         run: |
           export CFLAGS="-Wno-incompatible-function-pointer-types"
-          uv sync --python ${{ env.DEFAULT_PYTHON }} --extra hue --dev
+          uv sync --python ${{ env.DEFAULT_PYTHON }} --extra hue --group build
       - name: Get LedFx Version
         id: ledfx-version
         run: |
@@ -176,7 +176,7 @@ jobs:
           export LDFLAGS="-L/opt/homebrew/opt/mbedtls@2/lib"
           export CPPFLAGS="-I/opt/homebrew/opt/mbedtls@2/include"
           export CFLAGS="-Wno-incompatible-function-pointer-types"
-          uv sync --python ${{ env.DEFAULT_PYTHON }} --extra hue --dev
+          uv sync --python ${{ env.DEFAULT_PYTHON }} --extra hue --group build
       - name: Get LedFx Version
         id: ledfx-version
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ dev = [
     "pytest<9.0.0,>=8.0.0",
     "pytest-asyncio<1.3.0,>=1.2.0",
     "pytest-order<2.0.0,>=1.2.0",
+]
+build = [
     "pyinstaller<7.0.0,>=6.3.0",
 ]
 docs = [


### PR DESCRIPTION
Prior Bokeh and pandas was getting pulled into the binary release builds by default, this is not the intended behaviour. Bokeh / pandas is supposed to be a dev and specific investigation tool set only. All the code is protected including a UI workflow when present.

Splitting the dev tools from the build tools so that binaries can use only build.

22 Meg down to 86->64 Meg for windows installer as an example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration to use new dependency grouping structure for improved binary packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->