### PR TITLE
fix: include lifx-async in PyInstaller binary builds

### DIFF
--- a/hiddenimports.py
+++ b/hiddenimports.py
@@ -48,4 +48,9 @@ hiddenimports = [
     "netifaces",
     "aiohttp_cors",
     "dotenv",
+    "lifx",
+    "lifx.exceptions",
+    "lifx.network",
+    "lifx.protocol",
+    "lifx.protocol.packets",
 ]

--- a/osx-binary.spec
+++ b/osx-binary.spec
@@ -2,7 +2,7 @@
 import os
 from hiddenimports import hiddenimports
 from ledfx.consts import PROJECT_VERSION
-from PyInstaller.utils.hooks import collect_dynamic_libs, collect_data_files, collect_submodules
+from PyInstaller.utils.hooks import collect_dynamic_libs, collect_data_files, collect_submodules, copy_metadata
 
 spec_root = os.path.abspath(SPECPATH)
 
@@ -13,6 +13,9 @@ block_cipher = None
 numpy_binaries = collect_dynamic_libs('numpy')
 numpy_datas = collect_data_files('numpy', include_py_files=True)
 numpy_hiddenimports = collect_submodules('numpy')
+
+# Collect lifx-async package metadata (required by lifx/__init__.py for importlib.metadata)
+lifx_metadata = copy_metadata('lifx-async')
 
 # Remove the ledfx.env file if it exists
 os.remove("ledfx.env") if os.path.exists("ledfx.env") else None
@@ -42,7 +45,7 @@ with open('ledfx.env', 'a') as file:
 a = Analysis([f'{spec_root}/ledfx/__main__.py'],
              pathex=[f'{spec_root}', f'{spec_root}/ledfx'],
              binaries=numpy_binaries,
-             datas=[(f'{spec_root}/ledfx_frontend', 'ledfx_frontend/'), (f'{spec_root}/ledfx/', 'ledfx/'), (f'{spec_root}/ledfx_assets', 'ledfx_assets/'),(f'{spec_root}/ledfx_assets/tray.png','.'), (f'{spec_root}/ledfx.env','.')] + numpy_datas,
+             datas=[(f'{spec_root}/ledfx_frontend', 'ledfx_frontend/'), (f'{spec_root}/ledfx/', 'ledfx/'), (f'{spec_root}/ledfx_assets', 'ledfx_assets/'),(f'{spec_root}/ledfx_assets/tray.png','.'), (f'{spec_root}/ledfx.env','.')] + numpy_datas + lifx_metadata,
              hiddenimports=hiddenimports + numpy_hiddenimports,
              hookspath=[f'{venv_root}/lib/site-packages/pyupdater/hooks'],
              runtime_hooks=[],

--- a/windows-binary.spec
+++ b/windows-binary.spec
@@ -2,7 +2,7 @@
 import os
 from hiddenimports import hiddenimports
 from ledfx.consts import PROJECT_VERSION
-from PyInstaller.utils.hooks import collect_dynamic_libs, collect_data_files, collect_submodules
+from PyInstaller.utils.hooks import collect_dynamic_libs, collect_data_files, collect_submodules, copy_metadata
 
 spec_root = os.path.abspath(SPECPATH)
 
@@ -14,6 +14,10 @@ print(venv_root)
 numpy_binaries = collect_dynamic_libs('numpy')
 numpy_datas = collect_data_files('numpy', include_py_files=True)
 numpy_hiddenimports = collect_submodules('numpy')
+
+# Collect lifx-async package metadata (required by lifx/__init__.py for importlib.metadata)
+lifx_metadata = copy_metadata('lifx-async')
+
 # Remove the ledfx.env file if it exists
 os.remove("ledfx.env") if os.path.exists("ledfx.env") else None
 
@@ -41,7 +45,7 @@ with open('ledfx.env', 'a') as file:
 a = Analysis([f'{spec_root}\\ledfx\\__main__.py'],
              pathex=[f'{spec_root}', f'{spec_root}\\ledfx'],
              binaries=numpy_binaries,
-             datas=[(f'{spec_root}/ledfx_frontend', 'ledfx_frontend/'), (f'{spec_root}/ledfx/', 'ledfx/'), (f'{spec_root}/ledfx_assets', 'ledfx_assets/'),(f'{spec_root}/ledfx_assets/tray.png','.'), (f'{spec_root}/ledfx.env','.')] + numpy_datas,
+             datas=[(f'{spec_root}/ledfx_frontend', 'ledfx_frontend/'), (f'{spec_root}/ledfx/', 'ledfx/'), (f'{spec_root}/ledfx_assets', 'ledfx_assets/'),(f'{spec_root}/ledfx_assets/tray.png','.'), (f'{spec_root}/ledfx.env','.')] + numpy_datas + lifx_metadata,
              hiddenimports=hiddenimports + numpy_hiddenimports,
              hookspath=[f'{venv_root}\\lib\\site-packages\\pyupdater\\hooks'],
              runtime_hooks=[],


### PR DESCRIPTION
The lifx package was missing from frozen binaries because PyInstaller couldn't detect the dynamically-loaded imports. Added lifx submodules to hiddenimports and bundled lifx-async dist-info metadata (required by lifx/__init__.py which calls importlib.metadata.version at import time).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to include LIFX module support for macOS and Windows distributions.
  * Enhanced bundled dependencies to ensure LIFX functionality is properly packaged with the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->