### PR TITLE
Feat: add feature flag stansa to api/info for sendspin

### DIFF
--- a/docs/apis/api.md
+++ b/docs/apis/api.md
@@ -9,15 +9,31 @@ Information about LedFx
 
 **GET**
 
-Returns basic information about the LedFx instance as JSON
+Returns basic information about the LedFx instance as JSON, including a `features` object indicating which optional capabilities are available on this backend.
 
 ``` json
 {
   "url": "http://127.0.0.1:8888",
-  "name": "LedFx",
-  "version": "0.3.0"
+  "name": "LedFx Controller",
+  "version": "2.1.5",
+  "github_sha": "unknown",
+  "is_release": "false",
+  "developer_mode": false,
+  "features": {
+    "sendspin": true
+  }
 }
 ```
+
+### Features
+
+The `features` object provides boolean flags for optional backend capabilities that may not be available in all environments. Frontends should query this on startup to conditionally show or hide UI sections.
+
+| Feature | Description | Requirement |
+|---------|-------------|-------------|
+| `sendspin` | Sendspin synchronized multi-room audio integration | Python 3.12+ and `aiosendspin` package |
+
+When a feature is `false`, the corresponding API endpoints will return error responses and the frontend should hide the related UI.
 
 ## /api/config
 

--- a/docs/apis/sendspin_servers.md
+++ b/docs/apis/sendspin_servers.md
@@ -8,6 +8,20 @@ LedFx provides REST API endpoints for managing Sendspin server connections. [Sen
 
 **Availability:** Requires Python 3.12+ and the `aiosendspin` package installed. On Python < 3.12 or without the package, all endpoints return a `501 Not Implemented` equivalent response.
 
+### Detecting Availability
+
+Before rendering Sendspin UI, frontends should check the `features.sendspin` flag from `GET /api/info`:
+
+```json
+{
+  "features": {
+    "sendspin": true
+  }
+}
+```
+
+When `sendspin` is `false`, the backend does not support Sendspin (Python < 3.12 or `aiosendspin` not installed). All `/api/sendspin/*` endpoints will return error responses and the frontend should hide the Sendspin section entirely.
+
 ---
 
 ## Data Model

--- a/ledfx/api/info.py
+++ b/ledfx/api/info.py
@@ -5,6 +5,7 @@ from aiohttp import web
 
 from ledfx.api import RestEndpoint
 from ledfx.consts import PROJECT_VERSION
+from ledfx.sendspin import SENDSPIN_AVAILABLE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,5 +27,8 @@ class InfoEndpoint(RestEndpoint):
             "github_sha": os.getenv("GITHUB_SHA", "unknown"),
             "is_release": os.getenv("IS_RELEASE", "false").lower(),
             "developer_mode": self._ledfx.config["dev_mode"],
+            "features": {
+                "sendspin": SENDSPIN_AVAILABLE,
+            },
         }
         return await self.bare_request_success(response)


### PR DESCRIPTION
## Add Feature Availability Flag to `/api/info`

Adds a `features` object to the `GET /api/info` response so the frontend can detect which optional backend capabilities are available and conditionally show/hide UI sections.

### Changes

| File | Description |
|------|-------------|
| `ledfx/api/info.py` | Added `features` dict with `sendspin` boolean flag to the info response |
| `docs/apis/api.md` | Updated `/api/info` documentation with `features` object and feature table |
| `docs/apis/sendspin_servers.md` | Added "Detecting Availability" section referencing the feature flag |

### Example Response

```json
{
  "url": "http://127.0.0.1:8888",
  "name": "LedFx Controller",
  "version": "2.1.5",
  "developer_mode": false,
  "features": {
    "sendspin": true
  }
}
```

### Frontend Usage

Call `GET /api/info` on startup and check `response.features.sendspin`. When `false` (Python < 3.12 or `aiosendspin` not installed), hide all Sendspin-related UI. The `features` dict is extensible for future optional capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `/api/info` endpoint now returns feature availability flags, including support for Sendspin functionality.

* **Documentation**
  * Updated API documentation to reflect the new feature flag response structure.
  * Added guidance for frontend implementations on handling unavailable features and associated API endpoint errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->