### PR TITLE
Feat: add startup playlist

### DIFF
--- a/ledfx/api/utils.py
+++ b/ledfx/api/utils.py
@@ -56,6 +56,7 @@ PERMITTED_KEYS = {
         "flush_on_deactivate",
         "ui_brightness_boost",
         "startup_scene_id",
+        "startup_playlist_id",
         "lifx_broadcast_address",
         "lifx_discovery_timeout",
     ),

--- a/ledfx/config.py
+++ b/ledfx/config.py
@@ -47,6 +47,7 @@ CORE_CONFIG_KEYS_NO_RESTART = [
     "flush_on_deactivate",
     "ui_brightness_boost",
     "startup_scene_id",
+    "startup_playlist_id",
     "lifx_broadcast_address",
     "lifx_discovery_timeout",
 ]
@@ -180,6 +181,7 @@ CORE_CONFIG_SCHEMA = vol.Schema(
             vol.Coerce(float), vol.Range(0, 1.0)
         ),
         vol.Optional("startup_scene_id", default=""): str,
+        vol.Optional("startup_playlist_id", default=""): str,
         vol.Optional(
             "lifx_broadcast_address", default="255.255.255.255"
         ): validate_ipv4_address,

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -41,6 +41,7 @@ from ledfx.events import (
 from ledfx.http_manager import HttpServer
 from ledfx.integrations import Integrations
 from ledfx.mdns_manager import ZeroConfRunner
+from ledfx.playlists import PlaylistManager
 from ledfx.presets import ledfx_presets
 from ledfx.scenes import Scenes
 from ledfx.tools.ts_generator import generate_typescript_types
@@ -580,6 +581,21 @@ class LedFxCore:
                 _LOGGER.warning(
                     "startup_scene_id: %s not found.",
                     self.config["startup_scene_id"],
+                )
+
+        if self.config["startup_playlist_id"] != "":
+            if not hasattr(self, "playlists"):
+                self.playlists = PlaylistManager(self)
+            pid = self.config["startup_playlist_id"]
+            if await self.playlists.start(pid):
+                _LOGGER.info(
+                    "startup_playlist_id: %s started.",
+                    pid,
+                )
+            else:
+                _LOGGER.warning(
+                    "startup_playlist_id: %s not found.",
+                    pid,
                 )
 
         if pause_all:

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -583,6 +583,14 @@ class LedFxCore:
                     self.config["startup_scene_id"],
                 )
 
+        await self._handle_startup_playlist()
+
+        if pause_all:
+            # pause at the virtuals level
+            self.virtuals.pause_all()
+
+    async def _handle_startup_playlist(self):
+        """Activate the configured startup playlist, if any."""
         if self.config["startup_playlist_id"] != "":
             if not hasattr(self, "playlists"):
                 self.playlists = PlaylistManager(self)
@@ -597,10 +605,6 @@ class LedFxCore:
                     "startup_playlist_id: %s not found.",
                     pid,
                 )
-
-        if pause_all:
-            # pause at the virtuals level
-            self.virtuals.pause_all()
 
     def stop(self, exit_code):
         async_fire_and_forget(self.async_stop(exit_code), self.loop)

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -602,7 +602,7 @@ class LedFxCore:
                 )
             else:
                 _LOGGER.warning(
-                    "startup_playlist_id: %s not found.",
+                    "startup_playlist_id: %s could not be started.",
                     pid,
                 )
 

--- a/tests/test_startup_playlist.py
+++ b/tests/test_startup_playlist.py
@@ -1,11 +1,12 @@
 """Tests for startup_playlist_id configuration and activation logic."""
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from ledfx.config import CORE_CONFIG_SCHEMA
+from ledfx.api.utils import PERMITTED_KEYS
+from ledfx.config import CORE_CONFIG_KEYS_NO_RESTART, CORE_CONFIG_SCHEMA
+from ledfx.core import LedFxCore
 
 
 class TestStartupPlaylistConfig:
@@ -20,22 +21,19 @@ class TestStartupPlaylistConfig:
         assert config["startup_playlist_id"] == "my-playlist"
 
     def test_present_in_no_restart_keys(self):
-        from ledfx.config import CORE_CONFIG_KEYS_NO_RESTART
-
         assert "startup_playlist_id" in CORE_CONFIG_KEYS_NO_RESTART
 
     def test_present_in_api_permitted_keys(self):
-        from ledfx.api.utils import PERMITTED_KEYS
-
         assert "startup_playlist_id" in PERMITTED_KEYS["core"]
 
 
 class TestStartupPlaylistActivation:
-    """Test startup playlist activation logic in core startup flow."""
+    """Test startup playlist activation logic via LedFxCore._handle_startup_playlist."""
 
     @pytest.fixture
-    def mock_core(self):
-        core = MagicMock()
+    def core(self):
+        """Create a minimal LedFxCore-like object with _handle_startup_playlist."""
+        core = MagicMock(spec=LedFxCore)
         core.config = {
             "startup_scene_id": "",
             "startup_playlist_id": "test-playlist",
@@ -60,45 +58,53 @@ class TestStartupPlaylistActivation:
         }
         core.config_dir = ""
         core.events = MagicMock()
