### PR TITLE
Fix: Websocket Error handling

### DIFF
--- a/ledfx/api/websocket.py
+++ b/ledfx/api/websocket.py
@@ -60,7 +60,7 @@ class WebsocketEndpoint(RestEndpoint):
             return await WebsocketConnection(self._ledfx).handle(request)
         except ConnectionResetError:
             _LOGGER.debug("Connection Reset Error on Websocket Connection.")
-            return self.internal_error("Connection Reset Error.")
+            return await self.internal_error("Connection Reset Error.")
 
 
 class WebsocketConnection:


### PR DESCRIPTION
## Fix: Add missing await in websocket error handler

Fixed missing `await` keyword when calling `internal_error()` in the websocket ConnectionResetError handler, preventing coroutine warning and proper error response delivery.

### Changes
- **websocket.py**: Added `await` to `self.internal_error()` call on line 63

### Issue
Without `await`, the method returned a coroutine object instead of executing, causing:
- AttributeError: 'coroutine' object has no attribute 'prepare'
- RuntimeWarning: coroutine 'RestEndpoint.internal_error' was never awaited
- No error response sent to client on connection failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error response handling in WebSocket connections to properly execute asynchronous operations instead of returning unexecuted coroutines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->