### PR TITLE
Fix: Hotplug investigation and fix

### DIFF
--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -197,8 +197,13 @@ class LedFxCore:
         Callback for audio-hotplug library when device changes detected.
 
         Delegates all audio recovery logic to AudioInputSource.handle_device_list_change()
-        to keep audio lifecycle management in one place.
+        to keep audio lifecycle management in one place.  That method coalesces
+        rapid OS notifications so only one refresh runs at a time.
         """
+        _LOGGER.info(
+            "Audio refresh %d scheduled (system device-change event)",
+            AudioInputSource._refresh_generation + 1,
+        )
         # Let AudioInputSource handle the full lifecycle: stop, refresh, recover, restart
         if hasattr(self, "audio") and self.audio:
             self.audio.handle_device_list_change()
@@ -209,7 +214,7 @@ class LedFxCore:
         # Fire LedFx event for any listeners (e.g., websocket notifications)
         self.events.fire_event(AudioDeviceListChangedEvent())
 
-        _LOGGER.info("Audio device list updated in response to system change")
+        _LOGGER.debug("Audio device list event dispatched to websocket listeners")
 
     def _load_sendspin_servers(self):
         """Load Sendspin server configurations from config into the audio system."""

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -214,7 +214,9 @@ class LedFxCore:
         # Fire LedFx event for any listeners (e.g., websocket notifications)
         self.events.fire_event(AudioDeviceListChangedEvent())
 
-        _LOGGER.debug("Audio device list event dispatched to websocket listeners")
+        _LOGGER.debug(
+            "Audio device list event dispatched to websocket listeners"
+        )
 
     def _load_sendspin_servers(self):
         """Load Sendspin server configurations from config into the audio system."""

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -58,7 +58,9 @@ class AudioInputSource:
 
     # Hotplug refresh coalescing state (all guarded by _class_lock)
     _refresh_in_progress = False  # True while a refresh cycle is executing
-    _refresh_pending = False  # True if another refresh should run after current
+    _refresh_pending = (
+        False  # True if another refresh should run after current
+    )
     _refresh_generation = 0  # Monotonic counter: identifies each refresh cycle
 
     # Stream identity / callback staleness detection (guarded by _class_lock)
@@ -153,7 +155,9 @@ class AudioInputSource:
                 if hasattr(stream, "abort"):
                     stream.abort()
                     _LOGGER.info(
-                        "%sStream id=%s aborted successfully", prefix, stream_id
+                        "%sStream id=%s aborted successfully",
+                        prefix,
+                        stream_id,
                     )
                     stop_ok = True
                 else:
@@ -167,7 +171,9 @@ class AudioInputSource:
                     "%sstream.abort() id=%s failed: %s", prefix, stream_id, e
                 )
         else:
-            _LOGGER.debug("%sStream id=%s stopped gracefully", prefix, stream_id)
+            _LOGGER.debug(
+                "%sStream id=%s stopped gracefully", prefix, stream_id
+            )
             stop_ok = True
 
         # 3. close() releases the PortAudio stream handle.
@@ -206,7 +212,9 @@ class AudioInputSource:
             bool: True if an audio stream was active before refresh (and should be reactivated),
                   False otherwise
         """
-        gen_tag = f"Audio refresh {gen}: " if gen is not None else "Audio refresh: "
+        gen_tag = (
+            f"Audio refresh {gen}: " if gen is not None else "Audio refresh: "
+        )
 
         # Wait for any in-progress activation to complete before touching
         # PortAudio.  Setting _activating = True also blocks concurrent
@@ -265,9 +273,13 @@ class AudioInputSource:
                 sd._initialize()
                 # Clear the device list cache
                 AudioInputSource._device_list_cache = None
-                _LOGGER.info("%sPortAudio reinitialized, device list refreshed", gen_tag)
+                _LOGGER.info(
+                    "%sPortAudio reinitialized, device list refreshed", gen_tag
+                )
             except Exception as e:
-                _LOGGER.warning("%sFailed to refresh audio device list: %s", gen_tag, e)
+                _LOGGER.warning(
+                    "%sFailed to refresh audio device list: %s", gen_tag, e
+                )
 
             return was_active
         finally:

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -206,7 +206,6 @@ class AudioInputSource:
             )
             stop_ok = True
 
-
         # 3. close() releases the PortAudio stream handle.
         try:
             stream.close()

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -2,6 +2,7 @@ import logging
 import queue
 import threading
 import time
+import weakref
 from collections import deque
 from functools import cached_property, lru_cache
 
@@ -29,13 +30,28 @@ MIN_MIDI = 21
 MAX_MIDI = 108
 
 
-def _stream_stop_worker(stream):
+def _stream_stop_worker(stream_ref, stop_result):
     """Target for the timeout thread in _close_stream.
-    Calls stream.stop() which may block indefinitely on some drivers."""
+    Accepts a weakref to the stream so that a hung thread does not keep a
+    strong reference to the stream object after _close_stream returns.
+    Dereferences the weakref at entry; if the stream has already been
+    collected (e.g. close() raced ahead), marks stop as succeeded and
+    returns immediately.  Records any exception into
+    stop_result["stop_error"] so _close_stream can detect failures even
+    when stop() returns promptly."""
+    stream = stream_ref()
+    if stream is None:
+        # Stream was already collected — nothing to stop.
+        stop_result["stopped"] = True
+        return
     try:
         stream.stop()
-    except Exception:
-        pass  # Caller will fall back to abort()
+        stop_result["stopped"] = True
+    except Exception as exc:
+        stop_result["stopped"] = False
+        stop_result["stop_error"] = exc
+    finally:
+        stream = None  # Drop strong ref so GC is not blocked by this thread
 
 
 class AudioInputSource:
@@ -71,6 +87,8 @@ class AudioInputSource:
 
     # Timeout for graceful stream stop before falling back to abort
     _STREAM_STOP_TIMEOUT_S = 3.0
+    # Additional timeout after abort()+close() for the stop thread to exit
+    _STREAM_ABORT_TIMEOUT_S = 1.0
 
     @staticmethod
     def _close_stream(
@@ -130,9 +148,11 @@ class AudioInputSource:
         #    (seen on some Windows WASAPI loopback drivers during unplug)
         #    does not keep the caller blocked.
         stop_ok = False
+        stop_result = {"stopped": False, "stop_error": None}
+        stream_ref = weakref.ref(stream)
         stop_thread = threading.Thread(
             target=_stream_stop_worker,
-            args=(stream,),
+            args=(stream_ref, stop_result),
             daemon=True,
         )
         stop_thread.start()
@@ -147,6 +167,16 @@ class AudioInputSource:
                 stream_id,
                 device_hint,
             )
+        elif stop_result["stop_error"] is not None:
+            _LOGGER.warning(
+                "%sstream.stop() raised an exception (id=%s%s): %s — "
+                "attempting abort()",
+                prefix,
+                stream_id,
+                device_hint,
+                stop_result["stop_error"],
+            )
+        if stop_thread.is_alive() or stop_result["stop_error"] is not None:
             # 2. abort() is Pa_AbortStream — immediate, does not wait for
             #    the callback to finish.  After abort(), any still-running
             #    stop() in the worker thread should eventually return (or
@@ -176,6 +206,7 @@ class AudioInputSource:
             )
             stop_ok = True
 
+
         # 3. close() releases the PortAudio stream handle.
         try:
             stream.close()
@@ -183,6 +214,21 @@ class AudioInputSource:
         except Exception as e:
             _LOGGER.warning(
                 "%sstream.close() id=%s failed: %s", prefix, stream_id, e
+            )
+
+        # 4. Second bounded join: after abort()+close() the stop thread
+        #    should unblock promptly.  If it is still alive after this
+        #    extra wait, log a persistent-hang warning and proceed — do
+        #    not spawn further fire-and-forget threads for this close path.
+        stop_thread.join(timeout=AudioInputSource._STREAM_ABORT_TIMEOUT_S)
+        if stop_thread.is_alive():
+            _LOGGER.warning(
+                "%sStop thread for stream id=%s%s is still alive after "
+                "abort()+close() — the thread will be reclaimed by the OS "
+                "at process exit; proceeding",
+                prefix,
+                stream_id,
+                device_hint,
             )
 
         if not stop_ok:

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -56,11 +56,24 @@ class AudioInputSource:
     _class_lock = threading.Lock()  # Class-level lock for shared state
     _activating = False  # Re-entry guard for activate()
 
+    # Hotplug refresh coalescing state (all guarded by _class_lock)
+    _refresh_in_progress = False  # True while a refresh cycle is executing
+    _refresh_pending = False  # True if another refresh should run after current
+    _refresh_generation = 0  # Monotonic counter: identifies each refresh cycle
+
+    # Stream identity / callback staleness detection (guarded by _class_lock)
+    # Incremented each time a new stream is successfully opened; copied to the
+    # AudioInputSource instance as _callback_stream_gen so callbacks from a
+    # replaced stream can detect they are stale and self-discard.
+    _stream_generation = 0
+
     # Timeout for graceful stream stop before falling back to abort
     _STREAM_STOP_TIMEOUT_S = 3.0
 
     @staticmethod
-    def _close_stream(stream, context=""):
+    def _close_stream(
+        stream, context="", gen=None, device_name="", device_idx=None
+    ):
         """
         Defensively close a PortAudio stream with timeout-guarded stop()
         and abort() fallback.