+        # Bind the real helper so the production logic is exercised
+        core._handle_startup_playlist = (
+            LedFxCore._handle_startup_playlist.__get__(core, LedFxCore)
+        )
         return core
 
     @pytest.mark.asyncio
-    async def test_startup_playlist_starts_when_configured(self, mock_core):
-        from ledfx.playlists import PlaylistManager
+    async def test_startup_playlist_starts_when_configured(self, core):
+        core.playlists = MagicMock()
+        core.playlists.start = AsyncMock(return_value=True)
 
-        manager = PlaylistManager(mock_core)
-        manager.start = AsyncMock(return_value=True)
+        await core._handle_startup_playlist()
 
-        # Simulate the core.py startup logic
-        pid = mock_core.config["startup_playlist_id"]
-        assert pid != ""
-        result = await manager.start(pid)
-        assert result is True
-        manager.start.assert_called_once_with("test-playlist")
+        core.playlists.start.assert_called_once_with("test-playlist")
 
     @pytest.mark.asyncio
-    async def test_startup_playlist_skipped_when_empty(self, mock_core):
-        mock_core.config["startup_playlist_id"] = ""
+    async def test_startup_playlist_skipped_when_empty(self, core):
+        core.config["startup_playlist_id"] = ""
+        core.playlists = MagicMock()
+        core.playlists.start = AsyncMock(return_value=True)
 
-        from ledfx.playlists import PlaylistManager
+        await core._handle_startup_playlist()
 
-        manager = PlaylistManager(mock_core)
-        manager.start = AsyncMock(return_value=True)
-
-        pid = mock_core.config["startup_playlist_id"]
-        # Should not start when empty string
-        assert pid == ""
-        manager.start.assert_not_called()
+        core.playlists.start.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_startup_playlist_warns_when_not_found(self, mock_core):
-        mock_core.config["startup_playlist_id"] = "nonexistent"
+    async def test_startup_playlist_warns_when_not_found(self, core):
+        core.config["startup_playlist_id"] = "nonexistent"
+        core.playlists = MagicMock()
+        core.playlists.start = AsyncMock(return_value=False)
 
-        from ledfx.playlists import PlaylistManager
+        await core._handle_startup_playlist()
 
-        manager = PlaylistManager(mock_core)
-        manager.start = AsyncMock(return_value=False)
+        core.playlists.start.assert_called_once_with("nonexistent")
 
-        pid = mock_core.config["startup_playlist_id"]
-        result = await manager.start(pid)
-        assert result is False
+    @pytest.mark.asyncio
+    async def test_creates_playlist_manager_if_missing(self, core):
+        # Remove playlists attribute so hasattr check triggers
+        del core.playlists
+
+        with patch(
+            "ledfx.core.PlaylistManager", autospec=True
+        ) as MockPM:
+            mock_manager = MockPM.return_value
+            mock_manager.start = AsyncMock(return_value=True)
+
+            await core._handle_startup_playlist()
+
+            MockPM.assert_called_once_with(core)
+            mock_manager.start.assert_called_once_with("test-playlist")

--- a/tests/test_startup_playlist.py
+++ b/tests/test_startup_playlist.py
@@ -98,9 +98,7 @@ class TestStartupPlaylistActivation:
         # Remove playlists attribute so hasattr check triggers
         del core.playlists
 
-        with patch(
-            "ledfx.core.PlaylistManager", autospec=True
-        ) as MockPM:
+        with patch("ledfx.core.PlaylistManager", autospec=True) as MockPM:
             mock_manager = MockPM.return_value
             mock_manager.start = AsyncMock(return_value=True)
 

