### PR TITLE
Fix: Reject matching IP with no coexistance rule

### DIFF
--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -837,7 +837,8 @@ class Devices(RegistryLoader):
                 if "ip_address" in existing_device.config.keys() and (
                     existing_device.config["ip_address"] == device_ip
                     or existing_device.config["ip_address"] == resolved_dest
-                    or resolved_dest == getattr(existing_device, "_destination", None)
+                    or resolved_dest
+                    == getattr(existing_device, "_destination", None)
                 ):
                     self.run_device_ip_tests(
                         device_type, device_config, existing_device

--- a/ledfx/devices/__init__.py
+++ b/ledfx/devices/__init__.py
@@ -837,6 +837,7 @@ class Devices(RegistryLoader):
                 if "ip_address" in existing_device.config.keys() and (
                     existing_device.config["ip_address"] == device_ip
                     or existing_device.config["ip_address"] == resolved_dest
+                    or resolved_dest == getattr(existing_device, "_destination", None)
                 ):
                     self.run_device_ip_tests(
                         device_type, device_config, existing_device
@@ -1001,6 +1002,7 @@ class Devices(RegistryLoader):
             ValueError: if the devices cannot coexist due to a hard failure
         """
         for test in [
+            self.is_wled_duplicate,
             self.is_universe_separated,
             self.is_openrgb_id_separated,
             self.is_osc_port_path_separated,
@@ -1029,6 +1031,22 @@ class Devices(RegistryLoader):
         ):
             if result:
                 return
+
+        # No test explicitly approved coexistence - reject by default
+        msg = f"Ignoring {new_config.get('ip_address', 'unknown')}: Shares IP with existing device {pre_device.name} and no coexistence rule matched"
+        _LOGGER.info(msg)
+        raise ValueError(msg)
+
+    def is_wled_duplicate(self, new_type, new_config, pre_device):
+        """
+        Check if the new WLED device is a duplicate of an existing WLED device
+        on the same IP address.
+        """
+        if new_type == "wled" and pre_device.type == "wled":
+            msg = f"Ignoring {new_config['ip_address']}: WLED device already exists as {pre_device.name}"
+            _LOGGER.info(msg)
+            raise ValueError(msg)
+        return False
 
     def is_universe_separated(self, new_type, new_config, pre_device):
         """

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -7,6 +7,7 @@ from tests.conftest import all_effects, audio_configs
 from tests.test_definitions.coexistance import coexistance_tests
 from tests.test_definitions.devices import device_tests
 from tests.test_definitions.effects import effect_tests
+from tests.test_definitions.lifx import lifx_tests
 from tests.test_definitions.log import log_api_tests
 from tests.test_definitions.preset_delete import preset_delete_tests
 from tests.test_definitions.proof_of_life import proof_of_life_tests
@@ -40,6 +41,7 @@ test_groups = [
     ("coexistance_tests", coexistance_tests),
     ("log_api_tests", log_api_tests),
     ("preset_delete_tests", preset_delete_tests),
+    ("lifx_tests", lifx_tests),
 ]
 
 # Define a list of all test cases

--- a/tests/test_definitions/devices.py
+++ b/tests/test_definitions/devices.py
@@ -4,18 +4,7 @@
 # 3. Delete the device
 # 4. Check that the device no longer exists
 # 5. Recreate the device to allow it to be used in other tests
-#
-# Additional tests for LIFX devices:
-# 6. Create a LIFX device
-# 7. Check the LIFX device exists
-# 8. Delete the LIFX device
-# 9. Test find_lifx endpoint validation (missing ip_address)
 from tests.test_utilities.test_utils import APITestCase, SystemInfo
-
-_available_fps = SystemInfo.calc_available_fps()
-_default_lifx_fps = next(
-    (f for f in _available_fps if f >= 30), list(_available_fps)[-1]
-)
 
 device_tests = {
     "create_test_device": APITestCase(
@@ -145,105 +134,5 @@ device_tests = {
                 }
             },
         ],
-    ),
-    # LIFX device tests using lifx-emulator-core
-    # The emulator runs a Ceiling matrix device (8x8 = 64 pixels) at 127.0.0.1:56700
-    # LIFX devices auto-detect type on connect and update config accordingly
-    "create_lifx_device": APITestCase(
-        execution_order=6,
-        method="POST",
-        api_endpoint="/api/devices",
-        expected_return_code=200,
-        payload_to_send={
-            "type": "lifx",
-            "config": {
-                "icon_name": "mdi:lightbulb",
-                "center_offset": 0,
-                "refresh_rate": _default_lifx_fps,
-                "pixel_count": 1,
-                "name": "CI LIFX Test",
-                "ip_address": "127.0.0.1",
-            },
-        },
-        expected_response_keys=["status", "payload", "device"],
-        expected_response_values=[
-            {"status": "success"},
-            {
-                "device": {
-                    "type": "lifx",
-                    "config": {
-                        "icon_name": "mdi:lightbulb",
-                        "center_offset": 0,
-                        "refresh_rate": _default_lifx_fps,
-                        # Auto-detected from emulated matrix device
-                        "pixel_count": 64,
-                        "name": "CI LIFX Test",
-                        "ip_address": "127.0.0.1",
-                        "serial": "d073d9000001",
-                        "lifx_class": "CeilingLight",
-                        "lifx_type": "matrix",
-                        "matrix_width": 8,
-                        "matrix_height": 8,
-                    },
-                    "id": "ci-lifx-test",
-                    "virtuals": [],
-                }
-            },
-        ],
-    ),
-    "check_lifx_device": APITestCase(
-        execution_order=7,
-        method="GET",
-        api_endpoint="/api/devices",
-        expected_return_code=200,
-        expected_response_keys=["status", "devices"],
-        expected_response_values=[
-            {
-                "status": "success",
-                "devices": {
-                    "ci-lifx-test": {
-                        "config": {
-                            "icon_name": "mdi:lightbulb",
-                            "center_offset": 0,
-                            "refresh_rate": _default_lifx_fps,
-                            "pixel_count": 64,
-                            "name": "CI LIFX Test",
-                            "ip_address": "127.0.0.1",
-                            "serial": "d073d9000001",
-                            "lifx_class": "CeilingLight",
-                            "lifx_type": "matrix",
-                            "matrix_width": 8,
-                            "matrix_height": 8,
-                        },
-                        "id": "ci-lifx-test",
-                        "type": "lifx",
-                        "online": True,
-                        "virtuals": [],
-                        "active_virtuals": [],
-                    },
-                },
-            }
-        ],
-    ),
-    "delete_lifx_device": APITestCase(
-        execution_order=8,
-        method="DELETE",
-        api_endpoint="/api/virtuals/ci-lifx-test",
-        expected_return_code=200,
-        expected_response_keys=["status"],
-        expected_response_values=[{"status": "success"}],
-        payload_to_send={"name": "CI LIFX Test"},
-    ),
-    # find_lifx endpoint validation tests
-    # Send valid JSON without ip_address to test missing field validation
-    # Note: Empty {} is falsy and becomes None in test framework, so use non-empty payload
-    "find_lifx_missing_ip": APITestCase(
-        execution_order=9,
-        method="POST",
-        api_endpoint="/api/find_lifx",
-        expected_return_code=200,
-        payload_to_send={"timeout": 1},
-        expected_response_keys=["status"],
-        expected_response_values=[{"status": "failed"}],
     ),
 }