@@ -70,69 +83,112 @@ class AudioInputSource:
         indefinitely and ensures PortAudio is left in a safe state for a
         subsequent _terminate()/_initialize() cycle.
 
+        The stop() call runs in a daemon thread so that, if it wedges, we
+        can still fall through to abort() + close() without blocking the
+        caller.  The daemon thread will be reclaimed by the OS when the
+        process exits.  Rapid hotplug events are coalesced by
+        handle_device_list_change() so that at most one stop thread is
+        in-flight per refresh generation.
+
         Args:
-            stream: The sounddevice InputStream (or WebAudioStream / SendspinAudioStream)
-                    to close. May be None (no-op).
-            context: Short label for log messages (e.g. "refresh", "deactivate").
+            stream:      The sounddevice InputStream (or WebAudioStream /
+                         SendspinAudioStream) to close.  May be None (no-op).
+            context:     Short label for log messages (e.g. "stop", "deactivate").
+            gen:         Refresh generation integer, forwarded to log messages.
+            device_name: Human-readable device name for richer diagnostics.
+            device_idx:  Device index for richer diagnostics.
         """
         if stream is None:
             return
 
-        prefix = f"[{context}] " if context else ""
+        # Build a rich context prefix once so every log line is consistent.
+        parts = []
+        if gen is not None:
+            parts.append(f"refresh {gen}")
+        if context:
+            parts.append(context)
+        prefix = f"[{' | '.join(parts)}] " if parts else ""
 
-        # 1. Attempt graceful stop with a timeout
+        stream_id = id(stream)
+        device_hint = ""
+        if device_name:
+            device_hint += f" device='{device_name}'"
+        if device_idx is not None:
+            device_hint += f" index={device_idx}"
+
+        _LOGGER.debug(
+            "%sStopping stream id=%s%s",
+            prefix,
+            stream_id,
+            device_hint,
+        )
+
+        # 1. Attempt graceful stop with a timeout.
+        #    The worker is a daemon thread so a permanently wedged stop()
+        #    (seen on some Windows WASAPI loopback drivers during unplug)
+        #    does not keep the caller blocked.
         stop_ok = False
         stop_thread = threading.Thread(
             target=_stream_stop_worker,
             args=(stream,),
             daemon=True,
         )
-        _LOGGER.debug("%sRequesting stream stop...", prefix)
         stop_thread.start()
         stop_thread.join(timeout=AudioInputSource._STREAM_STOP_TIMEOUT_S)
 
         if stop_thread.is_alive():
             _LOGGER.warning(
-                "%sstream.stop() did not return within %.1fs — "
+                "%sstream.stop() timed out after %.1fs (id=%s%s) — "
                 "attempting abort()",
                 prefix,
                 AudioInputSource._STREAM_STOP_TIMEOUT_S,
+                stream_id,
+                device_hint,
             )
             # 2. abort() is Pa_AbortStream — immediate, does not wait for
-            #    the callback to finish.
+            #    the callback to finish.  After abort(), any still-running
+            #    stop() in the worker thread should eventually return (or
+            #    throw) and exit, releasing its reference to the stream.
             try:
                 if hasattr(stream, "abort"):
                     stream.abort()
-                    _LOGGER.info("%sStream aborted successfully", prefix)
+                    _LOGGER.info(
+                        "%sStream id=%s aborted successfully", prefix, stream_id
+                    )
                     stop_ok = True
                 else:
                     _LOGGER.warning(
-                        "%sStream has no abort() method; "
-                        "proceeding to close()",
+                        "%sStream id=%s has no abort(); proceeding to close()",
                         prefix,
+                        stream_id,
                     )
             except Exception as e:
-                _LOGGER.warning("%sstream.abort() failed: %s", prefix, e)
+                _LOGGER.warning(
+                    "%sstream.abort() id=%s failed: %s", prefix, stream_id, e
+                )
         else:
-            _LOGGER.debug("%sStream stopped gracefully", prefix)
+            _LOGGER.debug("%sStream id=%s stopped gracefully", prefix, stream_id)
             stop_ok = True
 
         # 3. close() releases the PortAudio stream handle.
         try:
             stream.close()
-            _LOGGER.debug("%sStream closed", prefix)
+            _LOGGER.debug("%sStream id=%s closed", prefix, stream_id)
         except Exception as e:
-            _LOGGER.warning("%sstream.close() failed: %s", prefix, e)
+            _LOGGER.warning(
+                "%sstream.close() id=%s failed: %s", prefix, stream_id, e
+            )
 
         if not stop_ok:
             _LOGGER.warning(
-                "%sStream may not have stopped cleanly — "
+                "%sStream id=%s may not have stopped cleanly — "
                 "PortAudio reinit recommended",
                 prefix,
+                stream_id,
             )
 
     @staticmethod
-    def refresh_device_list():
+    def refresh_device_list(gen=None):
         """
         Force sounddevice/PortAudio to rescan audio devices.
         This is necessary because PortAudio caches the device list at initialization.
