### PR TITLE
Fix: Ensure audio_input_device_changed is generated with no active audio effects

### DIFF
--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -388,8 +388,8 @@ class LedFxCore:
         self.devices = Devices(self)
         self.effects = Effects(self)
 
-        # implemnented eager substatiation of AudioAnalysisSource to avoid scenarios 
-        # where audio config could be changed, but no happy path to generate the 
+        # implemnented eager substatiation of AudioAnalysisSource to avoid scenarios
+        # where audio config could be changed, but no happy path to generate the
         # related event
         if AudioAnalysisSource.audio_input_device_exists():
             self.audio = AudioAnalysisSource(
@@ -400,7 +400,7 @@ class LedFxCore:
                 "No audio input devices found. Audio reactive effects will not be available."
             )
             self.audio = None
-        
+
         self.virtuals = Virtuals(self)
         # Ensure we start with a fresh virtual registry when reusing the
         # Virtuals singleton across LedFxCore lifecycles.


### PR DESCRIPTION
Eager substantiation of audio device to ensure audio device changed event can be generated when config changed via any api path ( of 3 ) even if no audio effects are active after an application start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio input device detection with warning notification when unavailable.

* **Refactor**
  * Optimized system startup sequence to initialize audio and virtual components earlier in the startup routine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->