--- a/tests/test_definitions/lifx.py
+++ b/tests/test_definitions/lifx.py
@@ -1,0 +1,128 @@
+# LIFX device tests using lifx-emulator-core
+# The emulator runs a Ceiling matrix device (8x8 = 64 pixels) at 127.0.0.1:56700
+# LIFX devices auto-detect type on connect and update config accordingly
+#
+# These tests run last because the LIFX emulator is bound to 127.0.0.1
+# and no coexistence rule exists between LIFX and the DDP test jig.
+# The test jig is deleted first to free the IP.
+#
+# 1. Delete the DDP test jig (frees 127.0.0.1)
+# 2. Create a LIFX device
+# 3. Check the LIFX device exists
+# 4. Delete the LIFX device
+# 5. Test find_lifx endpoint validation (missing ip_address)
+from tests.test_utilities.test_utils import APITestCase, SystemInfo
+
+_available_fps = SystemInfo.calc_available_fps()
+_default_lifx_fps = next(
+    (f for f in _available_fps if f >= 30), list(_available_fps)[-1]
+)
+
+lifx_tests = {
+    "delete_test_jig": APITestCase(
+        execution_order=1,
+        method="DELETE",
+        api_endpoint="/api/virtuals/ci-test-jig",
+        expected_return_code=200,
+        expected_response_keys=["status"],
+        expected_response_values=[{"status": "success"}],
+        payload_to_send={"name": "CI Test Jig"},
+    ),
+    "create_lifx_device": APITestCase(
+        execution_order=2,
+        method="POST",
+        api_endpoint="/api/devices",
+        expected_return_code=200,
+        payload_to_send={
+            "type": "lifx",
+            "config": {
+                "icon_name": "mdi:lightbulb",
+                "center_offset": 0,
+                "refresh_rate": _default_lifx_fps,
+                "pixel_count": 1,
+                "name": "CI LIFX Test",
+                "ip_address": "127.0.0.1",
+            },
+        },
+        expected_response_keys=["status", "payload", "device"],
+        expected_response_values=[
+            {"status": "success"},
+            {
+                "device": {
+                    "type": "lifx",
+                    "config": {
+                        "icon_name": "mdi:lightbulb",
+                        "center_offset": 0,
+                        "refresh_rate": _default_lifx_fps,
+                        # Auto-detected from emulated matrix device
+                        "pixel_count": 64,
+                        "name": "CI LIFX Test",
+                        "ip_address": "127.0.0.1",
+                        "serial": "d073d9000001",
+                        "lifx_class": "CeilingLight",
+                        "lifx_type": "matrix",
+                        "matrix_width": 8,
+                        "matrix_height": 8,
+                    },
+                    "id": "ci-lifx-test",
+                    "virtuals": [],
+                }
+            },
+        ],
+    ),
+    "check_lifx_device": APITestCase(
+        execution_order=3,
+        method="GET",
+        api_endpoint="/api/devices",
+        expected_return_code=200,
+        expected_response_keys=["status", "devices"],
+        expected_response_values=[
+            {
+                "status": "success",
+                "devices": {
+                    "ci-lifx-test": {
+                        "config": {
+                            "icon_name": "mdi:lightbulb",
+                            "center_offset": 0,
+                            "refresh_rate": _default_lifx_fps,
+                            "pixel_count": 64,
+                            "name": "CI LIFX Test",
+                            "ip_address": "127.0.0.1",
+                            "serial": "d073d9000001",
+                            "lifx_class": "CeilingLight",
+                            "lifx_type": "matrix",
+                            "matrix_width": 8,
+                            "matrix_height": 8,
+                        },
+                        "id": "ci-lifx-test",
+                        "type": "lifx",
+                        "online": True,
+                        "virtuals": [],
+                        "active_virtuals": [],
+                    },
+                },
+            }
+        ],
+    ),
+    "delete_lifx_device": APITestCase(
+        execution_order=4,
+        method="DELETE",
+        api_endpoint="/api/virtuals/ci-lifx-test",
+        expected_return_code=200,
+        expected_response_keys=["status"],
+        expected_response_values=[{"status": "success"}],
+        payload_to_send={"name": "CI LIFX Test"},
+    ),
+    # find_lifx endpoint validation tests
+    # Send valid JSON without ip_address to test missing field validation
+    # Note: Empty {} is falsy and becomes None in test framework, so use non-empty payload
+    "find_lifx_missing_ip": APITestCase(
+        execution_order=5,
+        method="POST",
+        api_endpoint="/api/find_lifx",
+        expected_return_code=200,
+        payload_to_send={"timeout": 1},
+        expected_response_keys=["status"],
+        expected_response_values=[{"status": "failed"}],
+    ),
+}

