### PR TITLE
Docs: add README tweaks about web interface access

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ The below image describes a basic setup - LedFx running on PC, communicating wit
      - Windows 10, `LedFx.exe`_
    * - Browser to access the LedFx web interface
      - Chrome/Edge/Firefox/Safari
-       
+
        http://127.0.0.1:8888
    * - Networked device controlling LED Strip
      - ESP8266 NODEMCU v3 running `WLED`_


### PR DESCRIPTION
Simple updates to improve visibility of localhost:8888 browser access

https://ledfx--1663.org.readthedocs.build/en/1663/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README with details about the browser-based web interface, including the default port (8888) and access URLs
  * Added guidance on using the --open-ui launch option to automatically open the web interface
  * Included instructions for accessing and navigating to the web UI

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->