### PR TITLE
Feat: add preset active flag to virtual presets api

### DIFF
--- a/docs/apis/api.md
+++ b/docs/apis/api.md
@@ -747,7 +747,50 @@ configs) with the matching *virtual_id* as JSON
 
 **GET**
 
-Get preset effect configs for active effect of a virtual
+Get preset effect configs for active effect of a virtual. The response includes an `active` flag for each preset that returns `true` if the preset's configuration exactly matches the virtual's currently active effect configuration. This allows clients to easily identify which preset (if any) is currently being displayed on the virtual.
+
+Example response for a virtual running the `singleColor` effect with the "Blue" preset active:
+
+``` json
+{
+  "status": "success",
+  "virtual": "my-virtual",
+  "effect": "singleColor",
+  "ledfx_presets": {
+    "blue": {
+      "name": "Blue",
+      "config": {
+        "color": "#0000ff",
+        "brightness": 1,
+        // ... additional effect config parameters
+      },
+      "active": true
+    },
+    "green": {
+      "name": "Green",
+      "config": {
+        "color": "#00ff00",
+        "brightness": 1,
+        // ... additional effect config parameters
+      },
+      "active": false
+    }
+  },
+  "user_presets": {
+    "my-custom-color": {
+      "name": "My Custom Color",
+      "config": {
+        "color": "#ff00ff",
+        "brightness": 1,
+        // ... additional effect config parameters
+      },
+      "active": false
+    }
+  }
+}
+```
+
+In this example, the "Blue" preset is marked `active: true` because its configuration matches what's currently playing on the virtual. The other presets are marked `active: false`.
 
 **PUT**
 

--- a/docs/effects/matrix/waterfall.md
+++ b/docs/effects/matrix/waterfall.md
@@ -81,5 +81,3 @@ These settings only apply when FADE OUT is non-zero
 
 - **Background Color**: Sets the color that the waterfall fades toward, default is Black
 - **Background Brightness**: Controls the brightness of the background, default is 1.0
-
----

