### PR TITLE
Docs: Linux fix dependancy installs

### DIFF
--- a/docs/developer/developer.md
+++ b/docs/developer/developer.md
@@ -79,10 +79,25 @@ This assumes an apt based system such as ubuntu. If your system uses another pac
 
     ```console
     $ sudo apt install libatlas3-base \
-          libavformat58 \
           portaudio19-dev \
           pulseaudio \
-          cmake \
+          cmake
+    ```
+
+2. The libavformat dependancy either need the specific lib according to your OS and release version or just install ffmpeg
+
+    ```console
+    $ apt-cache search libavformat
+    ```
+
+    Look for the relevant lib of the format libavformatXX, for example
+
+    libavformat60 - FFmpeg library with (de)muxers for multimedia containers - runtime files
+
+    Install that specific generation
+
+    ```console
+    $ sudo apt install libavformatXX
     ```
 
 ### macOS Specific Steps {#macos-dev}


### PR DESCRIPTION
https://ledfx--1774.org.readthedocs.build/en/1774/developer/developer.html#linux-specific-steps-linux-dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux system dependency installation instructions with improved guidance for the `libavformat` dependency, providing options to install the correct package version for your system or use `ffmpeg` as an alternative fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->