### PR TITLE
Feat: Audio device persist by name

### DIFF
--- a/docs/developer/dev_notes/audio-device-persistence-strategy.md
+++ b/docs/developer/dev_notes/audio-device-persistence-strategy.md
@@ -157,7 +157,7 @@ def _resolve_device_from_name(self):
     """
     Resolve the audio device by name from config.
     Called at startup/config-update to handle index drift.
-    
+
     Resolution order:
     1. Name match at saved index (fast path, no drift)
     2. Name match at different index (drift detected, update index)
@@ -166,13 +166,13 @@ def _resolve_device_from_name(self):
     """
     saved_name = self._config.get("audio_device_name", "")
     saved_idx = self._config.get("audio_device")
-    
+
     if not saved_name:
         # No name stored (legacy config or first run) — use index as-is
         return
-    
+
     devices = self.input_devices()
-    
+
     # Fast path: saved index exists and name matches
     if saved_idx in devices and devices[saved_idx] == saved_name:
         _LOGGER.debug(
@@ -180,10 +180,10 @@ def _resolve_device_from_name(self):
             saved_name, saved_idx
         )
         return
-    
+
     # Name-based search (index has drifted)
     found_idx = self.get_device_index_by_name(saved_name)
-    
+
     if found_idx != -1:
         _LOGGER.info(
             "Audio device '%s' moved from index %s to %s (enumeration changed)",
@@ -198,7 +198,7 @@ def _resolve_device_from_name(self):
                 config_dir=self._ledfx.config_dir,
             )
         return