@@ -143,10 +199,15 @@ class AudioInputSource:
         sd._terminate()/_initialize() from running concurrently with
         open_audio_stream().
 
+        Args:
+            gen: Optional refresh generation integer for log tagging.
+
         Returns:
             bool: True if an audio stream was active before refresh (and should be reactivated),
                   False otherwise
         """
+        gen_tag = f"Audio refresh {gen}: " if gen is not None else "Audio refresh: "
+
         # Wait for any in-progress activation to complete before touching
         # PortAudio.  Setting _activating = True also blocks concurrent
         # activate() calls while the refresh is running.
@@ -158,43 +219,55 @@ class AudioInputSource:
                     break
             if time.monotonic() > deadline:
                 _LOGGER.warning(
-                    "Timed out waiting for activation to complete before device list refresh"
+                    "%sTimed out waiting for activation to complete before device list refresh",
+                    gen_tag,
                 )
                 return False
             time.sleep(0.05)
 
         try:
-            # Check if there's an active stream that needs to be stopped
-            # Use class lock to safely cache and clear the stream reference
+            # Capture stream reference and device metadata under the lock
+            # so _close_stream() can log rich diagnostics without holding
+            # the lock (which would deadlock against the audio callback).
             stream_to_close = None
+            dev_name = ""
+            dev_idx = None
             with AudioInputSource._class_lock:
                 was_active = AudioInputSource._audio_stream_active
 
                 if was_active:
                     _LOGGER.info(
-                        "Stopping audio stream before device list refresh..."
+                        "%sStopping audio stream before device list refresh...",
+                        gen_tag,
                     )
-                    # Cache and clear inside lock (atomic operation)
                     stream_to_close = AudioInputSource._stream
+                    dev_name = AudioInputSource._last_device_name or ""
+                    dev_idx = AudioInputSource._last_active
                     AudioInputSource._stream = None
                     AudioInputSource._audio_stream_active = False
 
             # Close outside lock to avoid deadlock with audio callbacks
             if stream_to_close:
                 AudioInputSource._close_stream(
-                    stream_to_close, context="refresh"
+                    stream_to_close,
+                    context="stop",
+                    gen=gen,
+                    device_name=dev_name,
+                    device_idx=dev_idx,
                 )
 
-            _LOGGER.debug("Cycling PortAudio for device rescan...")
+            _LOGGER.debug("%sCycling PortAudio for device rescan...", gen_tag)
             try:
                 # Force PortAudio to rescan devices by terminating and reinitializing
+                _LOGGER.debug("%sTerminating PortAudio", gen_tag)
                 sd._terminate()
+                _LOGGER.debug("%sInitializing PortAudio", gen_tag)
                 sd._initialize()
                 # Clear the device list cache
                 AudioInputSource._device_list_cache = None
-                _LOGGER.info("Audio device list refreshed")
+                _LOGGER.info("%sPortAudio reinitialized, device list refreshed", gen_tag)
             except Exception as e:
-                _LOGGER.warning("Failed to refresh audio device list: %s", e)
+                _LOGGER.warning("%sFailed to refresh audio device list: %s", gen_tag, e)
 
             return was_active
         finally:
@@ -241,22 +314,77 @@ class AudioInputSource:
         """
         Handle audio device list changes with automatic stream recovery.
 
-        This method encapsulates the full lifecycle:
-        1. Stop active stream and refresh device list
-        2. Find previously active device by name (indices may have shifted)
-        3. Update config with new device index if changed
-        4. Reactivate stream with correct device
+        Rapid OS-level notifications (e.g. Windows emitting several events
+        for a single unplug/replug) are coalesced here:
 
