### PR TITLE
Fix: Preset and Scene matching for number effect

### DIFF
--- a/ledfx/effects/number.py
+++ b/ledfx/effects/number.py
@@ -233,7 +233,7 @@ class Number(Texter2d):
     def do_once(self):
         # override here to keep text centered and avoid config reset preset matching issues
         self.speed_option_1 = 0
-        
+
         """Initialize the sentence object with initial formatted number."""
         # update text before sentence creation
         self._display_text = self._format_number(


### PR DESCRIPTION
- Removed mutation of config["speed_option_1"] in Number effect’s __init__; now set as an instance attribute in do_once to avoid affecting config-based preset matching.
- Stopped storing display text in the config; now managed internally as _display_text.
- Updated rendering logic to use _display_text, ensuring no runtime config mutation.
- These changes ensure correct reset preset matching and prevent config drift for the Number effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text centering behavior in the number effect.
  * Fixed text formatting and display synchronization for number values.

* **Refactor**
  * Refined internal text handling logic to maintain consistent font and sizing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->