--- a/tests/test_definitions/lifx.py
+++ b/tests/test_definitions/lifx.py
@@ -19,13 +19,14 @@ _default_lifx_fps = next(
 )
 
 lifx_tests = {
+    # Delete test jig if it still exists (may already be gone from earlier test groups)
     "delete_test_jig": APITestCase(
         execution_order=1,
         method="DELETE",
         api_endpoint="/api/virtuals/ci-test-jig",
         expected_return_code=200,
         expected_response_keys=["status"],
-        expected_response_values=[{"status": "success"}],
+        expected_response_values=[],
         payload_to_send={"name": "CI Test Jig"},
     ),
     "create_lifx_device": APITestCase(


### PR DESCRIPTION
As per https://github.com/LedFx/LedFx/issues/1769

All the fancy co-existance rules were great, but instead of rejecting on matching IP at the end, we just accepted!!

Allowed duplicate device creation where specific rules did not exist instead of defaulting to rejection :-(

Test cases were for rule sets, not final state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-device detection and stricter IP-based matching when adding devices.
  * Explicitly prevents WLED devices from coexisting on the same IP; conflicting device creations are now rejected with clearer logging and errors.

* **Tests**
  * Added a dedicated LIFX API test suite and removed legacy LIFX cases from the general device test definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->