### PR TITLE
Feat: add RGBW for RPI_WS281X 

### DIFF
--- a/ledfx/devices/rpi_ws281x.py
+++ b/ledfx/devices/rpi_ws281x.py
@@ -124,11 +124,8 @@ class RPI_WS281X(DeviceWrapper):
         if self.white_mode == "None":
             # RGB: R, G, B
             def color_func(c):
-                return (
-                    (round(c[0]) << 16)
-                    | (round(c[1]) << 8)
-                    | round(c[2])
-                )
+                return (round(c[0]) << 16) | (round(c[1]) << 8) | round(c[2])
+
         else:
             # RGBW: W, R, G, B
             def color_func(c):


### PR DESCRIPTION
I have now implemented the W channel and color correction from rgbw_conversion.py so that RGBW LED strips can be controlled directly with the rpi_ws281x.py driver.
Thanks @bigredfrog for your hint! I hope everything is now fine for accepting this PR :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RGBW (RGB + white) LED strip support on Raspberry Pi.
  * New configuration option for white-channel behavior and output mode.

* **Improvements**
  * Automatic detection and selection between RGB and RGBW hardware for more accurate colors.
  * Updated activation and update flow for stable, correct channel mapping and visual output.
  * Documentation refreshed to reflect combined WS281X/SK6812 support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->