### PR TITLE
Add audio analysis (pitch/onset method) options to configuration guide

### DIFF
--- a/docs/settings/configuring.md
+++ b/docs/settings/configuring.md
@@ -1,5 +1,13 @@
 # Configuration
 
+## Audio analysis options - pitch method and onset method
+
+Caution: The defaults are default for a reason!
+
+(Developer) documentation describing the available onset and pitch methods is available here:
+- [Onset method](https://aubio.org/doc/latest/specdesc_8h.html)
+- [Pitch method](https://aubio.org/doc/latest/pitch_8h.html)
+
 ## Firmware Specific
 
 Once you have LedFx installed, it's time to add some devices! Make sure


### PR DESCRIPTION
Added section on pitch and onset methods with links to documentation.

I couldn't find this documented anywhere, so I looked at the code and found these links. This isn't great documentation, but adding these links might be helpful to someone wondering what those options are.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation section covering audio analysis configuration options, including information on pitch and onset methods with guidance resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->