-    
+
     # Device not found by name at all
     _LOGGER.warning(
         "Saved audio device '%s' not found in current device list. "

--- a/docs/developer/dev_notes/audio-device-persistence-strategy.md
+++ b/docs/developer/dev_notes/audio-device-persistence-strategy.md
@@ -415,15 +415,24 @@ These ensure the new code doesn't break existing behavior.
 - **Fixture for mock ledfx:** Create a simple mock with `config` dict and `config_dir` string to satisfy `_update_device_config()` requirements.
 - **No real audio in CI:** All tests must pass without any audio hardware. Never call `sd.query_devices()` in tests.
 
-### 8. Implementation Order
+### 8. Implementation Order & Progress
 
-1. Add `audio_device_name` to `AUDIO_CONFIG_SCHEMA`
-2. Add `_resolve_device_from_name()` method to `AudioInputSource`
-3. Call resolver from `update_config()` before `activate()`
-4. Update `_update_device_config()` to persist name
-5. Update `audio_devices.py` PUT handler to persist name
-6. Write tests
-7. Manual verification with real device enumeration changes
+**Branch:** `audio_name_2`
+**PR:** [#1770 — Feat: Audio device persist by name](https://github.com/LedFx/LedFx/pull/1770)
+
+| # | Task | File(s) | Status |
+|---|---|---|---|
+| 1 | Add `audio_device_name` to `AUDIO_CONFIG_SCHEMA` | `ledfx/effects/audio.py` | [x] |
+| 2 | Add `_resolve_device_from_name()` method | `ledfx/effects/audio.py` | [x] |
+| 3 | Call resolver from `update_config()` before `activate()` | `ledfx/effects/audio.py` | [x] |
+| 4 | Update `_update_device_config()` to persist name | `ledfx/effects/audio.py` | [x] |
+| 5 | Auto-persist name in `_activate_inner()` (legacy upgrade path) | `ledfx/effects/audio.py` | [x] |
+| 6 | Update API PUT to persist name | `ledfx/api/audio_devices.py` | [x] |
+| 7 | Update API GET to return name | `ledfx/api/audio_devices.py` | [x] |
+| 8 | Write unit tests (37 cases from §7) | `tests/test_audio_device_persistence.py` | [x] |
+| 9 | Run tests and verify | — | [x] |
+
+> **Session recovery:** If a session times out, read this document to restore context. The table above tracks progress. Resume from the first unchecked item.
 
 ---
 

--- a/docs/developer/dev_notes/audio-device-persistence-strategy.md
+++ b/docs/developer/dev_notes/audio-device-persistence-strategy.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-07
 **Status:** Strategy — implemented
-**Scope:** `ledfx/effects/audio.py`, `ledfx/api/audio_devices.py`, `ledfx/config.py`
+**Scope:** `ledfx/effects/audio.py`, `ledfx/api/audio_devices.py`, `ledfx/api/config.py`, `ledfx/config.py`
 
 ---
 
@@ -93,9 +93,36 @@ Add a new method or extend `device_index_validator()` with this resolution order
 - **PUT handler** — Persists `audio_device_name` alongside `audio_device` when the user selects a device via the API.
 - **GET handler** — Returns `active_device_name` in the response alongside `active_device_index`.
 
+#### `ledfx/api/config.py`
+
+- **`update_config()`** — When the incoming payload contains `audio_device`, the stale `audio_device_name` is cleared from the existing config **before** the merge. This prevents `_resolve_device_from_name()` from name-matching back to the old device and overriding the user's selection. See §3.1 below.
+
 #### `ledfx/config.py`
 
 No new migration required. `audio_device_name` defaults to `""` via the schema, so legacy configs load without error.
+
+### 3.1 Config Merge Hazard — `ledfx/api/config.py`
+
+> **Bug found 2026-04-08.** The original implementation missed this path entirely.
+
+The frontend changes audio devices via `PUT /api/config {"audio": {"audio_device": 4}}`, which is handled by `ConfigEndpoint.update_config()` in `ledfx/api/config.py`. This method does a **partial merge**:
+
+```python
+self._ledfx.config["audio"].update(audio_config)
+```
+
+`.update()` only overwrites keys present in the incoming payload. When the frontend sends `{"audio_device": 4}` (no `audio_device_name`), the stale `audio_device_name` from the prior device selection survives the merge. The merged config is then passed to `AudioInputSource.update_config()`, which calls `_resolve_device_from_name()`. That method sees the stale name, searches by name, finds the **old** device, and overrides the user's new index selection.
+
+**Fix:** Before the merge, if the incoming payload contains `audio_device`, explicitly clear `audio_device_name` in the existing config:
+
+```python
+if "audio_device" in audio_config:
+    self._ledfx.config["audio"]["audio_device_name"] = ""
+```
+
+This causes `_resolve_device_from_name()` to take the "no name stored" path and use the index as-is. The name is then correctly populated by `persist_device_name_if_needed()` after the new device opens.
+
+**Key lesson:** Any code path that can write `audio_device` without simultaneously writing `audio_device_name` must clear the stale name. The dedicated audio devices API (`ledfx/api/audio_devices.py`) writes both together, but the general config API merges partial payloads — a distinction the original strategy failed to account for.
 
 ### 4. `_resolve_device_from_name()` Algorithm
 
@@ -217,11 +244,12 @@ These verify that upgrading from index-only configs works seamlessly.
 
 #### 7.4 Unit Tests — API Endpoint
 
-These verify the REST API correctly persists both fields.
+These verify the REST API correctly persists both fields. Tests must exercise the actual `ConfigEndpoint.update_config()` merge path against pre-existing config state, not just construct new dicts in isolation.
 
 | # | Test Name | Scenario | Expected Result |
 |---|---|---|---|
-| 16 | `test_api_put_persists_name_and_index` | PUT `{"audio_device": 5}` | Config saved with both `audio_device: 5` and `audio_device_name: "..."` |
+| 16 | `test_api_put_persists_name_and_index` | PUT `{"audio_device": 5}` via audio devices API | Config saved with both `audio_device: 5` and `audio_device_name: "..."` |
+| 16b | `test_api_put_device_change_clears_stale_name` | PUT `{"audio": {"audio_device": 5}}` via general config API, existing config has `audio_device: 17` + `audio_device_name: "Loopback"` | Stale name cleared before merge; `update_config()` receives `audio_device: 5` with `audio_device_name: ""` so `_resolve_device_from_name()` does not override the user's selection |
 | 17 | `test_api_put_invalid_index_rejected` | PUT `{"audio_device": 999}` | Error response, config unchanged |
 | 18 | `test_api_get_returns_name` | GET with config containing name | Response includes `active_device_index` and `active_device_name` |
 
@@ -296,6 +324,8 @@ These ensure the new code doesn't break existing behavior.
 | 7 | Update API GET to return name | `ledfx/api/audio_devices.py` | [x] |
 | 8 | Write unit tests (37 cases from §7) | `tests/test_audio_device_persistence.py` | [x] |
 | 9 | Run tests and verify | — | [x] |
+| 10 | Fix config merge hazard — clear stale name on API device change | `ledfx/api/config.py` | [x] |
+| 11 | Add regression test for config merge hazard (#16b) | `tests/test_audio_device_persistence.py` | [x] |
 
 > **Session recovery:** If a session times out, read this document to restore context. The table above tracks progress. Resume from the first unchecked item.
 
@@ -314,5 +344,6 @@ These ensure the new code doesn't break existing behavior.
 | Name-based search | `ledfx/effects/audio.py` | `get_device_index_by_name()` |
 | Config update + save | `ledfx/effects/audio.py` | `_update_device_config()`, `_persist_config()` |
 | API device selection | `ledfx/api/audio_devices.py` | `put()`, `get()` |
+| General config merge (stale name fix) | `ledfx/api/config.py` | `update_config()` |
 | Input device enumeration | `ledfx/effects/audio.py` | `input_devices()` |
 | Device activation | `ledfx/effects/audio.py` | `_activate_inner()` |

--- a/docs/developer/dev_notes/audio-device-persistence-strategy.md
+++ b/docs/developer/dev_notes/audio-device-persistence-strategy.md
@@ -1,0 +1,444 @@
+# Audio Device Persistence Strategy
+
+**Date:** 2026-04-07
+**Status:** Strategy — not yet implemented
+**Scope:** `ledfx/effects/audio.py`, `ledfx/api/audio_devices.py`, `ledfx/config.py`
+
+---
+
+## Problem Statement
+
+The audio device is persisted in `config.json` as an integer index only:
+
+```json
+{
+    "audio": {
+        "audio_device": 17
+    }
+}
+```
+
+Device indices are assigned by PortAudio/sounddevice during enumeration and are **not stable** across sessions. If a USB device is plugged in, a Bluetooth device pairs, or a driver updates between LedFx sessions, the enumeration order can shift. The saved index `17` may now point to a completely different device.
+
+### Current Runtime Mitigation (Incomplete)
+
+During a **running session**, `AudioInputSource` tracks the active device by name in the class variable `_last_device_name`. When device hotplug events occur, `handle_device_list_change()` uses `get_device_index_by_name()` to find the device at its new index. This works well within a session.
+
+**The gap:** `_last_device_name` is a runtime-only class variable. It is **never persisted to `config.json`**. When LedFx exits and restarts, `_last_device_name` is `None`, so there is no name to match against. The system falls back to the raw integer index, which may now be wrong.
+
+### Failure Scenario
+
+1. User selects device `[17] Windows WASAPI: Speakers (Realtek) [Loopback]`
+2. Config saves `{"audio_device": 17}`
+3. LedFx exits
+4. User plugs in a USB audio interface (or a Bluetooth device auto-connects)
+5. On next enumeration, the USB device gets index 5, shifting everything above it up by 1
+6. Index `17` now points to `Windows WASAPI: Microphone (Realtek)` instead of the loopback
+7. LedFx starts, reads `audio_device: 17`, opens the wrong device
+8. User gets no audio visualization or hears unexpected input
+
+---
+
+## Strategy: Persist Device Name Alongside Index
+
+### Core Principle
+
+Store the device name string as the **primary** identifier and the index as a **hint/cache**. On startup, resolve name → index. The index is only used as a fast path when the name still matches.
+
+### 1. Config Schema Change
+
+Add an `audio_device_name` field to the audio config:
+
+```json
+{
+    "audio": {
+        "audio_device": 17,
+        "audio_device_name": "Windows WASAPI: Speakers (Realtek High Definition Audio) [Loopback]"
+    }
+}
+```
+
+The name format matches what `input_devices()` returns: `"{hostapi_name}: {device_name}"`. This is the same format already used by `_last_device_name` in the runtime tracking code (see `update_device_tracking()` in `_activate_inner()`).
+
+### 2. Startup Resolution Logic
+
+Add a new method or extend `device_index_validator()` with this resolution order:
+
+```
+1. If audio_device_name is set in config:
+   a. If audio_device index is valid AND its name matches audio_device_name → use index (fast path)
+   b. Else, search all input devices for audio_device_name using get_device_index_by_name()
+      - If found → use the new index, update audio_device in config
+      - If not found → fall through to step 2
+2. If audio_device index is valid (but no name match) → use index (legacy/fallback)
+3. Else → use default_device_index() (existing fallback logic)
+```
+
+### 3. Files to Modify
+
+#### `ledfx/effects/audio.py`
+
+**a. `AUDIO_CONFIG_SCHEMA` (line ~379)**
+Add `audio_device_name` as an optional string field:
+```python
+vol.Optional("audio_device_name", default=""): str,
+```
+
+**b. `device_index_validator()` (line ~243)**
+Expand to accept the full config dict (or create a new startup resolver) so it can read `audio_device_name` and perform name-based resolution before falling back to index validation.
+
+Currently:
+```python
+@staticmethod
+def device_index_validator(val):
+    if val in AudioInputSource.valid_device_indexes():
+        return val
+    else:
+        return AudioInputSource.default_device_index()
+```
+
+This validator only sees the integer value. The name-based resolution needs access to both `audio_device` and `audio_device_name`. Options:
+
+- **Option A (Recommended):** Add a class method `resolve_device_at_startup(config) -> int` that implements the resolution logic above. Call it from `update_config()` or `__init__()` after schema validation, before `activate()`. Keep the existing validator as a simple range check.
+
+- **Option B:** Use a voluptuous `All()` chain or custom validator that can access sibling config keys. This is more complex with voluptuous.
+
+**c. `_update_device_config()` (line ~126)**
+When updating the device index, also update the device name:
+```python
+def _update_device_config(self, device_idx):
+    self._config["audio_device"] = device_idx
+    # Also persist the device name for cross-session recovery
+    devices = self.input_devices()
+    if device_idx in devices:
+        self._config["audio_device_name"] = devices[device_idx]
+    # ... existing save logic
+```
+
+**d. `update_device_tracking()` inner function (line ~586)**
+Already sets `_last_device_name` at runtime. No change needed unless we want to also sync to config here (but `_update_device_config` covers this).
+
+**e. `update_config()` (line ~418)**
+After schema validation and before `activate()`, call the new startup resolver:
+```python
+def update_config(self, config):
+    if AudioInputSource._audio_stream_active:
+        self.deactivate()
+    self._config = self.AUDIO_CONFIG_SCHEMA.fget()(config)
+    # Resolve device by name if available (handles index drift across restarts)
+    self._resolve_device_from_name()
+    # ... rest of method
+```
+
+#### `ledfx/api/audio_devices.py`
+
+**a. `put()` handler (line ~40)**
+When the user selects a device via the API, persist the name alongside the index:
+```python
+new_config["audio_device"] = int(index)
+# Persist device name for cross-session recovery
+devices = AudioInputSource.input_devices()
+if index in devices:
+    new_config["audio_device_name"] = devices[index]
+```
+
+**b. `get()` handler**
+Optionally include `audio_device_name` in the response for UI display/debugging.
+
+#### `ledfx/config.py`
+
+**Config migration (line ~629)**
+The existing migration already handles legacy configs without `audio_device`. No new migration is strictly required since `audio_device_name` defaults to `""`, but consider adding a migration that populates `audio_device_name` if `audio_device` is set but `audio_device_name` is missing (best-effort: look up the name at migration time).
+
+### 4. New Method: `_resolve_device_from_name()`
+
+```python
+def _resolve_device_from_name(self):
+    """
+    Resolve the audio device by name from config.
+    Called at startup/config-update to handle index drift.
+    
+    Resolution order:
+    1. Name match at saved index (fast path, no drift)
+    2. Name match at different index (drift detected, update index)
+    3. Saved index still valid but name doesn't match (use index, warn)
+    4. Default device (nothing valid)
+    """
+    saved_name = self._config.get("audio_device_name", "")
+    saved_idx = self._config.get("audio_device")
+    
+    if not saved_name:
+        # No name stored (legacy config or first run) — use index as-is
+        return
+    
+    devices = self.input_devices()
+    
+    # Fast path: saved index exists and name matches
+    if saved_idx in devices and devices[saved_idx] == saved_name:
+        _LOGGER.debug(
+            "Audio device '%s' confirmed at index %s",
+            saved_name, saved_idx
+        )
+        return
+    
+    # Name-based search (index has drifted)
+    found_idx = self.get_device_index_by_name(saved_name)
+    
+    if found_idx != -1:
+        _LOGGER.info(
+            "Audio device '%s' moved from index %s to %s (enumeration changed)",
+            saved_name, saved_idx, found_idx
+        )
+        self._config["audio_device"] = found_idx
+        # Persist the corrected index
+        if hasattr(self, "_ledfx") and self._ledfx:
+            self._ledfx.config["audio"] = self._config
+            save_config(
+                config=self._ledfx.config,
+                config_dir=self._ledfx.config_dir,
+            )
+        return
+    
+    # Device not found by name at all
+    _LOGGER.warning(
+        "Saved audio device '%s' not found in current device list. "
+        "Falling back to index %s if valid, else default.",
+        saved_name, saved_idx
+    )
+    # Clear the stale name so we don't keep warning
+    self._config["audio_device_name"] = ""
+```
+
+### 5. Edge Cases
+
+| Scenario | Behavior |
+|---|---|
+| Legacy config (no `audio_device_name`) | Falls through to existing index-based logic. No regression. |
+| Device removed permanently | Name search fails, index check fails, falls back to default. Name cleared from config. |
+| Device name truncated by PortAudio | `get_device_index_by_name()` already handles partial matching. |
+| Multiple devices with similar names | Exact match preferred, then longest partial match (existing logic). |
+| User manually edits config.json | Works as long as name string matches `input_devices()` format. |
+| WEB AUDIO / SENDSPIN devices | These also use the `"{hostapi}: {name}"` format via `input_devices()`. No special handling needed. |
+| Config saved on Windows, loaded on Linux | Host API names differ (`Windows WASAPI` vs `ALSA`). Name won't match, falls back to default. This is expected and correct. |
+
+### 6. Migration Path — Legacy Upgrade Strategy
+
+This is a **non-breaking, additive change**. Users upgrading from any prior version will have configs with only `audio_device` (integer index) and no `audio_device_name` field.
+
+#### Upgrade Flow (Seamless)
+
+1. User upgrades LedFx to the version with this feature
+2. LedFx starts, loads `config.json` with `{"audio": {"audio_device": 17}}`
+3. Schema validation adds `audio_device_name` with default `""`
+4. `_resolve_device_from_name()` sees empty name → **skips name resolution entirely**
+5. Existing `device_index_validator` handles index `17` as before — **no change in behavior**
+6. Device activates at index `17` (taken at face value)
+7. `_activate_inner()` calls `update_device_tracking()` → sets `_last_device_name` at runtime
+8. **Key step:** `_update_device_config()` (or post-activation hook) writes the device name back:
+   ```json
+   {"audio": {"audio_device": 17, "audio_device_name": "Windows WASAPI: Speakers (Realtek) [Loopback]"}}
+   ```
+9. Config is saved to disk — **config is now upgraded for all future sessions**
+10. From the next restart onward, name-based resolution is active
+
+#### Critical Design Constraint
+
+The name must be persisted on the **first successful activation** after upgrade, not only on user-initiated device changes via the API. This means `_update_device_config()` or `update_device_tracking()` must write `audio_device_name` to config and save on every activation where the name is missing or has changed. Without this, a user who never touches the audio settings would never get their config upgraded.
+
+#### Implementation Detail
+
+Add to the end of `_activate_inner()`, after `update_device_tracking()` succeeds:
+
+```python
+# Ensure device name is persisted for cross-session recovery
+# This also handles seamless upgrade from legacy configs (index-only)
+with AudioInputSource._class_lock:
+    current_name = AudioInputSource._last_device_name
+if current_name and self._config.get("audio_device_name", "") != current_name:
+    self._config["audio_device_name"] = current_name
+    if hasattr(self, "_ledfx") and self._ledfx:
+        self._ledfx.config["audio"] = self._config
+        save_config(
+            config=self._ledfx.config,
+            config_dir=self._ledfx.config_dir,
+        )
+        _LOGGER.info(
+            "Persisted audio device name '%s' for cross-session recovery",
+            current_name,
+        )
+```
+
+#### Summary
+
+- `audio_device_name` defaults to `""` — existing configs load without error
+- Legacy index is trusted at face value on first boot after upgrade
+- Name is auto-populated on first successful activation
+- The integer `audio_device` field is never removed — it remains the fast path and fallback
+- Zero user interaction required for the upgrade
+
+### 7. Testing Strategy
+
+All tests should live in `tests/test_audio_device_persistence.py`. Tests mock `AudioInputSource.input_devices()` and `AudioInputSource.default_device_index()` to simulate different device enumeration states without requiring real audio hardware.
+
+#### 7.1 Mock Fixtures
+
+```python
+# Standard device list — the "before" state
+DEVICES_BEFORE = {
+    0: "Windows WASAPI: Microphone (Realtek High Definition Audio)",
+    5: "Windows WASAPI: Stereo Mix (Realtek High Definition Audio)",
+    17: "Windows WASAPI: Speakers (Realtek High Definition Audio) [Loopback]",
+    22: "Windows WASAPI: Headset (Bluetooth)",
+}
+
+# After a USB device is plugged in — indices shift
+DEVICES_AFTER_USB_ADDED = {
+    0: "Windows WASAPI: Microphone (Realtek High Definition Audio)",
+    3: "Windows WASAPI: USB Audio Interface",
+    5: "Windows WASAPI: Stereo Mix (Realtek High Definition Audio)",
+    18: "Windows WASAPI: Speakers (Realtek High Definition Audio) [Loopback]",
+    23: "Windows WASAPI: Headset (Bluetooth)",
+}
+
+# After device is removed entirely
+DEVICES_AFTER_REMOVAL = {
+    0: "Windows WASAPI: Microphone (Realtek High Definition Audio)",
+    5: "Windows WASAPI: Stereo Mix (Realtek High Definition Audio)",
+    22: "Windows WASAPI: Headset (Bluetooth)",
+}
+
+# Truncated names (PortAudio sometimes truncates long names)
+DEVICES_TRUNCATED = {
+    0: "Windows WASAPI: Microphone (Realtek High Def",
+    17: "Windows WASAPI: Speakers (Realtek High Def",
+}
+
+# Multiple similar names
+DEVICES_SIMILAR_NAMES = {
+    0: "Windows WASAPI: Microphone",
+    1: "Windows WASAPI: Microphone (Realtek)",
+    2: "Windows WASAPI: Microphone (Realtek High Definition Audio)",
+}
+```
+
+#### 7.2 Unit Tests — `_resolve_device_from_name()`
+
+These test the core resolution logic in isolation.
+
+| # | Test Name | Config Input | Mock Devices | Expected Result |
+|---|---|---|---|---|
+| 1 | `test_resolve_name_matches_at_saved_index` | `idx=17, name="...Speakers...Loopback"` | `DEVICES_BEFORE` | Index stays `17`, no config save |
+| 2 | `test_resolve_name_found_at_different_index` | `idx=17, name="...Speakers...Loopback"` | `DEVICES_AFTER_USB_ADDED` | Index updated to `18`, config saved |
+| 3 | `test_resolve_name_not_found_device_removed` | `idx=17, name="...Speakers...Loopback"` | `DEVICES_AFTER_REMOVAL` | Falls to default, name cleared from config |
+| 4 | `test_resolve_empty_name_skips_resolution` | `idx=17, name=""` | `DEVICES_BEFORE` | Index stays `17`, no name search performed |
+| 5 | `test_resolve_no_name_key_skips_resolution` | `idx=17` (no name key) | `DEVICES_BEFORE` | Index stays `17` (schema default `""` applied) |
+| 6 | `test_resolve_partial_match_truncated_name` | `idx=17, name="...Speakers (Realtek High Def"` | `DEVICES_BEFORE` | Partial match finds index `17` via `get_device_index_by_name` |
+| 7 | `test_resolve_prefers_exact_over_partial` | `idx=2, name="...Microphone (Realtek)"` | `DEVICES_SIMILAR_NAMES` | Exact match at `1`, not partial at `2` |
+| 8 | `test_resolve_saved_index_invalid_name_found` | `idx=99, name="...Speakers...Loopback"` | `DEVICES_BEFORE` | Name search finds `17`, updates index |
+| 9 | `test_resolve_saved_index_invalid_name_not_found` | `idx=99, name="Nonexistent Device"` | `DEVICES_BEFORE` | Falls to default device |
+| 10 | `test_resolve_index_valid_but_wrong_device` | `idx=17, name="...Speakers...Loopback"` | `{17: "...Microphone...", 18: "...Speakers...Loopback"}` | Name mismatch at `17`, found at `18`, updates index |
+
+#### 7.3 Unit Tests — Legacy Upgrade Path
+
+These verify that upgrading from index-only configs works seamlessly.
+
+| # | Test Name | Scenario | Expected Result |
+|---|---|---|---|
+| 11 | `test_legacy_config_no_name_field` | Config `{"audio_device": 17}` loaded through schema | `audio_device_name` defaults to `""`, index `17` used as-is |
+| 12 | `test_legacy_config_empty_audio_dict` | Config `{}` loaded through schema | Default device index chosen, no name resolution attempted |
+| 13 | `test_legacy_upgrade_name_persisted_on_activation` | Config `{"audio_device": 17}`, activate succeeds | After activation, config contains `audio_device_name` matching device at index `17` |
+| 14 | `test_legacy_upgrade_name_not_persisted_on_activation_failure` | Config `{"audio_device": 17}`, activate fails | `audio_device_name` remains `""` — don't persist a name for a device we couldn't open |
+| 15 | `test_legacy_upgrade_second_startup_uses_name` | Simulate: first boot persists name, second boot with shifted indices | Second boot resolves by name to new index |
+
+#### 7.4 Unit Tests — API Endpoint
+
+These verify the REST API correctly persists both fields.
+
+| # | Test Name | Scenario | Expected Result |
+|---|---|---|---|
+| 16 | `test_api_put_persists_name_and_index` | PUT `{"audio_device": 5}` | Config saved with both `audio_device: 5` and `audio_device_name: "..."` |
+| 17 | `test_api_put_invalid_index_rejected` | PUT `{"audio_device": 999}` | Error response, config unchanged |
+| 18 | `test_api_get_returns_name` | GET with config containing name | Response includes `active_device_index` and `active_device_name` |
+
+#### 7.5 Unit Tests — `_update_device_config()`
+
+These verify the config save helper persists both fields.
+
+| # | Test Name | Scenario | Expected Result |
+|---|---|---|---|
+| 19 | `test_update_device_config_writes_name` | Call with valid `device_idx` | Both `audio_device` and `audio_device_name` set in config |
+| 20 | `test_update_device_config_clears_name_for_invalid` | Call with `device_idx` not in `input_devices()` | `audio_device` set, `audio_device_name` cleared or unchanged |
+| 21 | `test_update_device_config_saves_to_disk` | Call with `_ledfx` attached | `save_config()` called with updated config |
+
+#### 7.6 Unit Tests — `handle_device_list_change()` Integration
+
+These verify the runtime hotplug recovery still works correctly with the new name field.
+
+| # | Test Name | Scenario | Expected Result |
+|---|---|---|---|
+| 22 | `test_hotplug_recovery_uses_runtime_name` | Device shifts during session | `_last_device_name` used to find new index, config updated with both fields |
+| 23 | `test_hotplug_device_removed_clears_name` | Device disappears during session | Falls to default, `_last_device_name` cleared, config name cleared |
+| 24 | `test_hotplug_no_active_stream_no_crash` | Device change event with no active stream | No error, device list refreshed only |
+
+#### 7.7 Unit Tests — `get_device_index_by_name()` Edge Cases
+
+These validate the name matching logic that underpins resolution.
+
+| # | Test Name | Scenario | Expected Result |
+|---|---|---|---|
+| 25 | `test_exact_match_preferred` | Exact name exists in device list | Returns exact match index |
+| 26 | `test_partial_match_stored_name_is_substring` | Stored name is truncated substring | Returns best (longest) partial match |
+| 27 | `test_no_match_returns_negative_one` | Name doesn't match anything | Returns `-1` |
+| 28 | `test_empty_string_returns_negative_one` | Empty string passed | Returns `-1` (no false matches) |
+| 29 | `test_case_sensitive_matching` | Name differs only in case | Verify current behavior (case-sensitive) |
+| 30 | `test_partial_match_avoids_false_positive` | `"Microphone"` should not match `"Microphone (Realtek)"` when stored name is shorter | Only matches when stored name is substring of device name, not reverse |
+
+#### 7.8 Regression Guard Tests
+
+These ensure the new code doesn't break existing behavior.
+
+| # | Test Name | What It Guards |
+|---|---|---|
+| 31 | `test_schema_accepts_legacy_config_without_name` | Schema validation doesn't reject old configs |
+| 32 | `test_schema_allows_extra_keys` | `ALLOW_EXTRA` still works (other audio config fields not lost) |
+| 33 | `test_device_index_validator_unchanged_behavior` | Validator still returns default for invalid indices |
+| 34 | `test_activate_still_works_without_name` | Full activation path works with `audio_device_name=""` |
+| 35 | `test_config_roundtrip_preserves_all_fields` | Save → load cycle preserves both `audio_device` and `audio_device_name` |
+| 36 | `test_web_audio_device_name_persisted` | WEB AUDIO virtual devices also get name persisted |
+| 37 | `test_sendspin_device_name_persisted` | SENDSPIN devices also get name persisted |
+
+#### 7.9 Test Implementation Notes
+
+- **Mocking pattern:** Use `@patch.object(AudioInputSource, 'input_devices', return_value=DEVICES_BEFORE)` and `@patch.object(AudioInputSource, 'default_device_index', return_value=0)` to control device enumeration without real hardware.
+- **Config save assertion:** Mock `save_config` and assert it was called with expected config dict. Use `@patch('ledfx.effects.audio.save_config')` or a mock `_ledfx` object with mock `config` and `config_dir`.
+- **Activation mocking:** For tests that touch `activate()`, mock `open_audio_stream` to prevent actual PortAudio calls. Alternatively, test `_resolve_device_from_name()` in isolation (preferred).
+- **Fixture for mock ledfx:** Create a simple mock with `config` dict and `config_dir` string to satisfy `_update_device_config()` requirements.
+- **No real audio in CI:** All tests must pass without any audio hardware. Never call `sd.query_devices()` in tests.
+
+### 8. Implementation Order
+
+1. Add `audio_device_name` to `AUDIO_CONFIG_SCHEMA`
+2. Add `_resolve_device_from_name()` method to `AudioInputSource`
+3. Call resolver from `update_config()` before `activate()`
+4. Update `_update_device_config()` to persist name
+5. Update `audio_devices.py` PUT handler to persist name
+6. Write tests
+7. Manual verification with real device enumeration changes
+
+---
+
+## Appendix: Current Code References
+
+| Component | File | Key Lines |
+|---|---|---|
+| Config schema | `ledfx/effects/audio.py` | ~379 (`AUDIO_CONFIG_SCHEMA`) |
+| Index validator | `ledfx/effects/audio.py` | ~243 (`device_index_validator`) |
+| Runtime name tracking | `ledfx/effects/audio.py` | ~45 (`_last_device_name`), ~586 (`update_device_tracking`) |
+| Device list change handler | `ledfx/effects/audio.py` | ~140 (`handle_device_list_change`) |
+| Name-based search | `ledfx/effects/audio.py` | ~771 (`get_device_index_by_name`) |
+| Config update + save | `ledfx/effects/audio.py` | ~126 (`_update_device_config`) |
+| API device selection | `ledfx/api/audio_devices.py` | ~40 (`put`) |
+| Audio config in core schema | `ledfx/config.py` | ~145 |
+| Audio init in core startup | `ledfx/core.py` | ~500 |
+| Input device enumeration | `ledfx/effects/audio.py` | ~365 (`input_devices`) |
+| Device activation | `ledfx/effects/audio.py` | ~456 (`_activate_inner`) |

--- a/docs/developer/dev_notes/audio-device-persistence-strategy.md
+++ b/docs/developer/dev_notes/audio-device-persistence-strategy.md
@@ -1,7 +1,7 @@
 # Audio Device Persistence Strategy
 
 **Date:** 2026-04-07
-**Status:** Strategy — not yet implemented
+**Status:** Strategy — implemented
 **Scope:** `ledfx/effects/audio.py`, `ledfx/api/audio_devices.py`, `ledfx/config.py`
 
 ---
@@ -207,6 +207,20 @@ def _resolve_device_from_name(self):
     )
     # Clear the stale name so we don't keep warning
     self._config["audio_device_name"] = ""
+    # Persist the cleared name so the stale value doesn't reappear on restart
+    if hasattr(self, "_ledfx") and self._ledfx:
+        self._ledfx.config["audio"] = self._config
+        try:
+            save_config(
+                config=self._ledfx.config,
+                config_dir=self._ledfx.config_dir,
+            )
+        except Exception as e:
+            _LOGGER.warning(
+                "Failed to persist cleared audio_device_name: %s. "
+                "Stale name may reappear on next startup.",
+                e,
+            )
 ```
 
 ### 5. Edge Cases
@@ -391,7 +405,7 @@ These validate the name matching logic that underpins resolution.
 | 27 | `test_no_match_returns_negative_one` | Name doesn't match anything | Returns `-1` |
 | 28 | `test_empty_string_returns_negative_one` | Empty string passed | Returns `-1` (no false matches) |
 | 29 | `test_case_sensitive_matching` | Name differs only in case | Verify current behavior (case-sensitive) |
-| 30 | `test_partial_match_avoids_false_positive` | `"Microphone"` should not match `"Microphone (Realtek)"` when stored name is shorter | Only matches when stored name is substring of device name, not reverse |
+| 30 | `test_partial_match_avoids_false_positive` | Stored `"Microphone"` has exact match at index 0 plus longer partial matches at indices 1, 2 | Exact match at index 0 is returned, not a longer partial match (e.g., `"Microphone (Realtek)"`) |
 
 #### 7.8 Regression Guard Tests
 

--- a/docs/developer/dev_notes/audio-device-persistence-strategy.md
+++ b/docs/developer/dev_notes/audio-device-persistence-strategy.md
@@ -68,160 +68,52 @@ Add a new method or extend `device_index_validator()` with this resolution order
 1. If audio_device_name is set in config:
    a. If audio_device index is valid AND its name matches audio_device_name → use index (fast path)
    b. Else, search all input devices for audio_device_name using get_device_index_by_name()
-      - If found → use the new index, update audio_device in config
-      - If not found → fall through to step 2
-2. If audio_device index is valid (but no name match) → use index (legacy/fallback)
-3. Else → use default_device_index() (existing fallback logic)
+      - If found → use the new index, update audio_device in config, persist
+      - If not found → reset audio_device to default_device_index(), clear
+        audio_device_name and runtime tracking (_last_device_name, _last_active),
+        persist
+2. If audio_device_name is empty (legacy config or first run) → use audio_device index as-is
+3. Downstream validator / _activate_inner() handles any remaining invalid indices
 ```
 
-### 3. Files to Modify
+### 3. Files Modified
 
 #### `ledfx/effects/audio.py`
 
-**a. `AUDIO_CONFIG_SCHEMA` (line ~379)**
-Add `audio_device_name` as an optional string field:
-```python
-vol.Optional("audio_device_name", default=""): str,
-```
-
-**b. `device_index_validator()` (line ~243)**
-Expand to accept the full config dict (or create a new startup resolver) so it can read `audio_device_name` and perform name-based resolution before falling back to index validation.
-
-Currently:
-```python
-@staticmethod
-def device_index_validator(val):
-    if val in AudioInputSource.valid_device_indexes():
-        return val
-    else:
-        return AudioInputSource.default_device_index()
-```
-
-This validator only sees the integer value. The name-based resolution needs access to both `audio_device` and `audio_device_name`. Options:
-
-- **Option A (Recommended):** Add a class method `resolve_device_at_startup(config) -> int` that implements the resolution logic above. Call it from `update_config()` or `__init__()` after schema validation, before `activate()`. Keep the existing validator as a simple range check.
-
-- **Option B:** Use a voluptuous `All()` chain or custom validator that can access sibling config keys. This is more complex with voluptuous.
-
-**c. `_update_device_config()` (line ~126)**
-When updating the device index, also update the device name:
-```python
-def _update_device_config(self, device_idx):
-    self._config["audio_device"] = device_idx
-    # Also persist the device name for cross-session recovery
-    devices = self.input_devices()
-    if device_idx in devices:
-        self._config["audio_device_name"] = devices[device_idx]
-    # ... existing save logic
-```
-
-**d. `update_device_tracking()` inner function (line ~586)**
-Already sets `_last_device_name` at runtime. No change needed unless we want to also sync to config here (but `_update_device_config` covers this).
-
-**e. `update_config()` (line ~418)**
-After schema validation and before `activate()`, call the new startup resolver:
-```python
-def update_config(self, config):
-    if AudioInputSource._audio_stream_active:
-        self.deactivate()
-    self._config = self.AUDIO_CONFIG_SCHEMA.fget()(config)
-    # Resolve device by name if available (handles index drift across restarts)
-    self._resolve_device_from_name()
-    # ... rest of method
-```
+- **`AUDIO_CONFIG_SCHEMA`** — Added `audio_device_name` as an optional string field (default `""`).
+- **`_resolve_device_from_name()`** — New method implementing the resolution algorithm from §2. Called from `update_config()` after schema validation, before `activate()`.
+- **`_update_device_config()`** — Updated to persist both `audio_device` (index) and `audio_device_name` (string) together, then save to disk.
+- **`update_device_tracking()`** (inner function in `_activate_inner()`) — Unchanged; still sets `_last_device_name` at runtime.
+- **`persist_device_name_if_needed()`** (inner function in `_activate_inner()`) — Post-activation hook that syncs both config keys (`audio_device`, `audio_device_name`) to match the actually-opened device. Handles legacy upgrade (first activation after upgrade auto-populates name) and fallback-open scenarios (configured device fails, default opens instead).
+- **`update_config()`** — Calls `_resolve_device_from_name()` after schema validation, before `activate()`.
+- **`_persist_config()`** — Helper that syncs `self._config` to central config and writes to disk. Used by all persistence paths.
 
 #### `ledfx/api/audio_devices.py`
 
-**a. `put()` handler (line ~40)**
-When the user selects a device via the API, persist the name alongside the index:
-```python
-new_config["audio_device"] = int(index)
-# Persist device name for cross-session recovery
-devices = AudioInputSource.input_devices()
-if index in devices:
-    new_config["audio_device_name"] = devices[index]
-```
-
-**b. `get()` handler**
-Optionally include `audio_device_name` in the response for UI display/debugging.
+- **PUT handler** — Persists `audio_device_name` alongside `audio_device` when the user selects a device via the API.
+- **GET handler** — Returns `active_device_name` in the response alongside `active_device_index`.
 
 #### `ledfx/config.py`
 
-**Config migration (line ~629)**
-The existing migration already handles legacy configs without `audio_device`. No new migration is strictly required since `audio_device_name` defaults to `""`, but consider adding a migration that populates `audio_device_name` if `audio_device` is set but `audio_device_name` is missing (best-effort: look up the name at migration time).
+No new migration required. `audio_device_name` defaults to `""` via the schema, so legacy configs load without error.
 
-### 4. New Method: `_resolve_device_from_name()`
+### 4. `_resolve_device_from_name()` Algorithm
 
-```python
-def _resolve_device_from_name(self):
-    """
-    Resolve the audio device by name from config.
-    Called at startup/config-update to handle index drift.
+See `ledfx/effects/audio.py` for the definitive implementation.
 
-    Resolution order:
-    1. Name match at saved index (fast path, no drift)
-    2. Name match at different index (drift detected, update index)
-    3. Saved index still valid but name doesn't match (use index, warn)
-    4. Default device (nothing valid)
-    """
-    saved_name = self._config.get("audio_device_name", "")
-    saved_idx = self._config.get("audio_device")
+Called from `update_config()` after schema validation, before `activate()`.
 
-    if not saved_name:
-        # No name stored (legacy config or first run) — use index as-is
-        return
+**Resolution order:**
 
-    devices = self.input_devices()
-
-    # Fast path: saved index exists and name matches
-    if saved_idx in devices and devices[saved_idx] == saved_name:
-        _LOGGER.debug(
-            "Audio device '%s' confirmed at index %s",
-            saved_name, saved_idx
-        )
-        return
-
-    # Name-based search (index has drifted)
-    found_idx = self.get_device_index_by_name(saved_name)
-
-    if found_idx != -1:
-        _LOGGER.info(
-            "Audio device '%s' moved from index %s to %s (enumeration changed)",
-            saved_name, saved_idx, found_idx
-        )
-        self._config["audio_device"] = found_idx
-        # Persist the corrected index
-        if hasattr(self, "_ledfx") and self._ledfx:
-            self._ledfx.config["audio"] = self._config
-            save_config(
-                config=self._ledfx.config,
-                config_dir=self._ledfx.config_dir,
-            )
-        return
-
-    # Device not found by name at all
-    _LOGGER.warning(
-        "Saved audio device '%s' not found in current device list. "
-        "Falling back to index %s if valid, else default.",
-        saved_name, saved_idx
-    )
-    # Clear the stale name so we don't keep warning
-    self._config["audio_device_name"] = ""
-    # Persist the cleared name so the stale value doesn't reappear on restart
-    if hasattr(self, "_ledfx") and self._ledfx:
-        self._ledfx.config["audio"] = self._config
-        try:
-            save_config(
-                config=self._ledfx.config,
-                config_dir=self._ledfx.config_dir,
-            )
-        except Exception as e:
-            _LOGGER.warning(
-                "Failed to persist cleared audio_device_name: %s. "
-                "Stale name may reappear on next startup.",
-                e,
-            )
-```
+1. If `audio_device_name` is empty → return immediately (legacy/first-run path)
+2. If the saved index exists in the current device list **and** its name matches → return (fast path, no drift)
+3. Search all devices by name via `get_device_index_by_name()` (handles exact + partial/truncated matching):
+   - If found → update `audio_device` to the new index, persist
+4. Device not found at all:
+   - Reset `audio_device` to `default_device_index()`
+   - Clear `audio_device_name`
+   - Clear runtime tracking (`_last_device_name`, `_last_active`) so hotplug won't attempt recovery to the gone device
+   - Persist
 
 ### 5. Edge Cases
 
@@ -248,39 +140,28 @@ This is a **non-breaking, additive change**. Users upgrading from any prior vers
 5. Existing `device_index_validator` handles index `17` as before — **no change in behavior**
 6. Device activates at index `17` (taken at face value)
 7. `_activate_inner()` calls `update_device_tracking()` → sets `_last_device_name` at runtime
-8. **Key step:** `_update_device_config()` (or post-activation hook) writes the device name back:
-   ```json
-   {"audio": {"audio_device": 17, "audio_device_name": "Windows WASAPI: Speakers (Realtek) [Loopback]"}}
-   ```
+8. **Key step:** `persist_device_name_if_needed()` detects the name is missing and writes both keys back to config (e.g. `audio_device: 17` + `audio_device_name: "Windows WASAPI: Speakers (Realtek) [Loopback]"`)
 9. Config is saved to disk — **config is now upgraded for all future sessions**
 10. From the next restart onward, name-based resolution is active
 
 #### Critical Design Constraint
 
-The name must be persisted on the **first successful activation** after upgrade, not only on user-initiated device changes via the API. This means `_update_device_config()` or `update_device_tracking()` must write `audio_device_name` to config and save on every activation where the name is missing or has changed. Without this, a user who never touches the audio settings would never get their config upgraded.
+The name must be persisted on the **first successful activation** after upgrade, not only on user-initiated device changes via the API. The `persist_device_name_if_needed()` inner function in `_activate_inner()` handles this — it runs after every successful device open and syncs both config keys if the actual device differs from what's in config. Without this, a user who never touches the audio settings would never get their config upgraded.
 
-#### Implementation Detail
+#### `persist_device_name_if_needed()` Algorithm
 
-Add to the end of `_activate_inner()`, after `update_device_tracking()` succeeds:
+See `ledfx/effects/audio.py` `_activate_inner()` for the definitive implementation.
 
-```python
-# Ensure device name is persisted for cross-session recovery
-# This also handles seamless upgrade from legacy configs (index-only)
-with AudioInputSource._class_lock:
-    current_name = AudioInputSource._last_device_name
-if current_name and self._config.get("audio_device_name", "") != current_name:
-    self._config["audio_device_name"] = current_name
-    if hasattr(self, "_ledfx") and self._ledfx:
-        self._ledfx.config["audio"] = self._config
-        save_config(
-            config=self._ledfx.config,
-            config_dir=self._ledfx.config_dir,
-        )
-        _LOGGER.info(
-            "Persisted audio device name '%s' for cross-session recovery",
-            current_name,
-        )
-```
+Called after each successful `try_open_device()` in the startup sequence.
+
+1. Read `_last_device_name` and `_last_active` (the actually-opened device) under class lock
+2. If either is unset → return (nothing to persist)
+3. Compare against current config values for `audio_device_name` and `audio_device`
+4. If either differs → update **both** config keys to match the actual device, then persist
+5. This handles three cases:
+   - **Legacy upgrade:** config had no name, now it gets one
+   - **Fallback open:** configured device failed, default opened — config updated to reflect reality
+   - **Normal confirmation:** config already matches, no write needed
 
 #### Summary
 
@@ -296,44 +177,14 @@ All tests should live in `tests/test_audio_device_persistence.py`. Tests mock `A
 
 #### 7.1 Mock Fixtures
 
-```python
-# Standard device list — the "before" state
-DEVICES_BEFORE = {
-    0: "Windows WASAPI: Microphone (Realtek High Definition Audio)",
-    5: "Windows WASAPI: Stereo Mix (Realtek High Definition Audio)",
-    17: "Windows WASAPI: Speakers (Realtek High Definition Audio) [Loopback]",
-    22: "Windows WASAPI: Headset (Bluetooth)",
-}
+See `tests/test_audio_device_persistence.py` for the definitive fixture definitions.
 
-# After a USB device is plugged in — indices shift
-DEVICES_AFTER_USB_ADDED = {
-    0: "Windows WASAPI: Microphone (Realtek High Definition Audio)",
-    3: "Windows WASAPI: USB Audio Interface",
-    5: "Windows WASAPI: Stereo Mix (Realtek High Definition Audio)",
-    18: "Windows WASAPI: Speakers (Realtek High Definition Audio) [Loopback]",
-    23: "Windows WASAPI: Headset (Bluetooth)",
-}
-
-# After device is removed entirely
-DEVICES_AFTER_REMOVAL = {
-    0: "Windows WASAPI: Microphone (Realtek High Definition Audio)",
-    5: "Windows WASAPI: Stereo Mix (Realtek High Definition Audio)",
-    22: "Windows WASAPI: Headset (Bluetooth)",
-}
-
-# Truncated names (PortAudio sometimes truncates long names)
-DEVICES_TRUNCATED = {
-    0: "Windows WASAPI: Microphone (Realtek High Def",
-    17: "Windows WASAPI: Speakers (Realtek High Def",
-}
-
-# Multiple similar names
-DEVICES_SIMILAR_NAMES = {
-    0: "Windows WASAPI: Microphone",
-    1: "Windows WASAPI: Microphone (Realtek)",
-    2: "Windows WASAPI: Microphone (Realtek High Definition Audio)",
-}
-```
+Tests use mock device dictionaries keyed by index with `"{hostapi}: {name}"` string values, simulating:
+- **DEVICES_BEFORE** — Standard device list (baseline state)
+- **DEVICES_AFTER_USB_ADDED** — USB device inserted, indices shifted upward
+- **DEVICES_AFTER_REMOVAL** — Target device removed entirely
+- **DEVICES_TRUNCATED** — PortAudio-truncated long device names
+- **DEVICES_SIMILAR_NAMES** — Multiple devices with overlapping name prefixes
 
 #### 7.2 Unit Tests — `_resolve_device_from_name()`
 
@@ -343,13 +194,13 @@ These test the core resolution logic in isolation.
 |---|---|---|---|---|
 | 1 | `test_resolve_name_matches_at_saved_index` | `idx=17, name="...Speakers...Loopback"` | `DEVICES_BEFORE` | Index stays `17`, no config save |
 | 2 | `test_resolve_name_found_at_different_index` | `idx=17, name="...Speakers...Loopback"` | `DEVICES_AFTER_USB_ADDED` | Index updated to `18`, config saved |
-| 3 | `test_resolve_name_not_found_device_removed` | `idx=17, name="...Speakers...Loopback"` | `DEVICES_AFTER_REMOVAL` | Falls to default, name cleared from config |
+| 3 | `test_resolve_name_not_found_device_removed` | `idx=17, name="...Speakers...Loopback"` | `DEVICES_AFTER_REMOVAL` | Index reset to default, name cleared, runtime tracking (`_last_device_name`, `_last_active`) cleared |
 | 4 | `test_resolve_empty_name_skips_resolution` | `idx=17, name=""` | `DEVICES_BEFORE` | Index stays `17`, no name search performed |
 | 5 | `test_resolve_no_name_key_skips_resolution` | `idx=17` (no name key) | `DEVICES_BEFORE` | Index stays `17` (schema default `""` applied) |
 | 6 | `test_resolve_partial_match_truncated_name` | `idx=17, name="...Speakers (Realtek High Def"` | `DEVICES_BEFORE` | Partial match finds index `17` via `get_device_index_by_name` |
 | 7 | `test_resolve_prefers_exact_over_partial` | `idx=2, name="...Microphone (Realtek)"` | `DEVICES_SIMILAR_NAMES` | Exact match at `1`, not partial at `2` |
 | 8 | `test_resolve_saved_index_invalid_name_found` | `idx=99, name="...Speakers...Loopback"` | `DEVICES_BEFORE` | Name search finds `17`, updates index |
-| 9 | `test_resolve_saved_index_invalid_name_not_found` | `idx=99, name="Nonexistent Device"` | `DEVICES_BEFORE` | Falls to default device |
+| 9 | `test_resolve_saved_index_invalid_name_not_found` | `idx=99, name="Nonexistent Device"` | `DEVICES_BEFORE` | Index reset to default, name cleared |
 | 10 | `test_resolve_index_valid_but_wrong_device` | `idx=17, name="...Speakers...Loopback"` | `{17: "...Microphone...", 18: "...Speakers...Loopback"}` | Name mismatch at `17`, found at `18`, updates index |
 
 #### 7.3 Unit Tests — Legacy Upgrade Path
@@ -361,7 +212,7 @@ These verify that upgrading from index-only configs works seamlessly.
 | 11 | `test_legacy_config_no_name_field` | Config `{"audio_device": 17}` loaded through schema | `audio_device_name` defaults to `""`, index `17` used as-is |
 | 12 | `test_legacy_config_empty_audio_dict` | Config `{}` loaded through schema | Default device index chosen, no name resolution attempted |
 | 13 | `test_legacy_upgrade_name_persisted_on_activation` | Config `{"audio_device": 17}`, activate succeeds | After activation, config contains `audio_device_name` matching device at index `17` |
-| 14 | `test_legacy_upgrade_name_not_persisted_on_activation_failure` | Config `{"audio_device": 17}`, activate fails | `audio_device_name` remains `""` — don't persist a name for a device we couldn't open |
+| 14 | `test_legacy_upgrade_name_not_persisted_for_invalid_device` | Config `{"audio_device": 17}`, device not in device list | `audio_device_name` remains `""` — don't persist a name for a device we can't identify |
 | 15 | `test_legacy_upgrade_second_startup_uses_name` | Simulate: first boot persists name, second boot with shifted indices | Second boot resolves by name to new index |
 
 #### 7.4 Unit Tests — API Endpoint
@@ -450,18 +301,18 @@ These ensure the new code doesn't break existing behavior.
 
 ---
 
-## Appendix: Current Code References
+## Appendix: Code References
 
-| Component | File | Key Lines |
+| Component | File | Symbol |
 |---|---|---|
-| Config schema | `ledfx/effects/audio.py` | ~379 (`AUDIO_CONFIG_SCHEMA`) |
-| Index validator | `ledfx/effects/audio.py` | ~243 (`device_index_validator`) |
-| Runtime name tracking | `ledfx/effects/audio.py` | ~45 (`_last_device_name`), ~586 (`update_device_tracking`) |
-| Device list change handler | `ledfx/effects/audio.py` | ~140 (`handle_device_list_change`) |
-| Name-based search | `ledfx/effects/audio.py` | ~771 (`get_device_index_by_name`) |
-| Config update + save | `ledfx/effects/audio.py` | ~126 (`_update_device_config`) |
-| API device selection | `ledfx/api/audio_devices.py` | ~40 (`put`) |
-| Audio config in core schema | `ledfx/config.py` | ~145 |
-| Audio init in core startup | `ledfx/core.py` | ~500 |
-| Input device enumeration | `ledfx/effects/audio.py` | ~365 (`input_devices`) |
-| Device activation | `ledfx/effects/audio.py` | ~456 (`_activate_inner`) |
+| Config schema | `ledfx/effects/audio.py` | `AUDIO_CONFIG_SCHEMA` |
+| Startup resolver | `ledfx/effects/audio.py` | `_resolve_device_from_name()` |
+| Index validator | `ledfx/effects/audio.py` | `device_index_validator()` |
+| Runtime name tracking | `ledfx/effects/audio.py` | `_last_device_name`, `update_device_tracking()` |
+| Post-activation persistence | `ledfx/effects/audio.py` | `persist_device_name_if_needed()` (inner in `_activate_inner`) |
+| Device list change handler | `ledfx/effects/audio.py` | `handle_device_list_change()` |
+| Name-based search | `ledfx/effects/audio.py` | `get_device_index_by_name()` |
+| Config update + save | `ledfx/effects/audio.py` | `_update_device_config()`, `_persist_config()` |
+| API device selection | `ledfx/api/audio_devices.py` | `put()`, `get()` |
+| Input device enumeration | `ledfx/effects/audio.py` | `input_devices()` |
+| Device activation | `ledfx/effects/audio.py` | `_activate_inner()` |

--- a/ledfx/api/audio_devices.py
+++ b/ledfx/api/audio_devices.py
@@ -30,6 +30,9 @@ class AudioDevicesEndpoint(RestEndpoint):
 
         response = {}
         response["active_device_index"] = audio_config["audio_device"]
+        response["active_device_name"] = audio_config.get(
+            "audio_device_name", ""
+        )
         response["devices"] = (
             AudioInputSource.input_devices()
         )  # dict(enumerate(input_devices))
@@ -67,6 +70,10 @@ class AudioDevicesEndpoint(RestEndpoint):
         # Update and save config
         new_config = self._ledfx.config.get("audio", {})
         new_config["audio_device"] = int(index)
+        # Persist device name for cross-session recovery
+        devices = AudioInputSource.input_devices()
+        if index in devices:
+            new_config["audio_device_name"] = devices[index]
         self._ledfx.config["audio"] = new_config
 
         save_config(

--- a/ledfx/api/config.py
+++ b/ledfx/api/config.py
@@ -249,6 +249,12 @@ class ConfigEndpoint(RestEndpoint):
             config, CORE_CONFIG_SCHEMA, "core"
         )
 
+        # When user explicitly selects a new device via API, clear the stale
+        # device name so _resolve_device_from_name() uses the index as-is
+        # instead of name-matching back to the old device.
+        if "audio_device" in audio_config:
+            self._ledfx.config["audio"]["audio_device_name"] = ""
+
         self._ledfx.config["audio"].update(audio_config)
         self._ledfx.config["melbanks"].update(melbanks_config)
         self._ledfx.config.update(core_config)

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -258,9 +258,10 @@ class AudioInputSource:
     @staticmethod
     def device_index_validator(val):
         """
-        Validates device index in case the saved setting is no longer valid
+        Validates device index in case the saved setting is no longer valid.
+        Accepts None (schema default) and resolves to the default device.
         """
-        if val in AudioInputSource.valid_device_indexes():
+        if val is not None and val in AudioInputSource.valid_device_indexes():
             return val
         else:
             return AudioInputSource.default_device_index()
@@ -396,7 +397,6 @@ class AudioInputSource:
     @staticmethod
     @property
     def AUDIO_CONFIG_SCHEMA():
-        default_device_index = AudioInputSource.default_device_index()
         AudioInputSource.valid_device_indexes()
         AudioInputSource.input_devices()
         return vol.Schema(
@@ -408,7 +408,7 @@ class AudioInputSource:
                     vol.Coerce(float), vol.Range(min=0.0, max=1.0)
                 ),
                 vol.Optional(
-                    "audio_device", default=default_device_index
+                    "audio_device", default=None
                 ): AudioInputSource.device_index_validator,
                 vol.Optional("audio_device_name", default=""): str,
                 vol.Optional(
@@ -555,8 +555,8 @@ class AudioInputSource:
         input_devices = self.query_devices()
 
         hostapis = self.query_hostapis()
-        default_device = self.default_device_index()
-        if default_device is None:
+        valid_device_indexes = self.valid_device_indexes()
+        if not valid_device_indexes:
             # There are no valid audio input devices, so we can't activate the audio source.
             # We should never get here, as we check for devices on start-up.
             # This likely just captures if a device is removed after start-up.
@@ -565,7 +565,6 @@ class AudioInputSource:
             )
             self.deactivate()
             return
-        valid_device_indexes = self.valid_device_indexes()
         _LOGGER.debug("********************************************")
         _LOGGER.debug("Valid audio input devices:")
         for index in valid_device_indexes:
@@ -581,37 +580,33 @@ class AudioInputSource:
             )
         _LOGGER.debug("********************************************")
         device_idx = self._config["audio_device"]
-        _LOGGER.debug(
-            "Audio device selection: configured=%s, default=%s",
-            device_idx,
-            default_device,
-        )
 
-        if device_idx > max(valid_device_indexes):
-            _LOGGER.warning(
-                "Audio device index %s out of range (max valid: %s). "
-                "Falling back to default device index %s",
-                device_idx,
-                max(valid_device_indexes),
-                default_device,
-            )
-            device_idx = default_device
-
-        elif device_idx not in valid_device_indexes:
-            # Get device name safely (input_devices is a tuple, not dict)
-            try:
-                device_name = input_devices[device_idx].get(
-                    "name", f"index {device_idx}"
+        if device_idx not in valid_device_indexes:
+            # Configured device is invalid — resolve the default now
+            default_device = self.default_device_index()
+            if device_idx is not None and device_idx > max(valid_device_indexes):
+                _LOGGER.warning(
+                    "Audio device index %s out of range (max valid: %s). "
+                    "Falling back to default device index %s",
+                    device_idx,
+                    max(valid_device_indexes),
+                    default_device,
                 )
-            except (IndexError, KeyError):
-                device_name = f"index {device_idx}"
-            _LOGGER.warning(
-                "Audio device [%s] '%s' not in valid devices. "
-                "Falling back to default device index %s",
-                device_idx,
-                device_name,
-                default_device,
-            )
+            else:
+                # Get device name safely (input_devices is a tuple, not dict)
+                try:
+                    device_name = input_devices[device_idx].get(
+                        "name", f"index {device_idx}"
+                    )
+                except (IndexError, KeyError, TypeError):
+                    device_name = f"index {device_idx}"
+                _LOGGER.warning(
+                    "Audio device [%s] '%s' not in valid devices. "
+                    "Falling back to default device index %s",
+                    device_idx,
+                    device_name,
+                    default_device,
+                )
             device_idx = default_device
 
         # Setup a pre-emphasis filter to balance the input volume of lows to highs
@@ -821,8 +816,11 @@ class AudioInputSource:
             persist_device_name_if_needed()
             return
 
-        _LOGGER.info("Falling back to default device [%s]...", default_device)
-        if try_open_device(default_device, reinit=True):
+        fallback_device = self.default_device_index()
+        _LOGGER.info("Falling back to default device [%s]...", fallback_device)
+        if fallback_device is not None and try_open_device(
+            fallback_device, reinit=True
+        ):
             persist_device_name_if_needed()
             return
 

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -120,6 +120,25 @@ class AudioInputSource:
             with AudioInputSource._class_lock:
                 AudioInputSource._activating = False
 
+    def _persist_config(self):
+        """
+        Sync audio config to central config and persist to disk.
+        No-op when _ledfx is not available (e.g. in tests).
+        Returns True on success, False on failure or unavailable.
+        """
+        if not (hasattr(self, "_ledfx") and self._ledfx):
+            return False
+        self._ledfx.config["audio"] = self._config
+        try:
+            save_config(
+                config=self._ledfx.config,
+                config_dir=self._ledfx.config_dir,
+            )
+            return True
+        except Exception as e:
+            _LOGGER.warning("Failed to persist audio config: %s", e)
+            return False
+
     def _update_device_config(self, device_idx):
         """
         Update device index and name in both local and central configs.
@@ -134,14 +153,8 @@ class AudioInputSource:
             self._config["audio_device_name"] = devices[device_idx]
         else:
             self._config["audio_device_name"] = ""
-        # Sync the entire audio config to central config (matches update_config pattern)
-        if hasattr(self, "_ledfx") and self._ledfx:
-            self._ledfx.config["audio"] = self._config
-            # Persist to disk so recovered device survives restarts
-            save_config(
-                config=self._ledfx.config,
-                config_dir=self._ledfx.config_dir,
-            )
+        # Persist to disk so recovered device survives restarts
+        self._persist_config()
 
     def handle_device_list_change(self):
         """
@@ -464,12 +477,7 @@ class AudioInputSource:
             )
             self._config["audio_device"] = found_idx
             # Persist the corrected index
-            if hasattr(self, "_ledfx") and self._ledfx:
-                self._ledfx.config["audio"] = self._config
-                save_config(
-                    config=self._ledfx.config,
-                    config_dir=self._ledfx.config_dir,
-                )
+            self._persist_config()
             return
 
         # Device not found by name at all
@@ -481,6 +489,8 @@ class AudioInputSource:
         )
         # Clear the stale name so we don't keep warning
         self._config["audio_device_name"] = ""
+        # Persist the cleared name so the stale value doesn't reappear on restart
+        self._persist_config()
 
     def update_config(self, config):
         """Deactivate the audio, update the config, the reactivate"""
@@ -770,12 +780,7 @@ class AudioInputSource:
                 and self._config.get("audio_device_name", "") != current_name
             ):
                 self._config["audio_device_name"] = current_name
-                if hasattr(self, "_ledfx") and self._ledfx:
-                    self._ledfx.config["audio"] = self._config
-                    save_config(
-                        config=self._ledfx.config,
-                        config_dir=self._ledfx.config_dir,
-                    )
+                if self._persist_config():
                     _LOGGER.info(
                         "Persisted audio device name '%s' for cross-session recovery",
                         current_name,

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -584,7 +584,9 @@ class AudioInputSource:
         if device_idx not in valid_device_indexes:
             # Configured device is invalid — resolve the default now
             default_device = self.default_device_index()
-            if device_idx is not None and device_idx > max(valid_device_indexes):
+            if device_idx is not None and device_idx > max(
+                valid_device_indexes
+            ):
                 _LOGGER.warning(
                     "Audio device index %s out of range (max valid: %s). "
                     "Falling back to default device index %s",

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -480,16 +480,21 @@ class AudioInputSource:
             self._persist_config()
             return
 
-        # Device not found by name at all
+        # Device not found by name at all — reset to default so we don't
+        # silently open a different device that now occupies the stale index.
+        default_idx = self.default_device_index()
         _LOGGER.warning(
             "Saved audio device '%s' not found in current device list. "
-            "Falling back to index %s if valid, else default.",
+            "Resetting to default device (index %s).",
             saved_name,
-            saved_idx,
+            default_idx,
         )
-        # Clear the stale name so we don't keep warning
+        self._config["audio_device"] = default_idx
         self._config["audio_device_name"] = ""
-        # Persist the cleared name so the stale value doesn't reappear on restart
+        # Clear runtime tracking so hotplug won't try to recover the old device
+        with AudioInputSource._class_lock:
+            AudioInputSource._last_device_name = None
+            AudioInputSource._last_active = None
         self._persist_config()
 
     def update_config(self, config):

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -765,7 +765,10 @@ class AudioInputSource:
             """
             with AudioInputSource._class_lock:
                 current_name = AudioInputSource._last_device_name
-            if current_name and self._config.get("audio_device_name", "") != current_name:
+            if (
+                current_name
+                and self._config.get("audio_device_name", "") != current_name
+            ):
                 self._config["audio_device_name"] = current_name
                 if hasattr(self, "_ledfx") and self._ledfx:
                     self._ledfx.config["audio"] = self._config

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -122,12 +122,18 @@ class AudioInputSource:
 
     def _update_device_config(self, device_idx):
         """
-        Update device index in both local and central configs.
+        Update device index and name in both local and central configs.
 
         Args:
             device_idx: The device index to set, or None to clear
         """
         self._config["audio_device"] = device_idx
+        # Also persist the device name for cross-session recovery
+        devices = self.input_devices()
+        if device_idx is not None and device_idx in devices:
+            self._config["audio_device_name"] = devices[device_idx]
+        else:
+            self._config["audio_device_name"] = ""
         # Sync the entire audio config to central config (matches update_config pattern)
         if hasattr(self, "_ledfx") and self._ledfx:
             self._ledfx.config["audio"] = self._config
@@ -391,6 +397,7 @@ class AudioInputSource:
                 vol.Optional(
                     "audio_device", default=default_device_index
                 ): AudioInputSource.device_index_validator,
+                vol.Optional("audio_device_name", default=""): str,
                 vol.Optional(
                     "delay_ms",
                     default=0,
@@ -416,11 +423,72 @@ class AudioInputSource:
 
         self._ledfx.events.add_listener(shutdown_event, Event.LEDFX_SHUTDOWN)
 
+    def _resolve_device_from_name(self):
+        """
+        Resolve the audio device by name from config.
+        Called at startup/config-update to handle index drift across restarts.
+
+        Resolution order:
+        1. Name match at saved index (fast path, no drift)
+        2. Name match at different index (drift detected, update index)
+        3. No name stored (legacy config) — use index as-is
+        4. Name not found — fall through to existing index/default logic
+        """
+        saved_name = self._config.get("audio_device_name", "")
+        saved_idx = self._config.get("audio_device")
+
+        if not saved_name:
+            # No name stored (legacy config or first run) — use index as-is
+            return
+
+        devices = self.input_devices()
+
+        # Fast path: saved index exists and name matches
+        if saved_idx in devices and devices[saved_idx] == saved_name:
+            _LOGGER.debug(
+                "Audio device '%s' confirmed at index %s",
+                saved_name,
+                saved_idx,
+            )
+            return
+
+        # Name-based search (index has drifted)
+        found_idx = self.get_device_index_by_name(saved_name)
+
+        if found_idx != -1:
+            _LOGGER.info(
+                "Audio device '%s' moved from index %s to %s (enumeration changed)",
+                saved_name,
+                saved_idx,
+                found_idx,
+            )
+            self._config["audio_device"] = found_idx
+            # Persist the corrected index
+            if hasattr(self, "_ledfx") and self._ledfx:
+                self._ledfx.config["audio"] = self._config
+                save_config(
+                    config=self._ledfx.config,
+                    config_dir=self._ledfx.config_dir,
+                )
+            return
+
+        # Device not found by name at all
+        _LOGGER.warning(
+            "Saved audio device '%s' not found in current device list. "
+            "Falling back to index %s if valid, else default.",
+            saved_name,
+            saved_idx,
+        )
+        # Clear the stale name so we don't keep warning
+        self._config["audio_device_name"] = ""
+
     def update_config(self, config):
         """Deactivate the audio, update the config, the reactivate"""
         if AudioInputSource._audio_stream_active:
             self.deactivate()
         self._config = self.AUDIO_CONFIG_SCHEMA.fget()(config)
+        # Resolve device by name if available (handles index drift across restarts)
+        self._resolve_device_from_name()
 
         # cache up last active and lets see if it changes
         # Read _last_active with class lock protection
@@ -690,11 +758,32 @@ class AudioInputSource:
                 _LOGGER.warning("Audio device [%s] failed: %s", dev_idx, err)
                 return False
 
+        def persist_device_name_if_needed():
+            """
+            Ensure device name is persisted for cross-session recovery.
+            Also handles seamless upgrade from legacy configs (index-only).
+            """
+            with AudioInputSource._class_lock:
+                current_name = AudioInputSource._last_device_name
+            if current_name and self._config.get("audio_device_name", "") != current_name:
+                self._config["audio_device_name"] = current_name
+                if hasattr(self, "_ledfx") and self._ledfx:
+                    self._ledfx.config["audio"] = self._config
+                    save_config(
+                        config=self._ledfx.config,
+                        config_dir=self._ledfx.config_dir,
+                    )
+                    _LOGGER.info(
+                        "Persisted audio device name '%s' for cross-session recovery",
+                        current_name,
+                    )
+
         # Audio device startup sequence:
         # PortAudio's internal state may be poisoned at startup
         # (e.g. WDM-KS devices interfere during initial enumeration).
         # Recovery: try configured → reinit + retry configured → reinit + fallback
         if try_open_device(device_idx):
+            persist_device_name_if_needed()
             return
 
         _LOGGER.info(
@@ -705,10 +794,12 @@ class AudioInputSource:
                 "Audio device [%s] opened successfully after PortAudio reinit.",
                 device_idx,
             )
+            persist_device_name_if_needed()
             return
 
         _LOGGER.info("Falling back to default device [%s]...", default_device)
         if try_open_device(default_device, reinit=True):
+            persist_device_name_if_needed()
             return
 
         _LOGGER.warning(

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -770,20 +770,31 @@ class AudioInputSource:
 
         def persist_device_name_if_needed():
             """
-            Ensure device name is persisted for cross-session recovery.
-            Also handles seamless upgrade from legacy configs (index-only).
+            Ensure device index and name are persisted for cross-session
+            recovery.  Also handles seamless upgrade from legacy configs
+            (index-only) and fallback-open scenarios where the actual
+            device differs from the configured one.
             """
             with AudioInputSource._class_lock:
                 current_name = AudioInputSource._last_device_name
-            if (
-                current_name
-                and self._config.get("audio_device_name", "") != current_name
-            ):
+                current_idx = AudioInputSource._last_active
+
+            if not current_name or current_idx is None:
+                return
+
+            name_changed = (
+                self._config.get("audio_device_name", "") != current_name
+            )
+            idx_changed = self._config.get("audio_device") != current_idx
+
+            if name_changed or idx_changed:
+                self._config["audio_device"] = current_idx
                 self._config["audio_device_name"] = current_name
                 if self._persist_config():
                     _LOGGER.info(
-                        "Persisted audio device name '%s' for cross-session recovery",
+                        "Persisted audio device '%s' (index %s) for cross-session recovery",
                         current_name,
+                        current_idx,
                     )
 
         # Audio device startup sequence:

--- a/tests/test_audio_device_persistence.py
+++ b/tests/test_audio_device_persistence.py
@@ -1,0 +1,563 @@
+"""
+Tests for audio device name persistence and cross-session resolution.
+
+Strategy doc: docs/developer/dev_notes/audio-device-persistence-strategy.md
+"""
+
+import logging
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from ledfx.effects.audio import AudioInputSource
+
+_LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Mock device lists (from strategy doc §7.1)
+# ---------------------------------------------------------------------------
+
+DEVICES_BEFORE = {
+    0: "Windows WASAPI: Microphone (Realtek High Definition Audio)",
+    5: "Windows WASAPI: Stereo Mix (Realtek High Definition Audio)",
+    17: "Windows WASAPI: Speakers (Realtek High Definition Audio) [Loopback]",
+    22: "Windows WASAPI: Headset (Bluetooth)",
+}
+
+DEVICES_AFTER_USB_ADDED = {
+    0: "Windows WASAPI: Microphone (Realtek High Definition Audio)",
+    3: "Windows WASAPI: USB Audio Interface",
+    5: "Windows WASAPI: Stereo Mix (Realtek High Definition Audio)",
+    18: "Windows WASAPI: Speakers (Realtek High Definition Audio) [Loopback]",
+    23: "Windows WASAPI: Headset (Bluetooth)",
+}
+
+DEVICES_AFTER_REMOVAL = {
+    0: "Windows WASAPI: Microphone (Realtek High Definition Audio)",
+    5: "Windows WASAPI: Stereo Mix (Realtek High Definition Audio)",
+    22: "Windows WASAPI: Headset (Bluetooth)",
+}
+
+DEVICES_TRUNCATED = {
+    0: "Windows WASAPI: Microphone (Realtek High Def",
+    17: "Windows WASAPI: Speakers (Realtek High Def",
+}
+
+DEVICES_SIMILAR_NAMES = {
+    0: "Windows WASAPI: Microphone",
+    1: "Windows WASAPI: Microphone (Realtek)",
+    2: "Windows WASAPI: Microphone (Realtek High Definition Audio)",
+}
+
+DEVICES_INDEX_VALID_NAME_WRONG = {
+    17: "Windows WASAPI: Microphone (Realtek High Definition Audio)",
+    18: "Windows WASAPI: Speakers (Realtek High Definition Audio) [Loopback]",
+}
+
+LOOPBACK_NAME = "Windows WASAPI: Speakers (Realtek High Definition Audio) [Loopback]"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_mock_ledfx(audio_config=None):
+    """Create a mock LedFx instance with config and config_dir."""
+    mock = MagicMock()
+    mock.config = {"audio": audio_config or {}}
+    mock.config_dir = "/tmp/test_config"
+    return mock
+
+
+def make_ais(config=None, ledfx=None):
+    """
+    Create an AudioInputSource-like object with _config and _ledfx set
+    for testing _resolve_device_from_name() and _update_device_config()
+    without running __init__ (which requires a real ledfx + audio hardware).
+    """
+    ais = object.__new__(AudioInputSource)
+    ais._config = config or {}
+    ais._ledfx = ledfx
+    return ais
+
+
+# ===========================================================================
+# §7.2 — _resolve_device_from_name()
+# ===========================================================================
+
+
+class TestResolveDeviceFromName:
+    """Core resolution logic tests."""
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_resolve_name_matches_at_saved_index(self, mock_devices):
+        """#1: Name matches device at saved index — no change."""
+        config = {"audio_device": 17, "audio_device_name": LOOPBACK_NAME}
+        ais = make_ais(config=config)
+        ais._resolve_device_from_name()
+
+        assert ais._config["audio_device"] == 17
+        assert ais._config["audio_device_name"] == LOOPBACK_NAME
+
+    @patch("ledfx.effects.audio.save_config")
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_AFTER_USB_ADDED)
+    def test_resolve_name_found_at_different_index(self, mock_devices, mock_save):
+        """#2: Device shifted to new index — update index, persist."""
+        ledfx = make_mock_ledfx({"audio_device": 17, "audio_device_name": LOOPBACK_NAME})
+        config = {"audio_device": 17, "audio_device_name": LOOPBACK_NAME}
+        ais = make_ais(config=config, ledfx=ledfx)
+        ais._resolve_device_from_name()
+
+        assert ais._config["audio_device"] == 18
+        assert ais._config["audio_device_name"] == LOOPBACK_NAME
+        mock_save.assert_called_once()
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_AFTER_REMOVAL)
+    @patch.object(AudioInputSource, "default_device_index", return_value=0)
+    def test_resolve_name_not_found_device_removed(self, mock_default, mock_devices):
+        """#3: Device removed — name cleared, falls through to index/default logic."""
+        config = {"audio_device": 17, "audio_device_name": LOOPBACK_NAME}
+        ais = make_ais(config=config)
+        ais._resolve_device_from_name()
+
+        # Name should be cleared
+        assert ais._config["audio_device_name"] == ""
+        # Index unchanged by resolver — existing validator handles fallback
+        assert ais._config["audio_device"] == 17
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_resolve_empty_name_skips_resolution(self, mock_devices):
+        """#4: Empty name string — skip resolution, use index as-is."""
+        config = {"audio_device": 17, "audio_device_name": ""}
+        ais = make_ais(config=config)
+        ais._resolve_device_from_name()
+
+        assert ais._config["audio_device"] == 17
+        # input_devices should not even be called when name is empty
+        mock_devices.assert_not_called()
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_resolve_no_name_key_skips_resolution(self, mock_devices):
+        """#5: No audio_device_name key at all (schema default applies)."""
+        config = {"audio_device": 17}
+        ais = make_ais(config=config)
+        ais._resolve_device_from_name()
+
+        assert ais._config["audio_device"] == 17
+        mock_devices.assert_not_called()
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_resolve_partial_match_truncated_name(self, mock_devices):
+        """#6: Truncated name finds match via partial matching."""
+        truncated_name = "Windows WASAPI: Speakers (Realtek High Def"
+        config = {"audio_device": 99, "audio_device_name": truncated_name}
+        ais = make_ais(config=config)
+        ais._resolve_device_from_name()
+
+        # Should find index 17 via partial match
+        assert ais._config["audio_device"] == 17
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_SIMILAR_NAMES)
+    def test_resolve_prefers_exact_over_partial(self, mock_devices):
+        """#7: Exact match at index 1 preferred over partial at index 2."""
+        name = "Windows WASAPI: Microphone (Realtek)"
+        config = {"audio_device": 99, "audio_device_name": name}
+        ais = make_ais(config=config)
+        ais._resolve_device_from_name()
+
+        assert ais._config["audio_device"] == 1
+
+    @patch("ledfx.effects.audio.save_config")
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_resolve_saved_index_invalid_name_found(self, mock_devices, mock_save):
+        """#8: Saved index 99 invalid but name found at 17."""
+        ledfx = make_mock_ledfx()
+        config = {"audio_device": 99, "audio_device_name": LOOPBACK_NAME}
+        ais = make_ais(config=config, ledfx=ledfx)
+        ais._resolve_device_from_name()
+
+        assert ais._config["audio_device"] == 17
+        mock_save.assert_called_once()
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_resolve_saved_index_invalid_name_not_found(self, mock_devices):
+        """#9: Index 99 invalid AND name not found — name cleared."""
+        config = {"audio_device": 99, "audio_device_name": "Nonexistent Device"}
+        ais = make_ais(config=config)
+        ais._resolve_device_from_name()
+
+        assert ais._config["audio_device_name"] == ""
+
+    @patch("ledfx.effects.audio.save_config")
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_INDEX_VALID_NAME_WRONG
+    )
+    def test_resolve_index_valid_but_wrong_device(self, mock_devices, mock_save):
+        """#10: Index 17 valid but points to wrong device — name search finds 18."""
+        ledfx = make_mock_ledfx()
+        config = {"audio_device": 17, "audio_device_name": LOOPBACK_NAME}
+        ais = make_ais(config=config, ledfx=ledfx)
+        ais._resolve_device_from_name()
+
+        assert ais._config["audio_device"] == 18
+        mock_save.assert_called_once()
+
+
+# ===========================================================================
+# §7.3 — Legacy Upgrade Path
+# ===========================================================================
+
+
+class TestLegacyUpgradePath:
+    """Verify seamless upgrade from index-only configs."""
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    @patch.object(AudioInputSource, "default_device_index", return_value=0)
+    def test_legacy_config_no_name_field(self, mock_default, mock_valid, mock_devices):
+        """#11: Config with only audio_device — schema defaults audio_device_name to ''."""
+        schema = AudioInputSource.AUDIO_CONFIG_SCHEMA.fget()
+        config = schema({"audio_device": 17})
+
+        assert config["audio_device"] == 17
+        assert config["audio_device_name"] == ""
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    @patch.object(AudioInputSource, "default_device_index", return_value=0)
+    def test_legacy_config_empty_audio_dict(self, mock_default, mock_valid, mock_devices):
+        """#12: Empty audio config — default device chosen, no name."""
+        schema = AudioInputSource.AUDIO_CONFIG_SCHEMA.fget()
+        config = schema({})
+
+        assert config["audio_device"] == 0  # default_device_index
+        assert config["audio_device_name"] == ""
+
+    @patch("ledfx.effects.audio.save_config")
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_legacy_upgrade_name_persisted_on_activation(self, mock_devices, mock_save):
+        """#13: After activation with legacy config, name is persisted."""
+        ledfx = make_mock_ledfx({"audio_device": 17})
+        config = {"audio_device": 17, "audio_device_name": ""}
+        ais = make_ais(config=config, ledfx=ledfx)
+
+        # Simulate _update_device_config which is called during activation
+        ais._update_device_config(17)
+
+        assert ais._config["audio_device_name"] == LOOPBACK_NAME
+        mock_save.assert_called_once()
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_legacy_upgrade_name_not_persisted_for_invalid_device(self, mock_devices):
+        """#14: Activation with invalid index — name not persisted (empty)."""
+        config = {"audio_device": 999, "audio_device_name": ""}
+        ais = make_ais(config=config)
+
+        ais._update_device_config(999)
+
+        assert ais._config["audio_device_name"] == ""
+
+    @patch("ledfx.effects.audio.save_config")
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_AFTER_USB_ADDED)
+    def test_legacy_upgrade_second_startup_uses_name(self, mock_devices, mock_save):
+        """#15: First boot persists name, second boot resolves by name to new index."""
+        # Simulate second boot: name was persisted, but indices shifted
+        ledfx = make_mock_ledfx()
+        config = {"audio_device": 17, "audio_device_name": LOOPBACK_NAME}
+        ais = make_ais(config=config, ledfx=ledfx)
+        ais._resolve_device_from_name()
+
+        assert ais._config["audio_device"] == 18
+
+
+# ===========================================================================
+# §7.4 — API Endpoint
+# ===========================================================================
+
+
+class TestAudioDevicesApi:
+    """API endpoint tests for name persistence."""
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    def test_api_put_persists_name_and_index(self, mock_valid, mock_devices):
+        """#16: PUT stores both audio_device and audio_device_name in config."""
+        # Simulate what the PUT handler does
+        index = 5
+        new_config = {}
+        new_config["audio_device"] = int(index)
+        devices = AudioInputSource.input_devices()
+        if index in devices:
+            new_config["audio_device_name"] = devices[index]
+
+        assert new_config["audio_device"] == 5
+        assert new_config["audio_device_name"] == "Windows WASAPI: Stereo Mix (Realtek High Definition Audio)"
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    def test_api_put_invalid_index_not_in_devices(self, mock_valid, mock_devices):
+        """#17: PUT with index not in valid_indexes — name not added."""
+        index = 999
+        valid_indexes = AudioInputSource.valid_device_indexes()
+
+        assert index not in valid_indexes
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    @patch.object(AudioInputSource, "default_device_index", return_value=0)
+    def test_api_get_returns_name(self, mock_default, mock_valid, mock_devices):
+        """#18: GET response includes active_device_name."""
+        schema = AudioInputSource.AUDIO_CONFIG_SCHEMA.fget()
+        audio_config = schema({"audio_device": 17, "audio_device_name": LOOPBACK_NAME})
+
+        response = {}
+        response["active_device_index"] = audio_config["audio_device"]
+        response["active_device_name"] = audio_config.get("audio_device_name", "")
+
+        assert response["active_device_index"] == 17
+        assert response["active_device_name"] == LOOPBACK_NAME
+
+
+# ===========================================================================
+# §7.5 — _update_device_config()
+# ===========================================================================
+
+
+class TestUpdateDeviceConfig:
+    """Config save helper tests."""
+
+    @patch("ledfx.effects.audio.save_config")
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_update_device_config_writes_name(self, mock_devices, mock_save):
+        """#19: Valid device_idx — both audio_device and audio_device_name set."""
+        ledfx = make_mock_ledfx()
+        ais = make_ais(config={"audio_device": 0, "audio_device_name": ""}, ledfx=ledfx)
+        ais._update_device_config(17)
+
+        assert ais._config["audio_device"] == 17
+        assert ais._config["audio_device_name"] == LOOPBACK_NAME
+
+    @patch("ledfx.effects.audio.save_config")
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_update_device_config_clears_name_for_invalid(self, mock_devices, mock_save):
+        """#20: Invalid device_idx — name cleared."""
+        ledfx = make_mock_ledfx()
+        ais = make_ais(
+            config={"audio_device": 17, "audio_device_name": LOOPBACK_NAME},
+            ledfx=ledfx,
+        )
+        ais._update_device_config(999)
+
+        assert ais._config["audio_device"] == 999
+        assert ais._config["audio_device_name"] == ""
+
+    @patch("ledfx.effects.audio.save_config")
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_update_device_config_saves_to_disk(self, mock_devices, mock_save):
+        """#21: With _ledfx attached — save_config is called."""
+        ledfx = make_mock_ledfx()
+        ais = make_ais(config={"audio_device": 0, "audio_device_name": ""}, ledfx=ledfx)
+        ais._update_device_config(17)
+
+        mock_save.assert_called_once_with(
+            config=ledfx.config,
+            config_dir=ledfx.config_dir,
+        )
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_update_device_config_no_ledfx_no_crash(self, mock_devices):
+        """_update_device_config without _ledfx doesn't crash."""
+        ais = make_ais(config={"audio_device": 0, "audio_device_name": ""}, ledfx=None)
+        ais._update_device_config(17)
+
+        assert ais._config["audio_device"] == 17
+        assert ais._config["audio_device_name"] == LOOPBACK_NAME
+
+
+# ===========================================================================
+# §7.6 — handle_device_list_change() integration
+# ===========================================================================
+
+
+class TestHandleDeviceListChangeIntegration:
+    """Runtime hotplug recovery with name field."""
+
+    @patch("ledfx.effects.audio.save_config")
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_AFTER_USB_ADDED)
+    @patch.object(AudioInputSource, "default_device_index", return_value=0)
+    def test_hotplug_recovery_updates_name(self, mock_default, mock_devices, mock_save):
+        """#22: Device shifts — _update_device_config persists new name."""
+        ledfx = make_mock_ledfx()
+        ais = make_ais(
+            config={"audio_device": 17, "audio_device_name": LOOPBACK_NAME},
+            ledfx=ledfx,
+        )
+
+        # Simulate what handle_device_list_change does when it finds device at new index
+        ais._update_device_config(18)
+
+        assert ais._config["audio_device"] == 18
+        assert ais._config["audio_device_name"] == LOOPBACK_NAME
+
+    @patch("ledfx.effects.audio.save_config")
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_AFTER_REMOVAL)
+    @patch.object(AudioInputSource, "default_device_index", return_value=0)
+    def test_hotplug_device_removed_uses_fallback(self, mock_default, mock_devices, mock_save):
+        """#23: Device removed — falls to default, name updated."""
+        ledfx = make_mock_ledfx()
+        ais = make_ais(
+            config={"audio_device": 17, "audio_device_name": LOOPBACK_NAME},
+            ledfx=ledfx,
+        )
+
+        # Simulate fallback to default device
+        ais._update_device_config(0)
+
+        assert ais._config["audio_device"] == 0
+        assert ais._config["audio_device_name"] == "Windows WASAPI: Microphone (Realtek High Definition Audio)"
+
+    def test_hotplug_no_active_stream_no_crash(self):
+        """#24: Device change event with no active stream — no error."""
+        # Just verify _resolve_device_from_name doesn't crash with empty config
+        ais = make_ais(config={})
+        ais._resolve_device_from_name()  # Should not raise
+
+
+# ===========================================================================
+# §7.7 — get_device_index_by_name() edge cases
+# ===========================================================================
+
+
+class TestGetDeviceIndexByName:
+    """Name matching logic tests."""
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_exact_match_preferred(self, mock_devices):
+        """#25: Exact name match returns correct index."""
+        ais = make_ais()
+        result = ais.get_device_index_by_name(LOOPBACK_NAME)
+        assert result == 17
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_partial_match_stored_name_is_substring(self, mock_devices):
+        """#26: Truncated stored name matches as substring."""
+        ais = make_ais()
+        truncated = "Windows WASAPI: Speakers (Realtek High Def"
+        result = ais.get_device_index_by_name(truncated)
+        assert result == 17
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_no_match_returns_negative_one(self, mock_devices):
+        """#27: No match returns -1."""
+        ais = make_ais()
+        result = ais.get_device_index_by_name("Totally Nonexistent Device XYZ")
+        assert result == -1
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_empty_string_returns_negative_one(self, mock_devices):
+        """#28: Empty string returns -1 (matches everything as substring, but
+        get_device_index_by_name tries exact first, then substring)."""
+        ais = make_ais()
+        result = ais.get_device_index_by_name("")
+        # Empty string is a substring of everything, so it will match.
+        # This is acceptable — callers should not pass empty strings.
+        # The resolver already guards against this.
+        assert isinstance(result, int)
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_case_sensitive_matching(self, mock_devices):
+        """#29: Device name matching is case-sensitive."""
+        ais = make_ais()
+        # Uppercase version should not exact-match
+        result = ais.get_device_index_by_name(LOOPBACK_NAME.upper())
+        # No exact match expected; partial match depends on case
+        assert result == -1 or isinstance(result, int)
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_SIMILAR_NAMES)
+    def test_partial_match_avoids_false_positive(self, mock_devices):
+        """#30: Short name 'Microphone' is substring of all — returns longest match."""
+        ais = make_ais()
+        result = ais.get_device_index_by_name("Windows WASAPI: Microphone")
+        # Exact match at 0
+        assert result == 0
+
+
+# ===========================================================================
+# §7.8 — Regression Guard Tests
+# ===========================================================================
+
+
+class TestRegressionGuards:
+    """Ensure new code doesn't break existing behavior."""
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    @patch.object(AudioInputSource, "default_device_index", return_value=0)
+    def test_schema_accepts_legacy_config_without_name(self, mock_default, mock_valid, mock_devices):
+        """#31: Schema validation doesn't reject old configs without audio_device_name."""
+        schema = AudioInputSource.AUDIO_CONFIG_SCHEMA.fget()
+        config = schema({"audio_device": 17})
+
+        assert "audio_device" in config
+        assert "audio_device_name" in config
+        assert config["audio_device_name"] == ""
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    @patch.object(AudioInputSource, "default_device_index", return_value=0)
+    def test_schema_allows_extra_keys(self, mock_default, mock_valid, mock_devices):
+        """#32: ALLOW_EXTRA still works — other audio config fields not lost."""
+        schema = AudioInputSource.AUDIO_CONFIG_SCHEMA.fget()
+        config = schema({"audio_device": 17, "custom_field": "preserved"})
+
+        assert config["custom_field"] == "preserved"
+
+    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    @patch.object(AudioInputSource, "default_device_index", return_value=0)
+    def test_device_index_validator_unchanged_behavior(self, mock_default, mock_valid):
+        """#33: Validator returns value for valid index, default for invalid."""
+        assert AudioInputSource.device_index_validator(17) == 17
+        assert AudioInputSource.device_index_validator(999) == 0
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    def test_resolve_still_works_without_name(self, mock_devices):
+        """#34: Full resolution path works with audio_device_name=''."""
+        config = {"audio_device": 17, "audio_device_name": ""}
+        ais = make_ais(config=config)
+        ais._resolve_device_from_name()
+
+        # No change — index preserved
+        assert ais._config["audio_device"] == 17
+
+    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    @patch.object(AudioInputSource, "default_device_index", return_value=0)
+    def test_config_roundtrip_preserves_all_fields(self, mock_default, mock_valid, mock_devices):
+        """#35: Save → load cycle preserves both audio_device and audio_device_name."""
+        schema = AudioInputSource.AUDIO_CONFIG_SCHEMA.fget()
+        original = {"audio_device": 17, "audio_device_name": LOOPBACK_NAME}
+        config = schema(original)
+
+        assert config["audio_device"] == 17
+        assert config["audio_device_name"] == LOOPBACK_NAME
+
+    @patch.object(AudioInputSource, "input_devices", return_value={
+        0: "WEB AUDIO: browser-client-123",
+    })
+    def test_web_audio_device_name_persisted(self, mock_devices):
+        """#36: WEB AUDIO virtual devices also get name persisted."""
+        ais = make_ais(config={"audio_device": 0, "audio_device_name": ""})
+        ais._update_device_config(0)
+
+        assert ais._config["audio_device_name"] == "WEB AUDIO: browser-client-123"
+
+    @patch.object(AudioInputSource, "input_devices", return_value={
+        0: "SENDSPIN: my-sendspin-server",
+    })
+    def test_sendspin_device_name_persisted(self, mock_devices):
+        """#37: SENDSPIN devices also get name persisted."""
+        ais = make_ais(config={"audio_device": 0, "audio_device_name": ""})
+        ais._update_device_config(0)
+
+        assert ais._config["audio_device_name"] == "SENDSPIN: my-sendspin-server"

--- a/tests/test_audio_device_persistence.py
+++ b/tests/test_audio_device_persistence.py
@@ -5,9 +5,7 @@ Strategy doc: docs/developer/dev_notes/audio-device-persistence-strategy.md
 """
 
 import logging
-from unittest.mock import MagicMock, call, patch
-
-import pytest
+from unittest.mock import MagicMock, patch
 
 from ledfx.effects.audio import AudioInputSource
 

--- a/tests/test_audio_device_persistence.py
+++ b/tests/test_audio_device_persistence.py
@@ -396,6 +396,68 @@ class TestAudioDevicesApi:
 
         assert index not in valid_indexes
 
+    @patch("ledfx.effects.audio.save_config")
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
+    @patch.object(
+        AudioInputSource,
+        "valid_device_indexes",
+        return_value=tuple(DEVICES_BEFORE.keys()),
+    )
+    @patch.object(AudioInputSource, "default_device_index", return_value=0)
+    def test_api_put_device_change_clears_stale_name(
+        self, mock_default, mock_valid, mock_devices, mock_save
+    ):
+        """PUT with new audio_device must not name-match back to old device.
+
+        Regression test: when config already has audio_device=17 with
+        audio_device_name pointing to loopback, and the frontend sends
+        audio_device=5, the merge used to leave the stale name in place.
+        _resolve_device_from_name() would then find the old device by name
+        and override the user's selection back to 17.
+        """
+        from ledfx.api.config import ConfigEndpoint
+
+        # Existing config: device 17 (loopback) with its name persisted
+        existing_audio = {
+            "audio_device": 17,
+            "audio_device_name": LOOPBACK_NAME,
+            "min_volume": 0.2,
+            "sample_rate": 60,
+            "mic_rate": 44100,
+            "fft_size": 8192,
+            "delay_ms": 0,
+        }
+
+        mock_ledfx = make_mock_ledfx(dict(existing_audio))
+        mock_ledfx.config["melbanks"] = {}
+        mock_ledfx.config["wled_preferences"] = {}
+
+        # Wire up a mock AudioInputSource that records the config it receives
+        mock_ais = make_ais(config=dict(existing_audio), ledfx=mock_ledfx)
+        received_configs = []
+        original_update = AudioInputSource.update_config
+
+        def capture_update(self_ais, cfg):
+            received_configs.append(dict(cfg))
+
+        mock_ais.update_config = lambda cfg: capture_update(mock_ais, cfg)
+        mock_ledfx.audio = mock_ais
+
+        endpoint = object.__new__(ConfigEndpoint)
+        endpoint._ledfx = mock_ledfx
+
+        # Frontend sends only audio_device=5 (user picks Stereo Mix)
+        endpoint.update_config({"audio": {"audio_device": 5}})
+
+        # The merged config passed to update_config must have the new index
+        # and a cleared name so _resolve_device_from_name() won't override it
+        assert len(received_configs) == 1
+        merged = received_configs[0]
+        assert merged["audio_device"] == 5
+        assert merged["audio_device_name"] == ""
+
     @patch.object(
         AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
     )
@@ -613,8 +675,8 @@ class TestGetDeviceIndexByName:
         ais = make_ais()
         # Uppercase version should not exact-match
         result = ais.get_device_index_by_name(LOOPBACK_NAME.upper())
-        # No exact match expected; partial match depends on case
-        assert result == -1 or isinstance(result, int)
+        # No exact match expected; case-sensitive matching means no match
+        assert result == -1
 
     @patch.object(
         AudioInputSource, "input_devices", return_value=DEVICES_SIMILAR_NAMES

--- a/tests/test_audio_device_persistence.py
+++ b/tests/test_audio_device_persistence.py
@@ -128,15 +128,26 @@ class TestResolveDeviceFromName:
     def test_resolve_name_not_found_device_removed(
         self, mock_default, mock_devices
     ):
-        """#3: Device removed — name cleared, falls through to index/default logic."""
+        """#3: Device removed — reset to default, name cleared, runtime tracking cleared."""
         config = {"audio_device": 17, "audio_device_name": LOOPBACK_NAME}
         ais = make_ais(config=config)
-        ais._resolve_device_from_name()
+        # Seed runtime tracking to verify it gets cleared
+        AudioInputSource._last_device_name = LOOPBACK_NAME
+        AudioInputSource._last_active = 17
+        try:
+            ais._resolve_device_from_name()
 
-        # Name should be cleared
-        assert ais._config["audio_device_name"] == ""
-        # Index unchanged by resolver — existing validator handles fallback
-        assert ais._config["audio_device"] == 17
+            # Name should be cleared
+            assert ais._config["audio_device_name"] == ""
+            # Index reset to default so we don't open the wrong device
+            assert ais._config["audio_device"] == 0
+            # Runtime tracking cleared so hotplug won't recover to old device
+            assert AudioInputSource._last_device_name is None
+            assert AudioInputSource._last_active is None
+        finally:
+            # Restore class state for other tests
+            AudioInputSource._last_device_name = None
+            AudioInputSource._last_active = None
 
     @patch.object(
         AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
@@ -204,11 +215,14 @@ class TestResolveDeviceFromName:
         assert ais._config["audio_device"] == 17
         mock_save.assert_called_once()
 
+    @patch.object(AudioInputSource, "default_device_index", return_value=0)
     @patch.object(
         AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
     )
-    def test_resolve_saved_index_invalid_name_not_found(self, mock_devices):
-        """#9: Index 99 invalid AND name not found — name cleared."""
+    def test_resolve_saved_index_invalid_name_not_found(
+        self, mock_devices, mock_default
+    ):
+        """#9: Index 99 invalid AND name not found — reset to default, name cleared."""
         config = {
             "audio_device": 99,
             "audio_device_name": "Nonexistent Device",
@@ -217,6 +231,7 @@ class TestResolveDeviceFromName:
         ais._resolve_device_from_name()
 
         assert ais._config["audio_device_name"] == ""
+        assert ais._config["audio_device"] == 0
 
     @patch("ledfx.effects.audio.save_config")
     @patch.object(

--- a/tests/test_audio_device_persistence.py
+++ b/tests/test_audio_device_persistence.py
@@ -54,7 +54,9 @@ DEVICES_INDEX_VALID_NAME_WRONG = {
     18: "Windows WASAPI: Speakers (Realtek High Definition Audio) [Loopback]",
 }
 
-LOOPBACK_NAME = "Windows WASAPI: Speakers (Realtek High Definition Audio) [Loopback]"
+LOOPBACK_NAME = (
+    "Windows WASAPI: Speakers (Realtek High Definition Audio) [Loopback]"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -90,7 +92,9 @@ def make_ais(config=None, ledfx=None):
 class TestResolveDeviceFromName:
     """Core resolution logic tests."""
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
     def test_resolve_name_matches_at_saved_index(self, mock_devices):
         """#1: Name matches device at saved index — no change."""
         config = {"audio_device": 17, "audio_device_name": LOOPBACK_NAME}
@@ -101,10 +105,16 @@ class TestResolveDeviceFromName:
         assert ais._config["audio_device_name"] == LOOPBACK_NAME
 
     @patch("ledfx.effects.audio.save_config")
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_AFTER_USB_ADDED)
-    def test_resolve_name_found_at_different_index(self, mock_devices, mock_save):
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_AFTER_USB_ADDED
+    )
+    def test_resolve_name_found_at_different_index(
+        self, mock_devices, mock_save
+    ):
         """#2: Device shifted to new index — update index, persist."""
-        ledfx = make_mock_ledfx({"audio_device": 17, "audio_device_name": LOOPBACK_NAME})
+        ledfx = make_mock_ledfx(
+            {"audio_device": 17, "audio_device_name": LOOPBACK_NAME}
+        )
         config = {"audio_device": 17, "audio_device_name": LOOPBACK_NAME}
         ais = make_ais(config=config, ledfx=ledfx)
         ais._resolve_device_from_name()
@@ -113,9 +123,13 @@ class TestResolveDeviceFromName:
         assert ais._config["audio_device_name"] == LOOPBACK_NAME
         mock_save.assert_called_once()
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_AFTER_REMOVAL)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_AFTER_REMOVAL
+    )
     @patch.object(AudioInputSource, "default_device_index", return_value=0)
-    def test_resolve_name_not_found_device_removed(self, mock_default, mock_devices):
+    def test_resolve_name_not_found_device_removed(
+        self, mock_default, mock_devices
+    ):
         """#3: Device removed — name cleared, falls through to index/default logic."""
         config = {"audio_device": 17, "audio_device_name": LOOPBACK_NAME}
         ais = make_ais(config=config)
@@ -126,7 +140,9 @@ class TestResolveDeviceFromName:
         # Index unchanged by resolver — existing validator handles fallback
         assert ais._config["audio_device"] == 17
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
     def test_resolve_empty_name_skips_resolution(self, mock_devices):
         """#4: Empty name string — skip resolution, use index as-is."""
         config = {"audio_device": 17, "audio_device_name": ""}
@@ -137,7 +153,9 @@ class TestResolveDeviceFromName:
         # input_devices should not even be called when name is empty
         mock_devices.assert_not_called()
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
     def test_resolve_no_name_key_skips_resolution(self, mock_devices):
         """#5: No audio_device_name key at all (schema default applies)."""
         config = {"audio_device": 17}
@@ -147,7 +165,9 @@ class TestResolveDeviceFromName:
         assert ais._config["audio_device"] == 17
         mock_devices.assert_not_called()
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
     def test_resolve_partial_match_truncated_name(self, mock_devices):
         """#6: Truncated name finds match via partial matching."""
         truncated_name = "Windows WASAPI: Speakers (Realtek High Def"
@@ -158,7 +178,9 @@ class TestResolveDeviceFromName:
         # Should find index 17 via partial match
         assert ais._config["audio_device"] == 17
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_SIMILAR_NAMES)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_SIMILAR_NAMES
+    )
     def test_resolve_prefers_exact_over_partial(self, mock_devices):
         """#7: Exact match at index 1 preferred over partial at index 2."""
         name = "Windows WASAPI: Microphone (Realtek)"
@@ -169,8 +191,12 @@ class TestResolveDeviceFromName:
         assert ais._config["audio_device"] == 1
 
     @patch("ledfx.effects.audio.save_config")
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
-    def test_resolve_saved_index_invalid_name_found(self, mock_devices, mock_save):
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
+    def test_resolve_saved_index_invalid_name_found(
+        self, mock_devices, mock_save
+    ):
         """#8: Saved index 99 invalid but name found at 17."""
         ledfx = make_mock_ledfx()
         config = {"audio_device": 99, "audio_device_name": LOOPBACK_NAME}
@@ -180,10 +206,15 @@ class TestResolveDeviceFromName:
         assert ais._config["audio_device"] == 17
         mock_save.assert_called_once()
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
     def test_resolve_saved_index_invalid_name_not_found(self, mock_devices):
         """#9: Index 99 invalid AND name not found — name cleared."""
-        config = {"audio_device": 99, "audio_device_name": "Nonexistent Device"}
+        config = {
+            "audio_device": 99,
+            "audio_device_name": "Nonexistent Device",
+        }
         ais = make_ais(config=config)
         ais._resolve_device_from_name()
 
@@ -191,9 +222,13 @@ class TestResolveDeviceFromName:
 
     @patch("ledfx.effects.audio.save_config")
     @patch.object(
-        AudioInputSource, "input_devices", return_value=DEVICES_INDEX_VALID_NAME_WRONG
+        AudioInputSource,
+        "input_devices",
+        return_value=DEVICES_INDEX_VALID_NAME_WRONG,
     )
-    def test_resolve_index_valid_but_wrong_device(self, mock_devices, mock_save):
+    def test_resolve_index_valid_but_wrong_device(
+        self, mock_devices, mock_save
+    ):
         """#10: Index 17 valid but points to wrong device — name search finds 18."""
         ledfx = make_mock_ledfx()
         config = {"audio_device": 17, "audio_device_name": LOOPBACK_NAME}
@@ -212,10 +247,18 @@ class TestResolveDeviceFromName:
 class TestLegacyUpgradePath:
     """Verify seamless upgrade from index-only configs."""
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
-    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
+    @patch.object(
+        AudioInputSource,
+        "valid_device_indexes",
+        return_value=tuple(DEVICES_BEFORE.keys()),
+    )
     @patch.object(AudioInputSource, "default_device_index", return_value=0)
-    def test_legacy_config_no_name_field(self, mock_default, mock_valid, mock_devices):
+    def test_legacy_config_no_name_field(
+        self, mock_default, mock_valid, mock_devices
+    ):
         """#11: Config with only audio_device — schema defaults audio_device_name to ''."""
         schema = AudioInputSource.AUDIO_CONFIG_SCHEMA.fget()
         config = schema({"audio_device": 17})
@@ -223,10 +266,18 @@ class TestLegacyUpgradePath:
         assert config["audio_device"] == 17
         assert config["audio_device_name"] == ""
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
-    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
+    @patch.object(
+        AudioInputSource,
+        "valid_device_indexes",
+        return_value=tuple(DEVICES_BEFORE.keys()),
+    )
     @patch.object(AudioInputSource, "default_device_index", return_value=0)
-    def test_legacy_config_empty_audio_dict(self, mock_default, mock_valid, mock_devices):
+    def test_legacy_config_empty_audio_dict(
+        self, mock_default, mock_valid, mock_devices
+    ):
         """#12: Empty audio config — default device chosen, no name."""
         schema = AudioInputSource.AUDIO_CONFIG_SCHEMA.fget()
         config = schema({})
@@ -235,8 +286,12 @@ class TestLegacyUpgradePath:
         assert config["audio_device_name"] == ""
 
     @patch("ledfx.effects.audio.save_config")
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
-    def test_legacy_upgrade_name_persisted_on_activation(self, mock_devices, mock_save):
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
+    def test_legacy_upgrade_name_persisted_on_activation(
+        self, mock_devices, mock_save
+    ):
         """#13: After activation with legacy config, name is persisted."""
         ledfx = make_mock_ledfx({"audio_device": 17})
         config = {"audio_device": 17, "audio_device_name": ""}
@@ -248,8 +303,12 @@ class TestLegacyUpgradePath:
         assert ais._config["audio_device_name"] == LOOPBACK_NAME
         mock_save.assert_called_once()
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
-    def test_legacy_upgrade_name_not_persisted_for_invalid_device(self, mock_devices):
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
+    def test_legacy_upgrade_name_not_persisted_for_invalid_device(
+        self, mock_devices
+    ):
         """#14: Activation with invalid index — name not persisted (empty)."""
         config = {"audio_device": 999, "audio_device_name": ""}
         ais = make_ais(config=config)
@@ -259,8 +318,12 @@ class TestLegacyUpgradePath:
         assert ais._config["audio_device_name"] == ""
 
     @patch("ledfx.effects.audio.save_config")
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_AFTER_USB_ADDED)
-    def test_legacy_upgrade_second_startup_uses_name(self, mock_devices, mock_save):
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_AFTER_USB_ADDED
+    )
+    def test_legacy_upgrade_second_startup_uses_name(
+        self, mock_devices, mock_save
+    ):
         """#15: First boot persists name, second boot resolves by name to new index."""
         # Simulate second boot: name was persisted, but indices shifted
         ledfx = make_mock_ledfx()
@@ -279,8 +342,14 @@ class TestLegacyUpgradePath:
 class TestAudioDevicesApi:
     """API endpoint tests for name persistence."""
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
-    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
+    @patch.object(
+        AudioInputSource,
+        "valid_device_indexes",
+        return_value=tuple(DEVICES_BEFORE.keys()),
+    )
     def test_api_put_persists_name_and_index(self, mock_valid, mock_devices):
         """#16: PUT stores both audio_device and audio_device_name in config."""
         # Simulate what the PUT handler does
@@ -292,28 +361,51 @@ class TestAudioDevicesApi:
             new_config["audio_device_name"] = devices[index]
 
         assert new_config["audio_device"] == 5
-        assert new_config["audio_device_name"] == "Windows WASAPI: Stereo Mix (Realtek High Definition Audio)"
+        assert (
+            new_config["audio_device_name"]
+            == "Windows WASAPI: Stereo Mix (Realtek High Definition Audio)"
+        )
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
-    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
-    def test_api_put_invalid_index_not_in_devices(self, mock_valid, mock_devices):
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
+    @patch.object(
+        AudioInputSource,
+        "valid_device_indexes",
+        return_value=tuple(DEVICES_BEFORE.keys()),
+    )
+    def test_api_put_invalid_index_not_in_devices(
+        self, mock_valid, mock_devices
+    ):
         """#17: PUT with index not in valid_indexes — name not added."""
         index = 999
         valid_indexes = AudioInputSource.valid_device_indexes()
 
         assert index not in valid_indexes
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
-    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
+    @patch.object(
+        AudioInputSource,
+        "valid_device_indexes",
+        return_value=tuple(DEVICES_BEFORE.keys()),
+    )
     @patch.object(AudioInputSource, "default_device_index", return_value=0)
-    def test_api_get_returns_name(self, mock_default, mock_valid, mock_devices):
+    def test_api_get_returns_name(
+        self, mock_default, mock_valid, mock_devices
+    ):
         """#18: GET response includes active_device_name."""
         schema = AudioInputSource.AUDIO_CONFIG_SCHEMA.fget()
-        audio_config = schema({"audio_device": 17, "audio_device_name": LOOPBACK_NAME})
+        audio_config = schema(
+            {"audio_device": 17, "audio_device_name": LOOPBACK_NAME}
+        )
 
         response = {}
         response["active_device_index"] = audio_config["audio_device"]
-        response["active_device_name"] = audio_config.get("audio_device_name", "")
+        response["active_device_name"] = audio_config.get(
+            "audio_device_name", ""
+        )
 
         assert response["active_device_index"] == 17
         assert response["active_device_name"] == LOOPBACK_NAME
@@ -328,19 +420,27 @@ class TestUpdateDeviceConfig:
     """Config save helper tests."""
 
     @patch("ledfx.effects.audio.save_config")
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
     def test_update_device_config_writes_name(self, mock_devices, mock_save):
         """#19: Valid device_idx — both audio_device and audio_device_name set."""
         ledfx = make_mock_ledfx()
-        ais = make_ais(config={"audio_device": 0, "audio_device_name": ""}, ledfx=ledfx)
+        ais = make_ais(
+            config={"audio_device": 0, "audio_device_name": ""}, ledfx=ledfx
+        )
         ais._update_device_config(17)
 
         assert ais._config["audio_device"] == 17
         assert ais._config["audio_device_name"] == LOOPBACK_NAME
 
     @patch("ledfx.effects.audio.save_config")
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
-    def test_update_device_config_clears_name_for_invalid(self, mock_devices, mock_save):
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
+    def test_update_device_config_clears_name_for_invalid(
+        self, mock_devices, mock_save
+    ):
         """#20: Invalid device_idx — name cleared."""
         ledfx = make_mock_ledfx()
         ais = make_ais(
@@ -353,11 +453,15 @@ class TestUpdateDeviceConfig:
         assert ais._config["audio_device_name"] == ""
 
     @patch("ledfx.effects.audio.save_config")
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
     def test_update_device_config_saves_to_disk(self, mock_devices, mock_save):
         """#21: With _ledfx attached — save_config is called."""
         ledfx = make_mock_ledfx()
-        ais = make_ais(config={"audio_device": 0, "audio_device_name": ""}, ledfx=ledfx)
+        ais = make_ais(
+            config={"audio_device": 0, "audio_device_name": ""}, ledfx=ledfx
+        )
         ais._update_device_config(17)
 
         mock_save.assert_called_once_with(
@@ -365,10 +469,14 @@ class TestUpdateDeviceConfig:
             config_dir=ledfx.config_dir,
         )
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
     def test_update_device_config_no_ledfx_no_crash(self, mock_devices):
         """_update_device_config without _ledfx doesn't crash."""
-        ais = make_ais(config={"audio_device": 0, "audio_device_name": ""}, ledfx=None)
+        ais = make_ais(
+            config={"audio_device": 0, "audio_device_name": ""}, ledfx=None
+        )
         ais._update_device_config(17)
 
         assert ais._config["audio_device"] == 17
@@ -384,9 +492,13 @@ class TestHandleDeviceListChangeIntegration:
     """Runtime hotplug recovery with name field."""
 
     @patch("ledfx.effects.audio.save_config")
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_AFTER_USB_ADDED)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_AFTER_USB_ADDED
+    )
     @patch.object(AudioInputSource, "default_device_index", return_value=0)
-    def test_hotplug_recovery_updates_name(self, mock_default, mock_devices, mock_save):
+    def test_hotplug_recovery_updates_name(
+        self, mock_default, mock_devices, mock_save
+    ):
         """#22: Device shifts — _update_device_config persists new name."""
         ledfx = make_mock_ledfx()
         ais = make_ais(
@@ -401,9 +513,13 @@ class TestHandleDeviceListChangeIntegration:
         assert ais._config["audio_device_name"] == LOOPBACK_NAME
 
     @patch("ledfx.effects.audio.save_config")
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_AFTER_REMOVAL)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_AFTER_REMOVAL
+    )
     @patch.object(AudioInputSource, "default_device_index", return_value=0)
-    def test_hotplug_device_removed_uses_fallback(self, mock_default, mock_devices, mock_save):
+    def test_hotplug_device_removed_uses_fallback(
+        self, mock_default, mock_devices, mock_save
+    ):
         """#23: Device removed — falls to default, name updated."""
         ledfx = make_mock_ledfx()
         ais = make_ais(
@@ -415,7 +531,10 @@ class TestHandleDeviceListChangeIntegration:
         ais._update_device_config(0)
 
         assert ais._config["audio_device"] == 0
-        assert ais._config["audio_device_name"] == "Windows WASAPI: Microphone (Realtek High Definition Audio)"
+        assert (
+            ais._config["audio_device_name"]
+            == "Windows WASAPI: Microphone (Realtek High Definition Audio)"
+        )
 
     def test_hotplug_no_active_stream_no_crash(self):
         """#24: Device change event with no active stream — no error."""
@@ -432,14 +551,18 @@ class TestHandleDeviceListChangeIntegration:
 class TestGetDeviceIndexByName:
     """Name matching logic tests."""
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
     def test_exact_match_preferred(self, mock_devices):
         """#25: Exact name match returns correct index."""
         ais = make_ais()
         result = ais.get_device_index_by_name(LOOPBACK_NAME)
         assert result == 17
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
     def test_partial_match_stored_name_is_substring(self, mock_devices):
         """#26: Truncated stored name matches as substring."""
         ais = make_ais()
@@ -447,14 +570,18 @@ class TestGetDeviceIndexByName:
         result = ais.get_device_index_by_name(truncated)
         assert result == 17
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
     def test_no_match_returns_negative_one(self, mock_devices):
         """#27: No match returns -1."""
         ais = make_ais()
         result = ais.get_device_index_by_name("Totally Nonexistent Device XYZ")
         assert result == -1
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
     def test_empty_string_returns_negative_one(self, mock_devices):
         """#28: Empty string returns -1 (matches everything as substring, but
         get_device_index_by_name tries exact first, then substring)."""
@@ -465,7 +592,9 @@ class TestGetDeviceIndexByName:
         # The resolver already guards against this.
         assert isinstance(result, int)
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
     def test_case_sensitive_matching(self, mock_devices):
         """#29: Device name matching is case-sensitive."""
         ais = make_ais()
@@ -474,7 +603,9 @@ class TestGetDeviceIndexByName:
         # No exact match expected; partial match depends on case
         assert result == -1 or isinstance(result, int)
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_SIMILAR_NAMES)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_SIMILAR_NAMES
+    )
     def test_partial_match_avoids_false_positive(self, mock_devices):
         """#30: Short name 'Microphone' is substring of all — returns longest match."""
         ais = make_ais()
@@ -491,10 +622,18 @@ class TestGetDeviceIndexByName:
 class TestRegressionGuards:
     """Ensure new code doesn't break existing behavior."""
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
-    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
+    @patch.object(
+        AudioInputSource,
+        "valid_device_indexes",
+        return_value=tuple(DEVICES_BEFORE.keys()),
+    )
     @patch.object(AudioInputSource, "default_device_index", return_value=0)
-    def test_schema_accepts_legacy_config_without_name(self, mock_default, mock_valid, mock_devices):
+    def test_schema_accepts_legacy_config_without_name(
+        self, mock_default, mock_valid, mock_devices
+    ):
         """#31: Schema validation doesn't reject old configs without audio_device_name."""
         schema = AudioInputSource.AUDIO_CONFIG_SCHEMA.fget()
         config = schema({"audio_device": 17})
@@ -503,24 +642,40 @@ class TestRegressionGuards:
         assert "audio_device_name" in config
         assert config["audio_device_name"] == ""
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
-    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
+    @patch.object(
+        AudioInputSource,
+        "valid_device_indexes",
+        return_value=tuple(DEVICES_BEFORE.keys()),
+    )
     @patch.object(AudioInputSource, "default_device_index", return_value=0)
-    def test_schema_allows_extra_keys(self, mock_default, mock_valid, mock_devices):
+    def test_schema_allows_extra_keys(
+        self, mock_default, mock_valid, mock_devices
+    ):
         """#32: ALLOW_EXTRA still works — other audio config fields not lost."""
         schema = AudioInputSource.AUDIO_CONFIG_SCHEMA.fget()
         config = schema({"audio_device": 17, "custom_field": "preserved"})
 
         assert config["custom_field"] == "preserved"
 
-    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    @patch.object(
+        AudioInputSource,
+        "valid_device_indexes",
+        return_value=tuple(DEVICES_BEFORE.keys()),
+    )
     @patch.object(AudioInputSource, "default_device_index", return_value=0)
-    def test_device_index_validator_unchanged_behavior(self, mock_default, mock_valid):
+    def test_device_index_validator_unchanged_behavior(
+        self, mock_default, mock_valid
+    ):
         """#33: Validator returns value for valid index, default for invalid."""
         assert AudioInputSource.device_index_validator(17) == 17
         assert AudioInputSource.device_index_validator(999) == 0
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
     def test_resolve_still_works_without_name(self, mock_devices):
         """#34: Full resolution path works with audio_device_name=''."""
         config = {"audio_device": 17, "audio_device_name": ""}
@@ -530,10 +685,18 @@ class TestRegressionGuards:
         # No change — index preserved
         assert ais._config["audio_device"] == 17
 
-    @patch.object(AudioInputSource, "input_devices", return_value=DEVICES_BEFORE)
-    @patch.object(AudioInputSource, "valid_device_indexes", return_value=tuple(DEVICES_BEFORE.keys()))
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
+    @patch.object(
+        AudioInputSource,
+        "valid_device_indexes",
+        return_value=tuple(DEVICES_BEFORE.keys()),
+    )
     @patch.object(AudioInputSource, "default_device_index", return_value=0)
-    def test_config_roundtrip_preserves_all_fields(self, mock_default, mock_valid, mock_devices):
+    def test_config_roundtrip_preserves_all_fields(
+        self, mock_default, mock_valid, mock_devices
+    ):
         """#35: Save → load cycle preserves both audio_device and audio_device_name."""
         schema = AudioInputSource.AUDIO_CONFIG_SCHEMA.fget()
         original = {"audio_device": 17, "audio_device_name": LOOPBACK_NAME}
@@ -542,22 +705,34 @@ class TestRegressionGuards:
         assert config["audio_device"] == 17
         assert config["audio_device_name"] == LOOPBACK_NAME
 
-    @patch.object(AudioInputSource, "input_devices", return_value={
-        0: "WEB AUDIO: browser-client-123",
-    })
+    @patch.object(
+        AudioInputSource,
+        "input_devices",
+        return_value={
+            0: "WEB AUDIO: browser-client-123",
+        },
+    )
     def test_web_audio_device_name_persisted(self, mock_devices):
         """#36: WEB AUDIO virtual devices also get name persisted."""
         ais = make_ais(config={"audio_device": 0, "audio_device_name": ""})
         ais._update_device_config(0)
 
-        assert ais._config["audio_device_name"] == "WEB AUDIO: browser-client-123"
+        assert (
+            ais._config["audio_device_name"] == "WEB AUDIO: browser-client-123"
+        )
 
-    @patch.object(AudioInputSource, "input_devices", return_value={
-        0: "SENDSPIN: my-sendspin-server",
-    })
+    @patch.object(
+        AudioInputSource,
+        "input_devices",
+        return_value={
+            0: "SENDSPIN: my-sendspin-server",
+        },
+    )
     def test_sendspin_device_name_persisted(self, mock_devices):
         """#37: SENDSPIN devices also get name persisted."""
         ais = make_ais(config={"audio_device": 0, "audio_device_name": ""})
         ais._update_device_config(0)
 
-        assert ais._config["audio_device_name"] == "SENDSPIN: my-sendspin-server"
+        assert (
+            ais._config["audio_device_name"] == "SENDSPIN: my-sendspin-server"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1151,7 +1151,7 @@ wheels = [
 
 [[package]]
 name = "ledfx"
-version = "2.1.6"
+version = "2.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2779,8 +2779,8 @@ name = "python-mbedtls"
 version = "2.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "typing-extensions" },
+    { name = "certifi", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/88/b7/b926727e3433ca2072e61572a36229ac21ebd46b0dca320d1c09f6fcd108/python-mbedtls-2.9.2.tar.gz", hash = "sha256:f541ccd23da2722724fd026c707a652883c497fe67340a8f1adb6ac73c487b31", size = 105334, upload-time = "2024-02-18T10:49:20.438Z" }
 wheels = [


### PR DESCRIPTION
See extensive strategy doc.

Audio device persistance based on index only breaks when system device changes shuffle enumeration.

Extend the new name based matching used in hotplug runtime to the persistance story.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added developer notes detailing cross-session audio-device persistence, resolution rules, edge cases, and a testing plan.
* **New Features**
  * UI/API now expose the active audio-device name; the app persists a device name alongside the selected device index and stores it on activation.
* **Bug Fixes / Reliability**
  * Improved startup/device-resolution to handle index drift, hotplug, missing-device fallbacks, and clearing stale saved names during config updates.
* **Tests**
  * Added comprehensive tests for name-based resolution, legacy upgrade behavior, API persistence, hotplug recovery, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->