### PR TITLE
Dev: Fix blatant deadlock introduced by audio lock protection improvements

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -398,7 +398,7 @@ class AudioInputSource:
                 stream_to_close = self._stream
                 self._stream = None
             self._audio_stream_active = False
-        
+
         # Stop/close outside the lock
         if stream_to_close:
             stream_to_close.stop()


### PR DESCRIPTION
Managed to trigger another deadlock, removing.

Dived deep to identify other remaining issues. Nothing new introduced by recent protections.

1000 postman calls 

Good device id
Random device id 

to introduce good, default and non functional audio chains

There are issues out there, but not churning further right now.

No new deadlocks introduced:

The circular lock risk doesn't materialize because effects only read audio data
Your deactivate() fix already prevents the real deadlock
Remaining issues are pre-existing:

_callbacks races existed before (just as rare)
_timer races existed before (just as rare)
_invoke_callbacks() iteration race existed before (just as rare)
Your changes IMPROVE thread safety:

Fixed _last_active race ✅
Fixed AudioDeviceChangeEvent ✅
No amplification of existing races ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio input stream management to enhance application stability during stream shutdown operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->