-        This keeps all audio recovery logic in one place rather than split
-        across core.py and audio.py.
+        * If a refresh is already running, we set _refresh_pending = True
+          and return immediately.  At most one extra refresh will be queued.
+        * Once the running refresh completes, it checks _refresh_pending and
+          spawns a single follow-up thread if needed.
+
+        The actual refresh logic lives in _run_device_refresh() so it can be
+        called both from here and from the follow-up thread.
+        """
+        with AudioInputSource._class_lock:
+            if AudioInputSource._refresh_in_progress:
+                if not AudioInputSource._refresh_pending:
+                    AudioInputSource._refresh_pending = True
+                    _LOGGER.info(
+                        "Audio refresh %d queued (refresh %d is in progress)",
+                        AudioInputSource._refresh_generation + 1,
+                        AudioInputSource._refresh_generation,
+                    )
+                # else: already one queued; silently drop this extra event
+                return
+            AudioInputSource._refresh_generation += 1
+            gen = AudioInputSource._refresh_generation
+            AudioInputSource._refresh_in_progress = True
+
+        _LOGGER.info("Audio refresh %d started", gen)
+        try:
+            self._run_device_refresh(gen)
+        finally:
+            with AudioInputSource._class_lock:
+                AudioInputSource._refresh_in_progress = False
+                should_rerun = AudioInputSource._refresh_pending
+                if should_rerun:
+                    AudioInputSource._refresh_pending = False
+
+            if should_rerun:
+                _LOGGER.info(
+                    "Audio refresh %d complete; launching refresh %d due to queued hotplug event",
+                    gen,
+                    gen + 1,
+                )
+                t = threading.Thread(
+                    target=self.handle_device_list_change,
+                    daemon=True,
+                    name="audio-hotplug-refresh",
+                )
+                t.start()
+            else:
+                _LOGGER.info("Audio refresh %d complete", gen)
+
+    def _run_device_refresh(self, gen):
+        """
+        Execute one full device-change refresh cycle: stop stream, rescan
+        devices, locate the previously-active device by name, update config,
+        and reactivate.
+
+        Called exclusively from handle_device_list_change() under the
+        _refresh_in_progress / _refresh_pending coalescing umbrella.
+
+        Args:
+            gen: Refresh generation number for log tagging.
         """
         # Stop any active stream and refresh the device list
-        was_active = self.refresh_device_list()
+        was_active = self.refresh_device_list(gen=gen)
 
         # If no stream was active, nothing to recover
         if not was_active:
             _LOGGER.debug(
-                "Device list changed but no audio stream was active - no recovery needed"
+                "Audio refresh %d: no stream was active - no recovery needed",
+                gen,
             )
             return
 
@@ -268,21 +396,22 @@ class AudioInputSource:
 
         if not last_device_name:
             _LOGGER.warning(
-                "Cannot recover audio stream: previous device name not tracked"
+                "Audio refresh %d: cannot recover stream - previous device name not tracked",
+                gen,
             )
             # Try to reactivate with current config anyway
             try:
                 self.activate()
             except Exception as e:
                 _LOGGER.error(
-                    "Failed to reactivate audio stream after device change: %s",
-                    e,
+                    "Audio refresh %d: failed to reactivate stream: %s", gen, e
                 )
             return
 
         # Find device at its new index
         _LOGGER.info(
-            "Attempting to recover audio device '%s' (was at index %s)",
+            "Audio refresh %d: recovering device '%s' (was at index %s)",
+            gen,
             last_device_name,
             last_device_idx,
         )
@@ -290,8 +419,9 @@ class AudioInputSource:
 
         if found_idx == -1:
             _LOGGER.warning(
-                "Previously active device '%s' no longer available after device list change. "
-                "Will use default device.",
+                "Audio refresh %d: device '%s' no longer available "
+                "(may have been unplugged). Falling back to default.",
+                gen,
                 last_device_name,
             )
             # Clear the stored device info since it's gone
@@ -302,24 +432,31 @@ class AudioInputSource:
             # Use default device logic (prefers loopback of default output, then default input)
             fallback_idx = AudioInputSource.default_device_index()
             if fallback_idx is not None:
-                _LOGGER.info("Using fallback device at index %s", fallback_idx)
+                _LOGGER.info(
+                    "Audio refresh %d: using fallback device at index %s",
+                    gen,
+                    fallback_idx,
+                )
                 self._update_device_config(fallback_idx)
             else:
-                # No valid devices at all - clear config to trigger validator
-                _LOGGER.warning("No fallback device available")
+                _LOGGER.warning(
+                    "Audio refresh %d: no fallback device available", gen
+                )
                 self._update_device_config(None)
         else:
             current_config_idx = self._config.get("audio_device", -1)
             if found_idx != current_config_idx:
                 _LOGGER.info(
-                    "Device list changed: '%s' moved from index %s to %s",
+                    "Audio refresh %d: '%s' moved from index %s to %s",
+                    gen,
                     last_device_name,
                     current_config_idx,
                     found_idx,
                 )
             else:
                 _LOGGER.info(
-                    "Device list changed: '%s' still at index %s",
+                    "Audio refresh %d: '%s' still at index %s",
+                    gen,
                     last_device_name,
                     found_idx,
                 )
@@ -328,12 +465,17 @@ class AudioInputSource:
             self._update_device_config(found_idx)
 
         # Reactivate the stream with the updated configuration
+        _LOGGER.info(
+            "Audio refresh %d: reopening stream on device='%s' index=%s",
+            gen,
+            last_device_name,
+            found_idx if found_idx != -1 else None,
+        )
         try:
-            _LOGGER.info("Reactivating audio stream after device list refresh")
             self.activate()
         except Exception as e:
             _LOGGER.error(
-                "Failed to reactivate audio stream after device change: %s", e
+                "Audio refresh %d: failed to reactivate stream: %s", gen, e
             )
 
     @staticmethod
@@ -506,6 +648,14 @@ class AudioInputSource:
         self.lock = threading.Lock()
         # We must not inherit legacy _callbacks from prior instances
         self._callbacks = []
+        # Callback-side generation tracking: set to _stream_generation each time
+        # a new stream is opened.  _audio_sample_callback() compares this to the
+        # class-level _stream_generation so that late-firing callbacks from a
+        # replaced stream are silently discarded rather than feeding stale data.
+        self._callback_stream_gen = 0
+        # Rate-limit malformed-frame logging: log once per stream generation so
+        # a bad device during teardown doesn't flood the log.
+        self._malformed_frame_last_gen = None
         self.update_config(config)
 
         def shutdown_event(e):
@@ -827,6 +977,10 @@ class AudioInputSource:
 
             AudioInputSource._stream.start()
             with AudioInputSource._class_lock:
+                # Bump the stream generation so that any lingering callbacks
+                # from the previous stream detect they are stale and self-discard.
+                AudioInputSource._stream_generation += 1
+                self._callback_stream_gen = AudioInputSource._stream_generation
                 AudioInputSource._audio_stream_active = True
 
         def try_open_device(dev_idx, reinit=False):
@@ -915,18 +1069,26 @@ class AudioInputSource:
     def deactivate(self):
         # Stop the stream outside the lock to avoid deadlock with audio callback
         # The audio callback thread may be waiting to complete, and if it needs
-        # any locks, holding the lock while calling stop() creates a circular wait
+        # any locks, holding the lock while calling stop() creates a circular wait.
+        # Capture device metadata inside the lock for rich diagnostics.
         stream_to_close = None
+        dev_name = ""
+        dev_idx = None
         with AudioInputSource._class_lock:
             if AudioInputSource._stream:
                 stream_to_close = AudioInputSource._stream
                 AudioInputSource._stream = None
+                dev_name = AudioInputSource._last_device_name or ""
+                dev_idx = AudioInputSource._last_active
             AudioInputSource._audio_stream_active = False
 
         # Stop/close outside the lock — uses timeout + abort() fallback
         if stream_to_close:
             AudioInputSource._close_stream(
-                stream_to_close, context="deactivate"
+                stream_to_close,
+                context="deactivate",
+                device_name=dev_name,
+                device_idx=dev_idx,
             )
             _LOGGER.info("Audio source closed.")
 
@@ -1009,8 +1171,16 @@ class AudioInputSource:
 
     def _audio_sample_callback(self, in_data, frame_count, time_info, status):
         """Callback for when a new audio sample is acquired"""
-        # time_start = time.time()
-        # self._raw_audio_sample = np.frombuffer(in_data, dtype=np.float32)
+        # Guard: discard callbacks that fire after the stream was replaced.
+        # _callback_stream_gen is set per-instance when the stream is opened;
+        # _stream_generation is the class-level counter.  A mismatch means
+        # this callback fires from a stream that has already been closed/replaced.
+        # This is a read-only check on immutable integers — no lock needed.
+        my_gen = self._callback_stream_gen
+        if my_gen != AudioInputSource._stream_generation:
+            # Stale callback from an old stream generation — silently discard.
+            return
+
         raw_sample = np.frombuffer(in_data, dtype=np.float32)
 
         in_sample_len = len(raw_sample)
@@ -1020,19 +1190,23 @@ class AudioInputSource:
             # Simple resampling
             processed_audio_sample = self.resampler.process(
                 raw_sample,
-                # MIC_RATE / self._stream.samplerate
                 out_sample_len / in_sample_len,
-                # end_of_input=True
             )
         else:
             processed_audio_sample = raw_sample
 
         if len(processed_audio_sample) != out_sample_len:
-            _LOGGER.debug(
-                "Discarded malformed audio frame - %s samples, expected %s",
-                len(processed_audio_sample),
-                out_sample_len,
-            )
+            # Rate-limit malformed-frame logging to once per stream generation
+            # so bad hardware during teardown doesn't flood the log.
+            if self._malformed_frame_last_gen != my_gen:
+                self._malformed_frame_last_gen = my_gen
+                _LOGGER.debug(
+                    "Discarded malformed audio frame (gen=%s, got=%s expected=%s); "
+                    "further malformed frames this stream will be silent.",
+                    my_gen,
+                    len(processed_audio_sample),
+                    out_sample_len,
+                )
             return
 
         # handle delaying the audio with the queue
@@ -1050,9 +1224,6 @@ class AudioInputSource:
             self.pre_process_audio()
             self._invalidate_caches()
             self._invoke_callbacks()
-
-        # print(f"Core Audio Processing Latency {round(time.time()-time_start, 3)} s")
-        # return self._raw_audio_sample
 
     def _invoke_callbacks(self):
         """Notifies all clients of the new data"""

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -29,6 +29,15 @@ MIN_MIDI = 21
 MAX_MIDI = 108
 
 
+def _stream_stop_worker(stream):
+    """Target for the timeout thread in _close_stream.
+    Calls stream.stop() which may block indefinitely on some drivers."""
+    try:
+        stream.stop()
+    except Exception:
+        pass  # Caller will fall back to abort()
+
+
 class AudioInputSource:
     _audio_stream_active = False
     _audio = None
@@ -46,6 +55,81 @@ class AudioInputSource:
     _device_list_cache = None  # Cache for device list
     _class_lock = threading.Lock()  # Class-level lock for shared state
     _activating = False  # Re-entry guard for activate()
+
+    # Timeout for graceful stream stop before falling back to abort
+    _STREAM_STOP_TIMEOUT_S = 3.0
+
+    @staticmethod
+    def _close_stream(stream, context=""):
+        """
+        Defensively close a PortAudio stream with timeout-guarded stop()
+        and abort() fallback.
+
+        Some Windows WASAPI drivers hang in Pa_StopStream when the device
+        is being unplugged.  This helper prevents the caller from blocking
+        indefinitely and ensures PortAudio is left in a safe state for a
+        subsequent _terminate()/_initialize() cycle.
+
+        Args:
+            stream: The sounddevice InputStream (or WebAudioStream / SendspinAudioStream)
+                    to close. May be None (no-op).
+            context: Short label for log messages (e.g. "refresh", "deactivate").
+        """
+        if stream is None:
+            return
+
+        prefix = f"[{context}] " if context else ""
+
+        # 1. Attempt graceful stop with a timeout
+        stop_ok = False
+        stop_thread = threading.Thread(
+            target=_stream_stop_worker,
+            args=(stream,),
+            daemon=True,
+        )
+        _LOGGER.debug("%sRequesting stream stop...", prefix)
+        stop_thread.start()
+        stop_thread.join(timeout=AudioInputSource._STREAM_STOP_TIMEOUT_S)
+
+        if stop_thread.is_alive():
+            _LOGGER.warning(
+                "%sstream.stop() did not return within %.1fs — "
+                "attempting abort()",
+                prefix,
+                AudioInputSource._STREAM_STOP_TIMEOUT_S,
+            )
+            # 2. abort() is Pa_AbortStream — immediate, does not wait for
+            #    the callback to finish.
+            try:
+                if hasattr(stream, "abort"):
+                    stream.abort()
+                    _LOGGER.info("%sStream aborted successfully", prefix)
+                    stop_ok = True
+                else:
+                    _LOGGER.warning(
+                        "%sStream has no abort() method; "
+                        "proceeding to close()",
+                        prefix,
+                    )
+            except Exception as e:
+                _LOGGER.warning("%sstream.abort() failed: %s", prefix, e)
+        else:
+            _LOGGER.debug("%sStream stopped gracefully", prefix)
+            stop_ok = True
+
+        # 3. close() releases the PortAudio stream handle.
+        try:
+            stream.close()
+            _LOGGER.debug("%sStream closed", prefix)
+        except Exception as e:
+            _LOGGER.warning("%sstream.close() failed: %s", prefix, e)
+
+        if not stop_ok:
+            _LOGGER.warning(
+                "%sStream may not have stopped cleanly — "
+                "PortAudio reinit recommended",
+                prefix,
+            )
 
     @staticmethod
     def refresh_device_list():
@@ -97,14 +181,11 @@ class AudioInputSource:
 
             # Close outside lock to avoid deadlock with audio callbacks
             if stream_to_close:
-                try:
-                    stream_to_close.stop()
-                    stream_to_close.close()
-                except Exception as e:
-                    _LOGGER.warning(
-                        "Error closing stream during refresh: %s", e
-                    )
+                AudioInputSource._close_stream(
+                    stream_to_close, context="refresh"
+                )
 
+            _LOGGER.debug("Cycling PortAudio for device rescan...")
             try:
                 # Force PortAudio to rescan devices by terminating and reinitializing
                 sd._terminate()
@@ -842,10 +923,11 @@ class AudioInputSource:
                 AudioInputSource._stream = None
             AudioInputSource._audio_stream_active = False
 
-        # Stop/close outside the lock
+        # Stop/close outside the lock — uses timeout + abort() fallback
         if stream_to_close:
-            stream_to_close.stop()
-            stream_to_close.close()
+            AudioInputSource._close_stream(
+                stream_to_close, context="deactivate"
+            )
             _LOGGER.info("Audio source closed.")
 
     def subscribe(self, callback):

--- a/tests/test_audio_hotplug_hardening.py
+++ b/tests/test_audio_hotplug_hardening.py
@@ -13,15 +13,15 @@ What is NOT tested (acceptable limitations):
 - Windows WASAPI loopback hang simulation requires a real or mock PortAudio driver
 """
 