--- a/tests/test_startup_playlist.py
+++ b/tests/test_startup_playlist.py
@@ -1,0 +1,104 @@
+"""Tests for startup_playlist_id configuration and activation logic."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ledfx.config import CORE_CONFIG_SCHEMA
+
+
+class TestStartupPlaylistConfig:
+    """Test that startup_playlist_id is properly defined in config schema."""
+
+    def test_default_value_is_empty_string(self):
+        config = CORE_CONFIG_SCHEMA({})
+        assert config["startup_playlist_id"] == ""
+
+    def test_accepts_string_value(self):
+        config = CORE_CONFIG_SCHEMA({"startup_playlist_id": "my-playlist"})
+        assert config["startup_playlist_id"] == "my-playlist"
+
+    def test_present_in_no_restart_keys(self):
+        from ledfx.config import CORE_CONFIG_KEYS_NO_RESTART
+
+        assert "startup_playlist_id" in CORE_CONFIG_KEYS_NO_RESTART
+
+    def test_present_in_api_permitted_keys(self):
+        from ledfx.api.utils import PERMITTED_KEYS
+
+        assert "startup_playlist_id" in PERMITTED_KEYS["core"]
+
+
+class TestStartupPlaylistActivation:
+    """Test startup playlist activation logic in core startup flow."""
+
+    @pytest.fixture
+    def mock_core(self):
+        core = MagicMock()
+        core.config = {
+            "startup_scene_id": "",
+            "startup_playlist_id": "test-playlist",
+            "playlists": {
+                "test-playlist": {
+                    "name": "Test Playlist",
+                    "items": [{"scene_id": "scene-1"}],
+                    "default_duration_ms": 5000,
+                    "mode": "sequence",
+                    "timing": {
+                        "jitter": {
+                            "enabled": False,
+                            "factor_min": 1.0,
+                            "factor_max": 1.0,
+                        }
+                    },
+                    "tags": [],
+                    "image": "Wallpaper",
+                }
+            },
+            "scenes": {"scene-1": {"name": "Scene 1", "virtuals": {}}},
+        }
+        core.config_dir = ""
+        core.events = MagicMock()
+        return core
+
+    @pytest.mark.asyncio
+    async def test_startup_playlist_starts_when_configured(self, mock_core):
+        from ledfx.playlists import PlaylistManager
+
+        manager = PlaylistManager(mock_core)
+        manager.start = AsyncMock(return_value=True)
+
+        # Simulate the core.py startup logic
+        pid = mock_core.config["startup_playlist_id"]
+        assert pid != ""
+        result = await manager.start(pid)
+        assert result is True
+        manager.start.assert_called_once_with("test-playlist")
+
+    @pytest.mark.asyncio
+    async def test_startup_playlist_skipped_when_empty(self, mock_core):
+        mock_core.config["startup_playlist_id"] = ""
+
+        from ledfx.playlists import PlaylistManager
+
+        manager = PlaylistManager(mock_core)
+        manager.start = AsyncMock(return_value=True)
+
+        pid = mock_core.config["startup_playlist_id"]
+        # Should not start when empty string
+        assert pid == ""
+        manager.start.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_startup_playlist_warns_when_not_found(self, mock_core):
+        mock_core.config["startup_playlist_id"] = "nonexistent"
+
+        from ledfx.playlists import PlaylistManager
+
+        manager = PlaylistManager(mock_core)
+        manager.start = AsyncMock(return_value=False)
+
+        pid = mock_core.config["startup_playlist_id"]
+        result = await manager.start(pid)
+        assert result is False

--- a/uv.lock
+++ b/uv.lock
@@ -1151,7 +1151,7 @@ wheels = [
 
 [[package]]
 name = "ledfx"
-version = "2.1.6"
+version = "2.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2779,8 +2779,8 @@ name = "python-mbedtls"
 version = "2.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "typing-extensions" },
+    { name = "certifi", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/88/b7/b926727e3433ca2072e61572a36229ac21ebd46b0dca320d1c09f6fcd108/python-mbedtls-2.9.2.tar.gz", hash = "sha256:f541ccd23da2722724fd026c707a652883c497fe67340a8f1adb6ac73c487b31", size = 105334, upload-time = "2024-02-18T10:49:20.438Z" }
 wheels = [


### PR DESCRIPTION
## Add startup playlist support

### Summary



Frontend PR is https://github.com/YeonV/LedFx-Frontend-v2/pull/128

Adds a `startup_playlist_id` config option that automatically starts a playlist when LedFx launches, mirroring the existing `startup_scene_id` behavior.

### Motivation

Users can already configure a scene to activate on startup via `startup_scene_id`. This PR extends that pattern to playlists, allowing LedFx to begin cycling through scenes immediately on boot — useful for always-on installations and kiosk setups.

### Changes

- **`ledfx/config.py`** — Added `startup_playlist_id` (default: `""`) to `CORE_CONFIG_SCHEMA` and `CORE_CONFIG_KEYS_NO_RESTART` (no restart required to change)
- **`ledfx/api/utils.py`** — Added `startup_playlist_id` to `PERMITTED_KEYS["core"]` so it can be set via `PUT /api/config`
- **`ledfx/core.py`** — Imported `PlaylistManager` and added startup playlist activation after the startup scene block in `async_start()`. Lazily initializes the `PlaylistManager` if not already present, then calls `await self.playlists.start(pid)`. Logs info on success, warning if the playlist ID is not found.
- **`tests/test_startup_playlist.py`** — 7 tests covering config schema defaults, string acceptance, presence in no-restart keys, API permitted keys, and activation logic (start, skip when empty, warn when not found)

### Behavior

1. If `startup_playlist_id` is empty (default), nothing happens — no change to existing behavior
2. If set to a valid playlist ID, that playlist starts after the startup scene is applied
3. If the playlist ID doesn't exist, a warning is logged and startup continues normally
4. The startup scene still activates first (if configured); the playlist then takes over and will cycle through its own scenes on its schedule

### Testing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional configuration to auto-start a playlist at system startup; when set the system will attempt activation and log success or warnings.

* **Tests**
  * Added unit tests validating the new startup playlist config behavior and the activation flow (including creation/usage of the playlist manager).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->