### PR TITLE
Dev: Fix codeql workflow warnings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,11 @@
 name: CodeQL Analysis
 
 on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.*/**'
   pull_request:
     branches:
       - main
@@ -37,9 +42,6 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          # Override the default behavior so that the action doesn't attempt
-          # to auto-install Python dependencies
-          setup-python-dependencies: false
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
Address warnings

Analyze Python (python)
The setup-python-dependencies input is deprecated and no longer has any effect. We recommend removing any references from your workflows. See https://github.blog/changelog/2024-01-23-codeql-2-16-python-dependency-installation-disabled-new-queries-and-bug-fixes/ for more information.

Analyze Python (python)
Unable to validate code scanning workflow: MissingPushHook

Analyze Python (python)
1 issue was detected with this workflow: Please specify an on.push hook to analyze and see code scanning alerts from the default branch on the Security tab.

Added on.push trigger for the main branch:

This ensures CodeQL scans run on pushes to main and alerts appear on the Security tab
Kept the same paths-ignore pattern to skip hidden files/directories
Removed deprecated setup-python-dependencies: false:

This input has been deprecated since CodeQL 2.16 (January 2024)
Python dependency installation is now automatically disabled by default
Removed the explanatory comment as it's no longer relevant
The workflow will now:

Run on pushes to main (resolves "MissingPushHook" warning)
Run on pull requests to main
Run on schedule (daily at 8 PM UTC)
Support manual triggering via workflow_dispatch
No longer show the deprecation warning about setup-python-dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration to improve code analysis workflow automation on the main branch while maintaining existing pull request triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->