--- a/tests/test_virtual_presets.py
+++ b/tests/test_virtual_presets.py
@@ -1,0 +1,175 @@
+import pytest
+
+from ledfx.api.virtual_presets import VirtualPresetsEndpoint
+
+
+class _DummyEffect:
+    def __init__(self, effect_type, config):
+        self.type = effect_type
+        self.config = config
+
+
+class _DummyVirtual:
+    def __init__(self, virtual_id, effect=None):
+        self.id = virtual_id
+        self.active_effect = effect
+
+
+class _DummyLedFx:
+    def __init__(self, config=None, virtuals=None):
+        self.config = config or {}
+        self.virtuals = virtuals or {}
+
+
+@pytest.fixture
+def preset_endpoint():
+    """Create a VirtualPresetsEndpoint instance for testing"""
+    endpoint = VirtualPresetsEndpoint(None)
+    endpoint._ledfx = _DummyLedFx()
+    return endpoint
+
+
+def test_add_active_flags_matching_preset(preset_endpoint):
+    """Test that matching preset gets active=True"""
+    presets = {
+        "preset1": {
+            "name": "Preset One",
+            "config": {"speed": 2, "color": "red"},
+        },
+        "preset2": {
+            "name": "Preset Two",
+            "config": {"speed": 3, "color": "blue"},
+        },
+    }
+    active_config = {"speed": 2, "color": "red"}
+
+    result = preset_endpoint._add_active_flags(presets, active_config)
+
+    assert result["preset1"]["active"] is True
+    assert result["preset2"]["active"] is False
+    # Verify original data is preserved
+    assert result["preset1"]["name"] == "Preset One"
+    assert result["preset1"]["config"] == {"speed": 2, "color": "red"}
+
+
+def test_add_active_flags_no_matching_preset(preset_endpoint):
+    """Test that no preset gets active=True when none match"""
+    presets = {
+        "preset1": {
+            "name": "Preset One",
+            "config": {"speed": 2, "color": "red"},
+        },
+        "preset2": {
+            "name": "Preset Two",
+            "config": {"speed": 3, "color": "blue"},
+        },
+    }
+    active_config = {"speed": 5, "color": "green"}
+
+    result = preset_endpoint._add_active_flags(presets, active_config)
+
+    assert result["preset1"]["active"] is False
+    assert result["preset2"]["active"] is False
+
+
+def test_add_active_flags_empty_presets(preset_endpoint):
+    """Test handling of empty presets dictionary"""
+    presets = {}
+    active_config = {"speed": 2}
+
+    result = preset_endpoint._add_active_flags(presets, active_config)
+
+    assert result == {}
+
+
+def test_add_active_flags_exact_match_required(preset_endpoint):
+    """Test that only exact config matches are marked active"""
+    presets = {
+        "preset1": {
+            "name": "Preset One",
+            "config": {"speed": 2, "color": "red"},
+        },
+        "preset2": {
+            "name": "Preset Two",
+            # Missing 'color' key - should not match
+            "config": {"speed": 2},
+        },
+    }
+    active_config = {"speed": 2, "color": "red"}
+
+    result = preset_endpoint._add_active_flags(presets, active_config)
+
+    assert result["preset1"]["active"] is True
+    assert result["preset2"]["active"] is False
+
+
+def test_add_active_flags_handles_empty_configs(preset_endpoint):
+    """Test handling of empty configs"""
+    presets = {
+        "preset1": {
+            "name": "Empty Preset",
+            "config": {},
+        },
+    }
+    active_config = {}
+
+    result = preset_endpoint._add_active_flags(presets, active_config)
+
+    assert result["preset1"]["active"] is True
+
+
+def test_add_active_flags_preserves_all_preset_data(preset_endpoint):
+    """Test that all preset data is preserved in the result"""
+    presets = {
+        "preset1": {
+            "name": "Test Preset",
+            "config": {"speed": 2},
+            "custom_field": "custom_value",
+            "another_field": 123,
+        },
+    }
+    active_config = {"speed": 2}
+
+    result = preset_endpoint._add_active_flags(presets, active_config)
+
+    assert result["preset1"]["name"] == "Test Preset"
+    assert result["preset1"]["config"] == {"speed": 2}
+    assert result["preset1"]["custom_field"] == "custom_value"
+    assert result["preset1"]["another_field"] == 123
+    assert result["preset1"]["active"] is True
+
+
+def test_add_active_flags_case_sensitivity(preset_endpoint):
+    """Test that config comparison is case-sensitive"""
+    presets = {
+        "preset1": {
+            "name": "Preset One",
+            "config": {"Color": "Red"},  # Uppercase C
+        },
+    }
+    active_config = {"color": "Red"}  # Lowercase c
+
+    result = preset_endpoint._add_active_flags(presets, active_config)
+
+    # Should not match due to case difference in key
+    assert result["preset1"]["active"] is False
+
+
+def test_add_active_flags_value_type_sensitivity(preset_endpoint):
+    """Test that config comparison is type-sensitive"""
+    presets = {
+        "preset1": {
+            "name": "Preset String",
+            "config": {"speed": "2"},  # String
+        },
+        "preset2": {
+            "name": "Preset Int",
+            "config": {"speed": 2},  # Integer
+        },
+    }
+    active_config = {"speed": 2}  # Integer
+
+    result = preset_endpoint._add_active_flags(presets, active_config)
+
+    assert result["preset1"]["active"] is False
+    assert result["preset2"]["active"] is True


### PR DESCRIPTION
Following recent addition of scenes active flag adding similar to virtuals presets api

https://ledfx--1587.org.readthedocs.build/en/1587/apis/api.html#api-virtuals-virtual-id-presets

Unit tests added and tested with postman and changing presets, observing responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preset API responses now include an active flag that indicates whether each preset's configuration currently matches the virtual's active effect.

* **Documentation**
  * Updated API documentation to reflect the new active flag behavior, including detailed examples demonstrating how the flag works.

* **Tests**
  * Added comprehensive unit test coverage for the new active flag comparison logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->