### PR TITLE
Dev: harden asset cache tests with mocking

### DIFF
--- a/tests/test_api_assets_cached_urls.py
+++ b/tests/test_api_assets_cached_urls.py
@@ -19,7 +19,7 @@ allocated port (configured via test harness).
 import io
 import time
 import urllib.error
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 import requests


### PR DESCRIPTION
## Fix test failures in Ubuntu + Python 3.10 by replacing network calls with mocking

### Problem
Tests in `test_api_assets_cached_urls.py` were timing out on Ubuntu + Python 3.10:
- `test_download_uncached_url_returns_error` 
- `test_thumbnail_uncached_url_returns_error`
- Related tests were cascading failures

The tests used real network URLs (example.com) with 5-second timeouts, but the application's `DOWNLOAD_TIMEOUT` is 30 seconds, causing test timeouts before the application could handle errors.

### Solution
Replaced error-handling tests with mocked versions using `@patch("ledfx.utils.urllib.request.urlopen")`:
- Mock `urllib.error.URLError` to simulate connection failures
- No actual network calls for error-handling tests
- Fast (~0.1s vs 5-30s), deterministic, platform-independent

Integration tests with real GitHub URLs remain unchanged and continue to validate actual download functionality.

### Results
- ✅ All 8 tests pass in 4.39s (previously would fail/timeout)
- ✅ Error-handling tests run instantly without network dependency
- ✅ No application code changes required
- ✅ Follows same mocking pattern as `test_image_security.py`

### Testing
```bash
uv run pytest tests/test_api_assets_cached_urls.py -v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for URL handling and error scenarios through enhanced mocking
  * Added integration tests with actual external URLs to validate real-world behavior
  * Optimized test execution with adjusted timeouts for improved reliability
  * Expanded coverage for SSRF protection and non-URL path handling scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->