### PR TITLE
Dev: Protect Game of life for memory leaks

### DIFF
--- a/ledfx/effects/game_of_life.py
+++ b/ledfx/effects/game_of_life.py
@@ -158,6 +158,10 @@ class GameOfLifeVisualiser(Twod):
         self.img_array = np.zeros(
             (self.r_height, self.r_width, 3), dtype=np.uint8
         )
+        # Pre-allocate history stack array to avoid creating new arrays every frame
+        self.game._history_stack = np.zeros(
+            (self.history, self.r_height, self.r_width), dtype=bool
+        )
 
     def deactivate(self):
         """Clean up resources when effect is deactivated"""
@@ -165,6 +169,7 @@ class GameOfLifeVisualiser(Twod):
             self.game.board = None
             self.game.board_history = None
             self.game._history_buffer = None
+            self.game._history_stack = None
             self.game = None
         self.img_array = None
         super().deactivate()
@@ -237,7 +242,10 @@ class GameOfLifeVisualiser(Twod):
 
         # Use game board and history directly
         current_board = self.game.board
-        history_stack = np.array(self.game.board_history)
+        # Update pre-allocated history stack in-place to avoid creating new arrays
+        for i, board in enumerate(self.game.board_history):
+            np.copyto(self.game._history_stack[i], board)
+        history_stack = self.game._history_stack
 
         # Calculate alive and dead durations using vectorization
         alive_durations = np.sum(history_stack, axis=0)


### PR DESCRIPTION
## Fix: Memory leaks in Game of Life effect

### Issues Addressed
Memory leaks when rapidly switching Game of Life effect in/out during playlists or long-running sessions.

### Changes

**Resource Cleanup:**
- Added explicit `deactivate()` method to clean up game board, history, and image arrays

**Image Array Optimization:**
- Pre-allocate `img_array` once in `do_once()` and reuse across frames (eliminates per-frame array allocation)
- Explicit PIL Image reference cleanup before creating new Image objects

**Board History Optimization:**
- Replace list-based `board_history` with `collections.deque(maxlen=depth)` (eliminates O(n) `pop(0)` operations)
- Pre-allocate `_history_buffer` array and use `np.copyto()` instead of `np.copy()` to reduce allocation churn

**Impact:**
Eliminates continuous memory growth during scene switching and reduces per-frame allocations from ~4-5 objects to ~1 object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Game of Life effect performance and memory usage for smoother, more consistent rendering.
  * Lowered per-frame allocations by reusing image and history buffers, reducing memory churn during long runs.
  * Enhanced cleanup on deactivation to free visual buffers and history, improving responsiveness on stop/start.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->