### PR TITLE
Fix: div zero protection in waterfull2d with 1d Strip and fade non zero

### DIFF
--- a/ledfx/effects/waterfall2d.py
+++ b/ledfx/effects/waterfall2d.py
@@ -110,7 +110,8 @@ class Waterfall(Twod, GradientEffect):
                 start, int(((self.r_width / float(self.bands)) * (i + 1)) - 1)
             )
             self.bandsx.append([start, end])
-        self.half_height = int(self.r_height // 2)
+        # protect from 0 half_height and divide by zero risk
+        self.half_height = max(1, int(self.r_height // 2))
         self.half_odd = bool(self.r_height % 2)
 
         if (


### PR DESCRIPTION
Protect against corner case of using waterfall2d with a 1d strip and setting the fade control to non zero

Reproduced prior to fix. Runs clean with fix

Seen in sentry

https://ledfx-org.sentry.io/issues/7028150832/?project=4506350233321472&referrer=github-pr-bot