-import numpy as np
 import threading
 import time
 import unittest
 from unittest.mock import MagicMock, patch
 
+import numpy as np
+
 from ledfx.effects.audio import AudioInputSource
 from ledfx.effects.melbank import MIC_RATE
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_audio_hotplug_hardening.py
+++ b/tests/test_audio_hotplug_hardening.py
@@ -13,13 +13,15 @@ What is NOT tested (acceptable limitations):
 - Windows WASAPI loopback hang simulation requires a real or mock PortAudio driver
 """
 
+import numpy as np
 import threading
 import time
-import types
 import unittest
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 from ledfx.effects.audio import AudioInputSource
+from ledfx.effects.melbank import MIC_RATE
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -227,7 +229,6 @@ class TestCallbackGenerationGuard(unittest.TestCase):
         _reset_class_state()
         self.ais = make_ais_bare()
         # Minimal attributes needed by _audio_sample_callback
-        import numpy as np
 
         self.ais._config = {
             "sample_rate": 60,
@@ -245,7 +246,6 @@ class TestCallbackGenerationGuard(unittest.TestCase):
         A callback from the current stream generation must be forwarded to
         pre_process_audio() / _invoke_callbacks().
         """
-        import numpy as np
 
         # Align generations
         AudioInputSource._stream_generation = 3
@@ -261,7 +261,6 @@ class TestCallbackGenerationGuard(unittest.TestCase):
         self.ais._invoke_callbacks = MagicMock()
 
         # Expected sample count for sample_rate=60, MIC_RATE=44100
-        from ledfx.effects.melbank import MIC_RATE
 
         out_len = MIC_RATE // 60  # = 735
         dummy_data = np.zeros(out_len, dtype=np.float32).tobytes()
@@ -280,7 +279,6 @@ class TestCallbackGenerationGuard(unittest.TestCase):
         A callback whose _callback_stream_gen is behind the current
         _stream_generation must be silently discarded.
         """
-        import numpy as np
 
         AudioInputSource._stream_generation = 5
         self.ais._callback_stream_gen = 3  # stale
@@ -292,8 +290,6 @@ class TestCallbackGenerationGuard(unittest.TestCase):
 
         self.ais.pre_process_audio = fake_pre_process
         self.ais._invoke_callbacks = MagicMock()
-
-        from ledfx.effects.melbank import MIC_RATE
 
         out_len = MIC_RATE // 60
         dummy_data = np.zeros(out_len, dtype=np.float32).tobytes()
@@ -318,7 +314,6 @@ class TestMalformedFrameRateLimit(unittest.TestCase):
     def setUp(self):
         _reset_class_state()
         self.ais = make_ais_bare()
-        import numpy as np
 
         self.ais._config = {
             "sample_rate": 60,
@@ -338,8 +333,6 @@ class TestMalformedFrameRateLimit(unittest.TestCase):
         Sending 10 malformed frames in the same generation should produce
         exactly one debug log, not 10.
         """
