### PR TITLE
Fix: BladePowerPlus collapses its HSV gradient.

### DIFF
--- a/ledfx/effects/blade_power_plus.py
+++ b/ledfx/effects/blade_power_plus.py
@@ -55,8 +55,6 @@ class BladePowerPlus(AudioReactiveEffect, HSVEffect):
 
     def on_activate(self, pixel_count):
         self.bar = 0
-        self.hsv_array[:, 0] = np.linspace(0, 1, self.pixel_count)
-        self.hsv_array[:, 1] = 1
 
     def config_updated(self, config):
         self.power_func = self.POWER_FUNCS_MAPPING[
@@ -70,6 +68,8 @@ class BladePowerPlus(AudioReactiveEffect, HSVEffect):
         )
 
     def render_hsv(self):
+        self.hsv_array[:, 0] = np.linspace(0, 1, self.pixel_count)
+        self.hsv_array[:, 1] = 1
         # Must be zeroed every cycle to clear the previous frame
         bar_idx = int(self.bar * self.pixel_count)
         self.hsv_array[:, 2] *= self._config["decay"] / 2 + 0.45


### PR DESCRIPTION
## Fix `BladePowerPlus` HSV gradient corruption

### Problem

`BladePowerPlus` initialized hue (`hsv_array[:, 0]`) and saturation (`hsv_array[:, 1]`) only once in `on_activate()`. Because `HSVEffect.render()` mutates the HSV array in-place each frame, the stored hue values became corrupted over time, causing the rainbow gradient to collapse to a single color.

### Fix

Moved hue and saturation initialization into `render_hsv()` so they are fully rebuilt every frame, complying with the `HSVEffect` contract that HSV data is rebuilt each render cycle.

- `self.hsv_array[:, 0] = np.linspace(0, 1, self.pixel_count)` — hue now set every frame
- `self.hsv_array[:, 1] = 1` — saturation now set every frame
- Removed both assignments from `on_activate()`

Bar logic, decay logic, and parent class behavior are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Blade Power Plus effect visual consistency by updating hue and saturation value recalculation behavior during rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->