-        import numpy as np
-        from ledfx.effects.melbank import MIC_RATE
 
         # Wrong size — will be malformed after resampler returns different length
         out_len = MIC_RATE // 60  # expected

--- a/tests/test_audio_hotplug_hardening.py
+++ b/tests/test_audio_hotplug_hardening.py
@@ -1,0 +1,548 @@
+"""
+Tests for the audio hotplug hardening pass introduced in PR 1776 follow-up.
+
+What is tested here:
+- Refresh coalescing: simultaneous hotplug events collapse to one refresh + one queued rerun
+- One-rerun-only guarantee: no unbounded queue of refresh threads
+- Stale stream generation rejection in the callback path
+- _close_stream() fallback ordering when stop() times out
+- Rate-limited malformed-frame logging (once per stream generation)
+
+What is NOT tested (acceptable limitations):
+- True end-to-end PortAudio cycle (sd._terminate / sd._initialize) requires real hardware
+- Windows WASAPI loopback hang simulation requires a real or mock PortAudio driver
+"""
+
+import threading
+import time
+import types
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+from ledfx.effects.audio import AudioInputSource
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reset_class_state():
+    """
+    Reset AudioInputSource class-level state between tests.
+    This is required because the class variables are shared singletons.
+    """
+    AudioInputSource._audio_stream_active = False
+    AudioInputSource._stream = None
+    AudioInputSource._activating = False
+    AudioInputSource._refresh_in_progress = False
+    AudioInputSource._refresh_pending = False
+    AudioInputSource._refresh_generation = 0
+    AudioInputSource._stream_generation = 0
+    AudioInputSource._last_active = None
+    AudioInputSource._last_device_name = None
+
+
+def make_ais_bare():
+    """
+    Return an AudioInputSource-like instance WITHOUT calling __init__
+    so we avoid needing real audio hardware or a real LedFx instance.
+
+    Sets up the minimum instance attributes used by handle_device_list_change
+    and _audio_sample_callback.
+    """
+    ais = object.__new__(AudioInputSource)
+    ais._ledfx = None
+    ais._callbacks = []
+    ais._config = {
+        "audio_device": 0,
+        "audio_device_name": "",
+        "sample_rate": 60,
+        "delay_ms": 0,
+    }
+    ais._callback_stream_gen = 0
+    ais._malformed_frame_last_gen = None
+    ais.lock = threading.Lock()
+    return ais
+
+
+# ---------------------------------------------------------------------------
+# §1 — Refresh coalescing
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshCoalescing(unittest.TestCase):
+    """
+    Verify that rapid back-to-back calls to handle_device_list_change()
+    collapse to one active refresh and at most one pending rerun.
+    """
+
+    def setUp(self):
+        _reset_class_state()
+        self.ais = make_ais_bare()
+
+    def tearDown(self):
+        _reset_class_state()
+
+    def test_second_call_while_refreshing_sets_pending(self):
+        """
+        While a refresh is running, a second call must set _refresh_pending
+        and return immediately — it must NOT start a concurrent refresh.
+        After the first refresh completes, exactly one follow-up (gen=2)
+        is expected (triggered by the pending flag).
+        """
+        entered = threading.Event()
+        proceed = threading.Event()
+        calls_to_run_refresh = []
+        all_done = threading.Event()
+
+        def slow_run_refresh(gen):
+            calls_to_run_refresh.append(gen)
+            if gen == 1:
+                entered.set()
+                proceed.wait(timeout=5)
+            else:
+                # gen=2 follow-up ran — signal completion
+                all_done.set()
+
+        self.ais._run_device_refresh = slow_run_refresh
+
+        t = threading.Thread(target=self.ais.handle_device_list_change)
+        t.start()
+        entered.wait(timeout=5)  # first call is inside _run_device_refresh
+
+        # Second and third calls arrive while first is in-flight
+        self.ais.handle_device_list_change()
+        self.ais.handle_device_list_change()
+
+        with AudioInputSource._class_lock:
+            pending = AudioInputSource._refresh_pending
+
+        self.assertTrue(pending, "_refresh_pending should be set")
+
+        proceed.set()
+        t.join(timeout=5)
+
+        # Wait for the queued follow-up refresh (gen=2) to complete too
+        all_done.wait(timeout=5)
+
+        # Exactly two refreshes ran: gen=1 (original) + gen=2 (queued rerun)
+        self.assertEqual(
+            len(calls_to_run_refresh),
+            2,
+            f"Expected [1, 2], got {calls_to_run_refresh}",
+        )
+
+    def test_no_unbounded_queue(self):
+        """
+        Even after many hotplug events while refreshing, only one follow-up
+        refresh can be queued (_refresh_pending, not a list or counter).
+        Calling handle_device_list_change 100 times while refresh is in
+        progress still results in exactly one pending flag, not 99.
+        """
+        barrier = threading.Barrier(2)
+        proceed = threading.Event()
+
+        def slow_run_refresh(gen):
+            barrier.wait(timeout=5)
+            proceed.wait(timeout=5)
+
+        self.ais._run_device_refresh = slow_run_refresh
+
+        t = threading.Thread(target=self.ais.handle_device_list_change)
+        t.start()
+        barrier.wait(timeout=5)
+
+        for _ in range(100):
+            self.ais.handle_device_list_change()
+
+        with AudioInputSource._class_lock:
+            pending = AudioInputSource._refresh_pending
+
+        proceed.set()
+        t.join(timeout=5)
+
+        self.assertTrue(pending, "Pending flag should be set")
+        # The important invariant: pending is a single boolean, not a counter.
+        self.assertIsInstance(pending, bool)
+
+    def test_first_call_when_idle_runs_immediately(self):
+        """
+        When no refresh is running, the first call runs synchronously and
+        sets _refresh_in_progress for its duration.
+        """
+        run_refresh_called_with = []
+        in_progress_during_call = []
+
+        def immediate_run_refresh(gen):
+            run_refresh_called_with.append(gen)
+            in_progress_during_call.append(
+                AudioInputSource._refresh_in_progress
+            )
+
+        self.ais._run_device_refresh = immediate_run_refresh
+
+        self.ais.handle_device_list_change()
+
+        self.assertEqual(len(run_refresh_called_with), 1)
+        self.assertTrue(
+            in_progress_during_call[0],
+            "_refresh_in_progress should be True while running",
+        )
+        # After return, _refresh_in_progress must be cleared
+        self.assertFalse(AudioInputSource._refresh_in_progress)
+
+    def test_generation_counter_increments_per_refresh(self):
+        """
+        Each distinct (non-coalesced) call to handle_device_list_change()
+        must increment _refresh_generation.
+        """
+        gens_seen = []
+
+        def capture_gen(gen):
+            gens_seen.append(gen)
+
+        self.ais._run_device_refresh = capture_gen
+
+        initial = AudioInputSource._refresh_generation
+        self.ais.handle_device_list_change()
+        self.ais.handle_device_list_change()
+
+        self.assertEqual(gens_seen[0], initial + 1)
+        self.assertEqual(gens_seen[1], initial + 2)
+
+
+# ---------------------------------------------------------------------------
+# §2 — Stale stream generation rejection in the callback
+# ---------------------------------------------------------------------------
+
+
+class TestCallbackGenerationGuard(unittest.TestCase):
+    """
+    Verify that _audio_sample_callback() silently discards frames that
+    arrive from a stream whose generation no longer matches the class-level
+    _stream_generation counter.
+    """
+
+    def setUp(self):
+        _reset_class_state()
+        self.ais = make_ais_bare()
+        # Minimal attributes needed by _audio_sample_callback
+        import numpy as np
+
+        self.ais._config = {
+            "sample_rate": 60,
+            "delay_ms": 0,
+            "min_volume": 0.2,
+            "fft_size": 256,
+        }
+        self.ais.delay_queue = None
+
+    def tearDown(self):
+        _reset_class_state()
+
+    def test_current_generation_processes_frame(self):
+        """
+        A callback from the current stream generation must be forwarded to
+        pre_process_audio() / _invoke_callbacks().
+        """
+        import numpy as np
+
+        # Align generations
+        AudioInputSource._stream_generation = 3
+        self.ais._callback_stream_gen = 3
+
+        processed = []
+
+        def fake_pre_process():
+            processed.append(True)
+
+        self.ais.pre_process_audio = fake_pre_process
+        self.ais._invalidate_caches = MagicMock()
+        self.ais._invoke_callbacks = MagicMock()
+
+        # Expected sample count for sample_rate=60, MIC_RATE=44100
+        from ledfx.effects.melbank import MIC_RATE
+
+        out_len = MIC_RATE // 60  # = 735
+        dummy_data = np.zeros(out_len, dtype=np.float32).tobytes()
+
+        self.ais.resampler = MagicMock()
+        self.ais.resampler.process = MagicMock(
+            return_value=np.zeros(out_len, dtype=np.float32)
+        )
+
+        self.ais._audio_sample_callback(dummy_data, out_len, None, None)
+
+        self.assertEqual(len(processed), 1, "Frame from current gen should be processed")
+
+    def test_stale_generation_discards_frame(self):
+        """
+        A callback whose _callback_stream_gen is behind the current
+        _stream_generation must be silently discarded.
+        """
+        import numpy as np
+
+        AudioInputSource._stream_generation = 5
+        self.ais._callback_stream_gen = 3  # stale
+
+        processed = []
+
+        def fake_pre_process():
+            processed.append(True)
+
+        self.ais.pre_process_audio = fake_pre_process
+        self.ais._invoke_callbacks = MagicMock()
+
+        from ledfx.effects.melbank import MIC_RATE
+
+        out_len = MIC_RATE // 60
+        dummy_data = np.zeros(out_len, dtype=np.float32).tobytes()
+
+        self.ais._audio_sample_callback(dummy_data, out_len, None, None)
+
+        self.assertEqual(len(processed), 0, "Stale callback must not process data")
+        self.ais._invoke_callbacks.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# §3 — Malformed frame rate-limiting
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedFrameRateLimit(unittest.TestCase):
+    """
+    Verify that malformed frame warnings are logged at most once per stream
+    generation to prevent log flooding during device teardown.
+    """
+
+    def setUp(self):
+        _reset_class_state()
+        self.ais = make_ais_bare()
+        import numpy as np
+
+        self.ais._config = {
+            "sample_rate": 60,
+            "delay_ms": 0,
+            "min_volume": 0.2,
+            "fft_size": 256,
+        }
+        self.ais.delay_queue = None
+        AudioInputSource._stream_generation = 1
+        self.ais._callback_stream_gen = 1
+
+    def tearDown(self):
+        _reset_class_state()
+
+    def test_malformed_frame_logged_once_per_gen(self):
+        """
+        Sending 10 malformed frames in the same generation should produce
+        exactly one debug log, not 10.
+        """
+        import numpy as np
+        from ledfx.effects.melbank import MIC_RATE
+
+        # Wrong size — will be malformed after resampler returns different length
+        out_len = MIC_RATE // 60  # expected
+        wrong_len = out_len - 1
+        dummy_data = np.zeros(wrong_len, dtype=np.float32).tobytes()
+
+        self.ais.resampler = MagicMock()
+        # Resampler returns wrong-size data
+        self.ais.resampler.process = MagicMock(
+            return_value=np.zeros(wrong_len, dtype=np.float32)
+        )
+
+        log_calls = []
+
+        with patch("ledfx.effects.audio._LOGGER") as mock_logger:
+            for _ in range(10):
+                self.ais._audio_sample_callback(
+                    dummy_data, wrong_len, None, None
+                )
+            debug_calls = [
+                c
+                for c in mock_logger.debug.call_args_list
+                if "malformed" in str(c).lower()
+            ]
+            self.assertEqual(
+                len(debug_calls),
+                1,
+                f"Expected 1 malformed-frame log, got {len(debug_calls)}",
+            )
+
+
+# ---------------------------------------------------------------------------
+# §4 — _close_stream() fallback ordering
+# ---------------------------------------------------------------------------
+
+
+class TestCloseStreamFallback(unittest.TestCase):
+    """
+    Verify _close_stream() correctly:
+    1. Calls stop() with a timeout
+    2. Falls back to abort() when stop() times out
+    3. Always calls close()
+    4. Logs the timeout warning
+    """
+
+    def setUp(self):
+        _reset_class_state()
+
+    def tearDown(self):
+        _reset_class_state()
+
+    def test_clean_stop_no_abort(self):
+        """When stop() returns quickly, abort() should NOT be called."""
+        stream = MagicMock()
+        stream.stop = MagicMock(return_value=None)
+        stream.close = MagicMock()
+        stream.abort = MagicMock()
+
+        AudioInputSource._close_stream(
+            stream, context="test", gen=1, device_name="TestDev", device_idx=5
+        )
+
+        stream.stop.assert_called_once()
+        stream.close.assert_called_once()
+        stream.abort.assert_not_called()
+
+    def test_timeout_triggers_abort_then_close(self):
+        """When stop() wedges, abort() and close() must both be called."""
+        stream = MagicMock()
+        # stop() blocks until abort() is called (simulated by a long sleep)
+        stop_event = threading.Event()
+
+        def blocking_stop():
+            stop_event.wait(timeout=30)  # simulate wedged stop
+
+        stream.stop = MagicMock(side_effect=blocking_stop)
+        stream.close = MagicMock()
+        stream.abort = MagicMock(side_effect=lambda: stop_event.set())
+
+        # Use a very short timeout for the test
+        orig_timeout = AudioInputSource._STREAM_STOP_TIMEOUT_S
+        AudioInputSource._STREAM_STOP_TIMEOUT_S = 0.1
+        try:
+            AudioInputSource._close_stream(
+                stream, context="test", gen=7, device_name="WedgeDev", device_idx=2
+            )
+        finally:
+            AudioInputSource._STREAM_STOP_TIMEOUT_S = orig_timeout
+
+        stream.abort.assert_called_once()
+        stream.close.assert_called_once()
+
+    def test_stop_exception_still_closes(self):
+        """If stop() raises immediately, close() must still be called."""
+        stream = MagicMock()
+        stream.stop = MagicMock(side_effect=RuntimeError("stop exploded"))
+        stream.close = MagicMock()
+        stream.abort = MagicMock()
+
+        AudioInputSource._close_stream(stream, context="test", gen=2)
+
+        # stop() threw in the worker thread — the worker exits and join() returns
+        # immediately (no timeout), so abort() is not called
+        stream.close.assert_called_once()
+
+    def test_close_exception_logged_not_raised(self):
+        """If close() raises, it must be caught and logged — not propagate."""
+        stream = MagicMock()
+        stream.stop = MagicMock(return_value=None)
+        stream.close = MagicMock(side_effect=RuntimeError("close boom"))
+
+        # Must not raise
+        AudioInputSource._close_stream(stream, context="test", gen=3)
+
+    def test_none_stream_is_noop(self):
+        """Passing None for the stream must be a silent no-op."""
+        # Must not raise
+        AudioInputSource._close_stream(None, context="test", gen=1)
+
+    def test_timeout_logs_warning(self):
+        """A timed-out stop() must produce a warning log containing the gen."""
+        stream = MagicMock()
+        stop_event = threading.Event()
+
+        def blocking_stop():
+            stop_event.wait(timeout=30)
+
+        stream.stop = MagicMock(side_effect=blocking_stop)
+        stream.close = MagicMock()
+        stream.abort = MagicMock(side_effect=lambda: stop_event.set())
+
+        orig_timeout = AudioInputSource._STREAM_STOP_TIMEOUT_S
+        AudioInputSource._STREAM_STOP_TIMEOUT_S = 0.1
+        try:
+            with patch("ledfx.effects.audio._LOGGER") as mock_logger:
+                AudioInputSource._close_stream(
+                    stream, context="test", gen=42, device_name="Dev", device_idx=3
+                )
+                warning_messages = [
+                    str(c) for c in mock_logger.warning.call_args_list
+                ]
+                self.assertTrue(
+                    any("timed out" in m.lower() for m in warning_messages),
+                    f"Expected timed-out warning, got: {warning_messages}",
+                )
+        finally:
+            AudioInputSource._STREAM_STOP_TIMEOUT_S = orig_timeout
+
+
+# ---------------------------------------------------------------------------
+# §5 — Rerun-only-once guarantee after pending refresh
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshRerunOnce(unittest.TestCase):
+    """
+    After a refresh completes and _refresh_pending was set, exactly one
+    follow-up refresh must be launched — not two, not zero.
+    """
+
+    def setUp(self):
+        _reset_class_state()
+        self.ais = make_ais_bare()
+
+    def tearDown(self):
+        _reset_class_state()
+
+    def test_one_rerun_when_pending(self):
+        """
+        Simulate: refresh 1 runs, multiple hotplug events arrive during it.
+        After refresh 1 completes, exactly one follow-up refresh (refresh 2)
+        must run.  No more.
+        """
+        barrier = threading.Barrier(2)
+        proceed = threading.Event()
+        gens_executed = []
+
+        def controlled_refresh(gen):
+            gens_executed.append(gen)
+            if gen == 1:
+                # Signal the main thread that gen=1 is in progress
+                barrier.wait(timeout=5)
+                # Wait until main thread has fired extra hotplug events
+                proceed.wait(timeout=5)
+
+        self.ais._run_device_refresh = controlled_refresh
+
+        t = threading.Thread(target=self.ais.handle_device_list_change)
+        t.start()
+        barrier.wait(timeout=5)
+
+        # Fire several hotplug events while gen=1 is running
+        for _ in range(5):
+            self.ais.handle_device_list_change()
+
+        proceed.set()
+        t.join(timeout=5)
+
+        # Allow the follow-up thread (gen=2) to finish
+        time.sleep(0.3)
+
+        self.assertEqual(gens_executed, [1, 2], f"Expected [1, 2], got {gens_executed}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_audio_hotplug_hardening.py
+++ b/tests/test_audio_hotplug_hardening.py
@@ -273,7 +273,9 @@ class TestCallbackGenerationGuard(unittest.TestCase):
 
         self.ais._audio_sample_callback(dummy_data, out_len, None, None)
 
-        self.assertEqual(len(processed), 1, "Frame from current gen should be processed")
+        self.assertEqual(
+            len(processed), 1, "Frame from current gen should be processed"
+        )
 
     def test_stale_generation_discards_frame(self):
         """
@@ -300,7 +302,9 @@ class TestCallbackGenerationGuard(unittest.TestCase):
 
         self.ais._audio_sample_callback(dummy_data, out_len, None, None)
 
-        self.assertEqual(len(processed), 0, "Stale callback must not process data")
+        self.assertEqual(
+            len(processed), 0, "Stale callback must not process data"
+        )
         self.ais._invoke_callbacks.assert_not_called()
 
 
@@ -339,6 +343,7 @@ class TestMalformedFrameRateLimit(unittest.TestCase):
         exactly one debug log, not 10.
         """
         import numpy as np
+
         from ledfx.effects.melbank import MIC_RATE
 
         # Wrong size — will be malformed after resampler returns different length
@@ -424,7 +429,11 @@ class TestCloseStreamFallback(unittest.TestCase):
         AudioInputSource._STREAM_STOP_TIMEOUT_S = 0.1
         try:
             AudioInputSource._close_stream(
-                stream, context="test", gen=7, device_name="WedgeDev", device_idx=2
+                stream,
+                context="test",
+                gen=7,
+                device_name="WedgeDev",
+                device_idx=2,
             )
         finally:
             AudioInputSource._STREAM_STOP_TIMEOUT_S = orig_timeout
@@ -476,7 +485,11 @@ class TestCloseStreamFallback(unittest.TestCase):
         try:
             with patch("ledfx.effects.audio._LOGGER") as mock_logger:
                 AudioInputSource._close_stream(
-                    stream, context="test", gen=42, device_name="Dev", device_idx=3
+                    stream,
+                    context="test",
+                    gen=42,
+                    device_name="Dev",
+                    device_idx=3,
                 )
                 warning_messages = [
                     str(c) for c in mock_logger.warning.call_args_list
@@ -541,7 +554,9 @@ class TestRefreshRerunOnce(unittest.TestCase):
         # Allow the follow-up thread (gen=2) to finish
         time.sleep(0.3)
 
-        self.assertEqual(gens_executed, [1, 2], f"Expected [1, 2], got {gens_executed}")
+        self.assertEqual(
+            gens_executed, [1, 2], f"Expected [1, 2], got {gens_executed}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Memory leak seen in certain windows hotplug scenarios

Add diagnostic and more controlled audio shutdown / start behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable audio stream shutdown with a timed stop and fallback to abort/close to avoid hangs during device changes.
  * Serialized device-refresh handling that coalesces rapid hotplug events so refreshes don't overlap and only a single follow-up refresh runs.
  * Stale audio frames are ignored to prevent spurious callbacks; malformed-frame debug logging is rate-limited per stream generation.

* **Tests**
  * Added comprehensive hotplug/hardening tests covering refresh coalescing, generation guards, malformed-frame rate limiting, and stream-close fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->