### PR TITLE
Dev: move to pyFlac

### DIFF
--- a/ledfx/sendspin/__init__.py
+++ b/ledfx/sendspin/__init__.py
@@ -19,8 +19,8 @@ if sys.version_info >= (3, 12):
 
         __all__ = ["SendspinAudioStream"]
         SENDSPIN_AVAILABLE = True
-    except ImportError:
-        # aiosendspin not available
+    except (ImportError, OSError):
+        # aiosendspin not available, or native library (e.g. libFLAC.dll) failed to load
         SENDSPIN_AVAILABLE = False
         __all__ = []
 else:

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -139,7 +139,9 @@ class SendspinAudioStream:
                 audio_float32 = self._convert_to_float32_mono(
                     chunk_data, audio_format
                 )
-                self._schedule_mono_samples(audio_float32, play_time_us, sample_rate)
+                self._schedule_mono_samples(
+                    audio_float32, play_time_us, sample_rate
+                )
 
         except Exception as e:
             _LOGGER.error("Error processing audio chunk: %s", e, exc_info=True)
@@ -309,7 +311,8 @@ class SendspinAudioStream:
                 decoder.process(codec_header)
             except Exception as e:
                 _LOGGER.warning(
-                    "pyFLAC: ignoring error while processing stream header: %s", e
+                    "pyFLAC: ignoring error while processing stream header: %s",
+                    e,
                 )
 
         _LOGGER.info(
@@ -371,7 +374,9 @@ class SendspinAudioStream:
             else:
                 mono = audio.flatten().astype(np.float32) / scale
 
-            self._schedule_mono_samples(mono, current_play_time_us, sample_rate)
+            self._schedule_mono_samples(
+                mono, current_play_time_us, sample_rate
+            )
             self._flac_pending_samples_emitted += num_samples
 
         except Exception as e:

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -165,7 +165,7 @@ class SendspinAudioStream:
             samples:      Mono float32 numpy array of decoded audio.
             play_time_us: Intended play time (µs) for the first sample in
                           *samples*.  Ignored when leftover samples from the
-                          previous chunk are prepended – in that case the
+                          previous chunk are prepended - in that case the
                           leftover's saved timestamp is used as the base.
             sample_rate:  Sample rate of *samples* in Hz.
         """
@@ -217,7 +217,7 @@ class SendspinAudioStream:
         """
         Convert Sendspin PCM audio to LedFx format (float32 mono).
 
-        FLAC chunks are no longer routed here – they go directly through
+        FLAC chunks are no longer routed here - they go directly through
         the pyFLAC decoder in _audio_chunk_handler.
 
         Args:
@@ -331,7 +331,7 @@ class SendspinAudioStream:
         num_samples: int,
     ) -> None:
         """
-        pyFLAC write callback – called synchronously during process().
+        pyFLAC write callback - called synchronously during process().
 
         ``audio`` is a NumPy array of shape ``(num_samples, num_channels)``
         with dtype ``int16`` (or matching the source bit depth).  Sample
@@ -368,7 +368,7 @@ class SendspinAudioStream:
             # bit depth; divide by 2^(bit_depth-1).
             scale = float(1 << (self._flac_bit_depth - 1))
 
-            # pyFLAC delivers shape (num_samples, num_channels) – row-per-sample.
+            # pyFLAC delivers shape (num_samples, num_channels) - row-per-sample.
             # Average across channels (axis=1) to downmix to mono.
             if num_channels >= 2:
                 mono = np.mean(audio.astype(np.float32), axis=1) / scale

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -15,9 +15,9 @@ import numpy as np
 from ledfx.sendspin.config import BUFFER_CAPACITY
 
 try:
-    import av
+    import pyflac
 except ImportError:
-    av = None
+    pyflac = None
 
 try:
     from aiosendspin.client import AudioFormat, SendspinClient
@@ -75,9 +75,19 @@ class SendspinAudioStream:
         self._buffer_lock = threading.Lock()
         self._scheduler_task: Optional[asyncio.Task] = None
 
-        # FLAC decoder (persistent across chunks within a stream)
-        self._flac_decoder: Optional["av.AudioCodecContext"] = None
-        self._flac_fmt_logged = False
+        # FLAC decoder (persistent across chunks within a stream).
+        # Recreated on _stream_start_handler; None until first FLAC chunk.
+        self._flac_decoder = None  # pyflac.StreamDecoder instance
+        self._flac_bit_depth: int = 16  # bit depth negotiated with server
+        self._flac_fmt_logged: bool = False
+        # Timing context for the pyFLAC write callback.
+        # These are set immediately before each decoder.process() call so
+        # the callback can stamp every decoded PCM block with the correct
+        # play timestamp, even when one compressed chunk yields multiple
+        # callback invocations.
+        self._flac_pending_play_time_us: int = 0
+        self._flac_pending_sample_rate: int = 48000
+        self._flac_pending_samples_emitted: int = 0
 
         # Leftover samples from previous frame, carried over so every
         # callback receives exactly _SUB_CHUNK_SAMPLES samples.
@@ -110,67 +120,103 @@ class SendspinAudioStream:
 
         try:
             play_time_us = self._client.compute_play_time(timestamp)
-            now_us = int(self._loop.time() * 1_000_000)
+            sample_rate = audio_format.pcm_format.sample_rate
 
-            audio_float32 = self._convert_to_float32_mono(
-                chunk_data, audio_format
-            )
-
-            sub_duration_us = int(
-                _SUB_CHUNK_SAMPLES
-                / audio_format.pcm_format.sample_rate
-                * 1_000_000
-            )
-
-            # Prepend any leftover samples from the previous frame and
-            # use the leftover's original timestamp as the base so
-            # carryover samples keep their scheduled play time.
-            if len(self._leftover) > 0:
-                audio_float32 = np.concatenate([self._leftover, audio_float32])
-                base_ts = self._leftover_ts
-                self._leftover = np.array([], dtype=np.float32)
+            if audio_format.codec == AudioCodec.FLAC:
+                # pyFLAC path: decoded PCM is delivered to
+                # _flac_write_callback which calls _schedule_mono_samples
+                # directly.  Set the timing context before process() so the
+                # callback can timestamp each decoded PCM block correctly,
+                # even when one compressed chunk produces multiple blocks.
+                if self._flac_decoder is None:
+                    self._init_flac_decoder(audio_format)
+                self._flac_pending_play_time_us = play_time_us
+                self._flac_pending_sample_rate = sample_rate
+                self._flac_pending_samples_emitted = 0
+                self._flac_decoder.process(chunk_data)
             else:
-                base_ts = play_time_us
-
-            total_samples = len(audio_float32)
-            n_full = total_samples // _SUB_CHUNK_SAMPLES
-            remainder = total_samples % _SUB_CHUNK_SAMPLES
-
-            # Per-sub-chunk late check: drop only sub-chunks whose
-            # play time is already in the past instead of discarding
-            # the entire packet.
-            if n_full > 0:
-                with self._buffer_lock:
-                    for i in range(n_full):
-                        sub_play = base_ts + i * sub_duration_us
-                        if sub_play < now_us:
-                            continue
-                        start = i * _SUB_CHUNK_SAMPLES
-                        end = start + _SUB_CHUNK_SAMPLES
-                        self._chunk_seq += 1
-                        heapq.heappush(
-                            self._chunk_buffer,
-                            (
-                                sub_play,
-                                self._chunk_seq,
-                                audio_float32[start:end].copy(),
-                            ),
-                        )
-            # Save leftover samples with their scheduled play time
-            if remainder > 0:
-                self._leftover = audio_float32[
-                    n_full * _SUB_CHUNK_SAMPLES :
-                ].copy()
-                self._leftover_ts = base_ts + n_full * sub_duration_us
+                # PCM path: decode synchronously then schedule.
+                audio_float32 = self._convert_to_float32_mono(
+                    chunk_data, audio_format
+                )
+                self._schedule_mono_samples(audio_float32, play_time_us, sample_rate)
 
         except Exception as e:
             _LOGGER.error("Error processing audio chunk: %s", e, exc_info=True)
+
+    def _schedule_mono_samples(
+        self,
+        samples: np.ndarray,
+        play_time_us: int,
+        sample_rate: int,
+    ) -> None:
+        """
+        Schedule decoded mono float32 samples into the heap playback buffer.
+
+        Extracted so both the PCM path and the callback-driven FLAC backend
+        (Stage 2) share identical leftover-handling and scheduling logic
+        without duplication.  Keeping the scheduling in one place also means
+        the FLAC backend can be purely callback-driven (pyFLAC fires this
+        from within process()) without any duplicate heap/leftover state.
+
+        Args:
+            samples:      Mono float32 numpy array of decoded audio.
+            play_time_us: Intended play time (µs) for the first sample in
+                          *samples*.  Ignored when leftover samples from the
+                          previous chunk are prepended – in that case the
+                          leftover's saved timestamp is used as the base.
+            sample_rate:  Sample rate of *samples* in Hz.
+        """
+        sub_duration_us = int(_SUB_CHUNK_SAMPLES / sample_rate * 1_000_000)
+        now_us = int(self._loop.time() * 1_000_000)
+
+        # Prepend any leftover samples from the previous frame and use
+        # the leftover's original timestamp as the base so carryover
+        # samples keep their scheduled play time.
+        if len(self._leftover) > 0:
+            samples = np.concatenate([self._leftover, samples])
+            base_ts = self._leftover_ts
+            self._leftover = np.array([], dtype=np.float32)
+        else:
+            base_ts = play_time_us
+
+        total_samples = len(samples)
+        n_full = total_samples // _SUB_CHUNK_SAMPLES
+        remainder = total_samples % _SUB_CHUNK_SAMPLES
+
+        # Per-sub-chunk late check: drop only sub-chunks whose play time
+        # is already in the past instead of discarding the entire packet.
+        if n_full > 0:
+            with self._buffer_lock:
+                for i in range(n_full):
+                    sub_play = base_ts + i * sub_duration_us
+                    if sub_play < now_us:
+                        continue
+                    start = i * _SUB_CHUNK_SAMPLES
+                    end = start + _SUB_CHUNK_SAMPLES
+                    self._chunk_seq += 1
+                    heapq.heappush(
+                        self._chunk_buffer,
+                        (
+                            sub_play,
+                            self._chunk_seq,
+                            samples[start:end].copy(),
+                        ),
+                    )
+
+        # Save leftover samples with their scheduled play time.
+        if remainder > 0:
+            self._leftover = samples[n_full * _SUB_CHUNK_SAMPLES :].copy()
+            self._leftover_ts = base_ts + n_full * sub_duration_us
 
     def _convert_to_float32_mono(
         self, data: bytes, audio_format: AudioFormat
     ) -> np.ndarray:
         """
-        Convert Sendspin audio to LedFx format (float32 mono).
+        Convert Sendspin PCM audio to LedFx format (float32 mono).
+
+        FLAC chunks are no longer routed here – they go directly through
+        the pyFLAC decoder in _audio_chunk_handler.
 
         Args:
             data: Raw audio bytes
@@ -201,9 +247,6 @@ class SendspinAudioStream:
             else:
                 raise ValueError(f"Unsupported bit depth: {bit_depth}")
 
-        elif codec == AudioCodec.FLAC:
-            # FLAC decode handles channel conversion internally
-            return self._decode_flac(data, audio_format)
         else:
             raise ValueError(f"Unsupported codec: {codec}")
 
@@ -217,102 +260,124 @@ class SendspinAudioStream:
 
         return audio_float.astype(np.float32)
 
-    def _init_flac_decoder(self, audio_format: AudioFormat):
-        """Create or reconfigure the persistent FLAC decoder."""
-        if av is None:
+    def _init_flac_decoder(self, audio_format: AudioFormat) -> None:
+        """
+        Create a new persistent pyFLAC StreamDecoder for this stream.
+
+        Feeds the FLAC stream header (STREAMINFO + metadata blocks) to the
+        decoder immediately so subsequent audio-frame process() calls can be
+        decoded without requiring the decoder to resync from scratch.
+        """
+        if pyflac is None:
             raise ImportError(
-                "PyAV (av) is required for FLAC decoding but not installed"
+                "pyFLAC is required for FLAC decoding but is not installed. "
+                "Install it with: uv add 'pyflac>=2.2.0'"
             )
         pcm = audio_format.pcm_format
-        decoder = av.CodecContext.create("flac", "r")
-        decoder.sample_rate = pcm.sample_rate
-        channels = pcm.channels
-        decoder.layout = "stereo" if channels == 2 else "mono"
+        self._flac_bit_depth = pcm.bit_depth
 
+        decoder = pyflac.StreamDecoder(
+            write_callback=self._flac_write_callback,
+        )
+        self._flac_decoder = decoder
+
+        # Prime the decoder with the FLAC stream header (fLaC marker +
+        # STREAMINFO block) that Sendspin sends ahead of audio frames.
         codec_header = audio_format.codec_header
         if codec_header:
-            # codec_header from server is: b"fLaC\x80" + 3-byte len + streaminfo
-            # Strip the fLaC stream marker + block header (8 bytes) to get raw streaminfo
-            if codec_header[:4] == b"fLaC":
-                decoder.extradata = codec_header[8:]
-            else:
-                decoder.extradata = codec_header
+            if codec_header[:4] != b"fLaC":
+                # Reconstruct a minimal valid FLAC stream header from the
+                # raw STREAMINFO bytes supplied by the server.
+                # FLAC metadata block header: 1 byte (type | last-flag) +
+                # 3-byte big-endian block length.
+                hdr_len = len(codec_header)
+                block_hdr = bytes(
+                    [
+                        0x80,  # type=STREAMINFO (0), last-metadata-block flag
+                        (hdr_len >> 16) & 0xFF,
+                        (hdr_len >> 8) & 0xFF,
+                        hdr_len & 0xFF,
+                    ]
+                )
+                codec_header = b"fLaC" + block_hdr + codec_header
+            # Header contains only metadata — no audio expected.
+            # Initialise pending timing state to safe defaults.
+            self._flac_pending_play_time_us = 0
+            self._flac_pending_sample_rate = pcm.sample_rate
+            self._flac_pending_samples_emitted = 0
+            try:
+                decoder.process(codec_header)
+            except Exception as e:
+                _LOGGER.warning(
+                    "pyFLAC: ignoring error while processing stream header: %s", e
+                )
 
-        decoder.open()
-        self._flac_decoder = decoder
         _LOGGER.info(
-            "FLAC decoder initialized: %dHz %dch",
+            "FLAC decoder (pyFLAC) initialized: %dHz %dch %dbit",
             pcm.sample_rate,
-            channels,
+            pcm.channels,
+            pcm.bit_depth,
         )
 
-    def _decode_flac(
-        self, data: bytes, audio_format: AudioFormat
-    ) -> np.ndarray:
+    def _flac_write_callback(
+        self,
+        audio: np.ndarray,
+        sample_rate: int,
+        num_channels: int,
+        num_samples: int,
+    ) -> None:
         """
-        Decode a FLAC frame to float32 mono samples.
+        pyFLAC write callback – called synchronously during process().
 
-        Handles planar/packed formats and channel downmix internally.
-        Returns float32 mono array ready for LedFx.
+        ``audio`` is a NumPy array of shape ``(num_samples, num_channels)``
+        with dtype ``int16`` (or matching the source bit depth).  Sample
+        values are scaled to the source bit depth range
+        (e.g. 16-bit FLAC yields values in ``[-32768, 32767]``).
+
+        Timing: ``_flac_pending_play_time_us`` is the play timestamp of the
+        first sample in the current compressed chunk.  Each callback
+        invocation advances the base timestamp by the number of mono samples
+        already emitted for that chunk so multiple FLAC frames within one
+        compressed chunk are stamped correctly.
         """
-        if self._flac_decoder is None:
-            self._init_flac_decoder(audio_format)
-
-        packet = av.Packet(data)
-        frames = self._flac_decoder.decode(packet)
-
-        parts = []
-        for frame in frames:
-            arr = frame.to_ndarray()
-            fmt = frame.format
-            is_planar = fmt.is_planar
-            channels = frame.layout.nb_channels
-
-            # Log format details on first decoded frame
+        try:
             if not self._flac_fmt_logged:
                 _LOGGER.info(
-                    "FLAC first frame: format=%s planar=%s shape=%s "
-                    "dtype=%s samples=%d rate=%d channels=%d layout=%s",
-                    fmt.name,
-                    is_planar,
-                    arr.shape,
-                    arr.dtype,
-                    frame.samples,
-                    frame.sample_rate,
-                    channels,
-                    frame.layout.name,
+                    "pyFLAC first block: dtype=%s shape=%s rate=%d "
+                    "channels=%d num_samples=%d",
+                    audio.dtype,
+                    audio.shape,
+                    sample_rate,
+                    num_channels,
+                    num_samples,
                 )
                 self._flac_fmt_logged = True
 
-            # Normalise to float32 based on sample format
-            fmt_name = fmt.name
-            if "32" in fmt_name and "flt" not in fmt_name:
-                scale = 2147483648.0
-            elif "flt" in fmt_name:
-                scale = 1.0
-            elif "16" in fmt_name:
-                scale = 32768.0
+            # Advance the base timestamp by however many mono samples have
+            # already been emitted for this compressed chunk.
+            current_play_time_us = self._flac_pending_play_time_us + int(
+                self._flac_pending_samples_emitted / sample_rate * 1_000_000
+            )
+
+            # Normalise to float32 in approximately [-1.0, 1.0].
+            # pyFLAC delivers int32 with values in the range of the source
+            # bit depth; divide by 2^(bit_depth-1).
+            scale = float(1 << (self._flac_bit_depth - 1))
+
+            # pyFLAC delivers shape (num_samples, num_channels) – row-per-sample.
+            # Average across channels (axis=1) to downmix to mono.
+            if num_channels >= 2:
+                mono = np.mean(audio.astype(np.float32), axis=1) / scale
             else:
-                scale = 32768.0
+                mono = audio.flatten().astype(np.float32) / scale
 
-            if is_planar and arr.ndim == 2 and channels >= 2:
-                # Planar: shape is (channels, samples) e.g. (2, 1200)
-                # Average channels to mono
-                mono = np.mean(arr.astype(np.float32), axis=0) / scale
-            elif not is_planar and channels >= 2:
-                # Packed interleaved: shape is (1, channels*samples)
-                flat = arr.flatten().astype(np.float32) / scale
-                mono = np.mean(flat.reshape(-1, channels), axis=1)
-            else:
-                # Mono
-                mono = arr.flatten().astype(np.float32) / scale
+            self._schedule_mono_samples(mono, current_play_time_us, sample_rate)
+            self._flac_pending_samples_emitted += num_samples
 
-            parts.append(mono)
-
-        if not parts:
-            return np.array([], dtype=np.float32)
-
-        return np.concatenate(parts).astype(np.float32)
+        except Exception as e:
+            _LOGGER.error(
+                "Error in pyFLAC write callback: %s", e, exc_info=True
+            )
 
     @staticmethod
     def _unpack_int24(data: bytes) -> np.ndarray:
@@ -357,9 +422,20 @@ class SendspinAudioStream:
         else:
             _LOGGER.info("Sendspin stream started (no player info)")
 
-        # Reset FLAC decoder on new stream (format may have changed)
-        self._flac_decoder = None
+        # Reset pyFLAC decoder on new stream (format may have changed).
+        # Call finish() to free libFLAC resources before discarding the instance.
+        if self._flac_decoder is not None:
+            try:
+                self._flac_decoder.finish()
+            except Exception as e:
+                _LOGGER.warning(
+                    "Error finishing FLAC decoder on stream reset: %s", e
+                )
+            self._flac_decoder = None
         self._flac_fmt_logged = False
+        self._flac_pending_play_time_us = 0
+        self._flac_pending_sample_rate = 48000
+        self._flac_pending_samples_emitted = 0
         self._leftover = np.array([], dtype=np.float32)
         self._leftover_ts = 0
 
@@ -449,6 +525,14 @@ class SendspinAudioStream:
                 self._loop.call_soon_threadsafe(self._loop.stop)
             self._thread.join(timeout=2.0)
 
+        # Clean up pyFLAC decoder once the stream thread has fully stopped.
+        if self._flac_decoder is not None:
+            try:
+                self._flac_decoder.finish()
+            except Exception:
+                pass
+            self._flac_decoder = None
+
         _LOGGER.info("Sendspin stream closed")
 
     def _run_client(self):
@@ -500,7 +584,7 @@ class SendspinAudioStream:
             # then fall back to PCM. Server picks the first mutually supported.
             # Request mono since LedFx downmixes to mono anyway.
             supported_formats = []
-            if av is not None:
+            if pyflac is not None:
                 supported_formats.append(
                     SupportedAudioFormat(
                         codec=AudioCodec.FLAC,

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -16,7 +16,7 @@ from ledfx.sendspin.config import BUFFER_CAPACITY
 
 try:
     import pyflac
-except ImportError:
+except (ImportError, OSError):
     pyflac = None
 
 try:

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -311,7 +311,8 @@ class SendspinAudioStream:
                 decoder.process(codec_header)
             except Exception as e:
                 _LOGGER.warning(
-                    "pyFLAC: ignoring error while processing stream header: %s",
+                    "pyFLAC: ignoring %s while processing stream header: %s",
+                    type(e).__name__,
                     e,
                 )
 
@@ -534,8 +535,10 @@ class SendspinAudioStream:
         if self._flac_decoder is not None:
             try:
                 self._flac_decoder.finish()
-            except Exception:
-                pass
+            except Exception as e:
+                _LOGGER.debug(
+                    "FLAC decoder finish failed (%s): %s", type(e).__name__, e
+                )
             self._flac_decoder = None
 
         _LOGGER.info("Sendspin stream closed")

--- a/osx-binary.spec
+++ b/osx-binary.spec
@@ -23,6 +23,14 @@ lifx_metadata = copy_metadata('lifx-async')
 # Remove the ledfx.env file if it exists
 os.remove("ledfx.env") if os.path.exists("ledfx.env") else None
 
+# Collect ledfx_assets excluding animated_frames source PNGs
+import glob
+ledfx_assets_datas = []
+for filepath in glob.glob(f'{spec_root}/ledfx_assets/**/*', recursive=True):
+    if os.path.isfile(filepath) and 'animated_frames' not in filepath:
+        rel_dir = os.path.relpath(os.path.dirname(filepath), spec_root)
+        ledfx_assets_datas.append((filepath, rel_dir))
+
 # Get environment variables
 github_ref = os.getenv('GITHUB_REF')
 github_sha_value = os.getenv('GITHUB_SHA')
@@ -47,8 +55,8 @@ with open('ledfx.env', 'a') as file:
 
 a = Analysis([f'{spec_root}/ledfx/__main__.py'],
              pathex=[f'{spec_root}', f'{spec_root}/ledfx'],
-             binaries=numpy_binaries,
-             datas=[(f'{spec_root}/ledfx_frontend', 'ledfx_frontend/'), (f'{spec_root}/ledfx/', 'ledfx/'), (f'{spec_root}/ledfx_assets', 'ledfx_assets/'),(f'{spec_root}/ledfx_assets/tray.png','.'), (f'{spec_root}/ledfx.env','.')] + numpy_datas + lifx_metadata,
+             binaries=numpy_binaries + pyflac_binaries,
+             datas=[(f'{spec_root}/ledfx_frontend', 'ledfx_frontend/'), (f'{spec_root}/ledfx/', 'ledfx/'), (f'{spec_root}/ledfx_assets/tray.png','.'), (f'{spec_root}/ledfx.env','.')] + ledfx_assets_datas + numpy_datas + lifx_metadata,
              hiddenimports=hiddenimports + numpy_hiddenimports,
              hookspath=[f'{venv_root}/lib/site-packages/pyupdater/hooks'],
              runtime_hooks=[],

--- a/osx-binary.spec
+++ b/osx-binary.spec
@@ -14,6 +14,9 @@ numpy_binaries = collect_dynamic_libs('numpy')
 numpy_datas = collect_data_files('numpy', include_py_files=True)
 numpy_hiddenimports = collect_submodules('numpy')
 
+# Collect pyFLAC native libraries (libFLAC.dylib must be bundled alongside the .so files)
+pyflac_binaries = collect_dynamic_libs('pyflac')
+
 # Collect lifx-async package metadata (required by lifx/__init__.py for importlib.metadata)
 lifx_metadata = copy_metadata('lifx-async')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "samplerate-ledfx>=0.2.3",
     "audio-hotplug>=0.1.0",
     "aiosendspin>=4.0.0; python_version >= '3.12'",
+    "pyflac>=2.2.0; python_version >= '3.12'",
 ]
 name = "LedFx"
 version = "2.1.7"

--- a/uv.lock
+++ b/uv.lock
@@ -1177,6 +1177,7 @@ dependencies = [
     { name = "psutil" },
     { name = "pybase64" },
     { name = "pyfastnoiselite" },
+    { name = "pyflac", marker = "python_full_version >= '3.12'" },
     { name = "pyserial" },
     { name = "pystray" },
     { name = "python-dotenv" },
@@ -1262,6 +1263,7 @@ requires-dist = [
     { name = "psutil", specifier = ">=5.9.7" },
     { name = "pybase64", specifier = "~=1.4.0" },
     { name = "pyfastnoiselite", specifier = ">=0.0.7" },
+    { name = "pyflac", marker = "python_full_version >= '3.12'", specifier = ">=2.2.0" },
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pystray", specifier = ">=0.19.5" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2.0.0" },
@@ -2552,6 +2554,17 @@ wheels = [
 ]
 
 [[package]]
+name = "pyflac"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "soundfile", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/83/4f3e184618b1847d3b9905adc134ce016d32712151cc2c478d36f09727ef/pyFLAC-3.0.0.tar.gz", hash = "sha256:825d920e696f61493249afa2f7fd2fb42d7e7d2884a7b3e8b6ad1d76b5998119", size = 1843739, upload-time = "2024-04-16T15:07:42.119Z" }
+
+[[package]]
 name = "pyflakes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3243,6 +3256,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/a1/d19dd9889cd4bce2e233c4fac007cd8daaf5b9fe6e6a5d432cf17be0b807/sounddevice-0.5.5-py3-none-win32.whl", hash = "sha256:1234cc9b4c9df97b6cbe748146ae0ec64dd7d6e44739e8e42eaa5b595313a103", size = 317765, upload-time = "2026-01-23T18:36:39.047Z" },
     { url = "https://files.pythonhosted.org/packages/c3/0e/002ed7c4c1c2ab69031f78989d3b789fee3a7fba9e586eb2b81688bf4961/sounddevice-0.5.5-py3-none-win_amd64.whl", hash = "sha256:cfc6b2c49fb7f555591c78cb8ecf48d6a637fd5b6e1db5fec6ed9365d64b3519", size = 365324, upload-time = "2026-01-23T18:36:40.496Z" },
     { url = "https://files.pythonhosted.org/packages/4e/39/a61d4b83a7746b70d23d9173be688c0c6bfc7173772344b7442c2c155497/sounddevice-0.5.5-py3-none-win_arm64.whl", hash = "sha256:3861901ddd8230d2e0e8ae62ac320cdd4c688d81df89da036dcb812f757bb3e6", size = 317115, upload-time = "2026-01-23T18:36:42.235Z" },
+]
+
+[[package]]
+name = "soundfile"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/41/9b873a8c055582859b239be17902a85339bec6a30ad162f98c9b0288a2cc/soundfile-0.13.1.tar.gz", hash = "sha256:b2c68dab1e30297317080a5b43df57e302584c49e2942defdde0acccc53f0e5b", size = 46156, upload-time = "2025-01-25T09:17:04.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/28/e2a36573ccbcf3d57c00626a21fe51989380636e821b341d36ccca0c1c3a/soundfile-0.13.1-py2.py3-none-any.whl", hash = "sha256:a23c717560da2cf4c7b5ae1142514e0fd82d6bbd9dfc93a50423447142f2c445", size = 25751, upload-time = "2025-01-25T09:16:44.235Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ab/73e97a5b3cc46bba7ff8650a1504348fa1863a6f9d57d7001c6b67c5f20e/soundfile-0.13.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:82dc664d19831933fe59adad199bf3945ad06d84bc111a5b4c0d3089a5b9ec33", size = 1142250, upload-time = "2025-01-25T09:16:47.583Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e5/58fd1a8d7b26fc113af244f966ee3aecf03cb9293cb935daaddc1e455e18/soundfile-0.13.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:743f12c12c4054921e15736c6be09ac26b3b3d603aef6fd69f9dde68748f2593", size = 1101406, upload-time = "2025-01-25T09:16:49.662Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ae/c0e4a53d77cf6e9a04179535766b3321b0b9ced5f70522e4caf9329f0046/soundfile-0.13.1-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:9c9e855f5a4d06ce4213f31918653ab7de0c5a8d8107cd2427e44b42df547deb", size = 1235729, upload-time = "2025-01-25T09:16:53.018Z" },
+    { url = "https://files.pythonhosted.org/packages/57/5e/70bdd9579b35003a489fc850b5047beeda26328053ebadc1fb60f320f7db/soundfile-0.13.1-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:03267c4e493315294834a0870f31dbb3b28a95561b80b134f0bd3cf2d5f0e618", size = 1313646, upload-time = "2025-01-25T09:16:54.872Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/df/8c11dc4dfceda14e3003bb81a0d0edcaaf0796dd7b4f826ea3e532146bba/soundfile-0.13.1-py2.py3-none-win32.whl", hash = "sha256:c734564fab7c5ddf8e9be5bf70bab68042cd17e9c214c06e365e20d64f9a69d5", size = 899881, upload-time = "2025-01-25T09:16:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/6b761de83277f2f02ded7e7ea6f07828ec78e4b229b80e4ca55dd205b9dc/soundfile-0.13.1-py2.py3-none-win_amd64.whl", hash = "sha256:1e70a05a0626524a69e9f0f4dd2ec174b4e9567f4d8b6c11d38b5c289be36ee9", size = 1019162, upload-time = "2025-01-25T09:16:59.573Z" },
 ]
 
 [[package]]

--- a/windows-binary.spec
+++ b/windows-binary.spec
@@ -24,6 +24,14 @@ lifx_metadata = copy_metadata('lifx-async')
 # Remove the ledfx.env file if it exists
 os.remove("ledfx.env") if os.path.exists("ledfx.env") else None
 
+# Collect ledfx_assets excluding animated_frames source PNGs
+import glob
+ledfx_assets_datas = []
+for filepath in glob.glob(f'{spec_root}/ledfx_assets/**/*', recursive=True):
+    if os.path.isfile(filepath) and 'animated_frames' not in filepath:
+        rel_dir = os.path.relpath(os.path.dirname(filepath), spec_root)
+        ledfx_assets_datas.append((filepath, rel_dir))
+
 # Get environment variables
 github_ref = os.getenv('GITHUB_REF')
 github_sha_value = os.getenv('GITHUB_SHA')
@@ -48,7 +56,7 @@ with open('ledfx.env', 'a') as file:
 a = Analysis([f'{spec_root}\\ledfx\\__main__.py'],
              pathex=[f'{spec_root}', f'{spec_root}\\ledfx'],
              binaries=numpy_binaries + pyflac_binaries,
-             datas=[(f'{spec_root}/ledfx_frontend', 'ledfx_frontend/'), (f'{spec_root}/ledfx/', 'ledfx/'), (f'{spec_root}/ledfx_assets', 'ledfx_assets/'),(f'{spec_root}/ledfx_assets/tray.png','.'), (f'{spec_root}/ledfx.env','.')] + numpy_datas + lifx_metadata,
+             datas=[(f'{spec_root}/ledfx_frontend', 'ledfx_frontend/'), (f'{spec_root}/ledfx/', 'ledfx/'), (f'{spec_root}/ledfx_assets/tray.png','.'), (f'{spec_root}/ledfx.env','.')] + ledfx_assets_datas + numpy_datas + lifx_metadata,
              hiddenimports=hiddenimports + numpy_hiddenimports,
              hookspath=[f'{venv_root}\\lib\\site-packages\\pyupdater\\hooks'],
              runtime_hooks=[],

--- a/windows-binary.spec
+++ b/windows-binary.spec
@@ -15,6 +15,9 @@ numpy_binaries = collect_dynamic_libs('numpy')
 numpy_datas = collect_data_files('numpy', include_py_files=True)
 numpy_hiddenimports = collect_submodules('numpy')
 
+# Collect pyFLAC native libraries (libFLAC.dll must be bundled alongside the .pyd files)
+pyflac_binaries = collect_dynamic_libs('pyflac')
+
 # Collect lifx-async package metadata (required by lifx/__init__.py for importlib.metadata)
 lifx_metadata = copy_metadata('lifx-async')
 
@@ -44,7 +47,7 @@ with open('ledfx.env', 'a') as file:
     file.write('\n'.join(variables))
 a = Analysis([f'{spec_root}\\ledfx\\__main__.py'],
              pathex=[f'{spec_root}', f'{spec_root}\\ledfx'],
-             binaries=numpy_binaries,
+             binaries=numpy_binaries + pyflac_binaries,
              datas=[(f'{spec_root}/ledfx_frontend', 'ledfx_frontend/'), (f'{spec_root}/ledfx/', 'ledfx/'), (f'{spec_root}/ledfx_assets', 'ledfx_assets/'),(f'{spec_root}/ledfx_assets/tray.png','.'), (f'{spec_root}/ledfx.env','.')] + numpy_datas + lifx_metadata,
              hiddenimports=hiddenimports + numpy_hiddenimports,
              hookspath=[f'{venv_root}\\lib\\site-packages\\pyupdater\\hooks'],


### PR DESCRIPTION
Move from av which is basically all of ffmpeg and bloating us by 35 meg to pyFlac

We need a new version of aiosendspin lib that splits the dependancy out before we can prove the new image size.

That is in the aiosendspin lib via https://github.com/Sendspin/aiosendspin/pull/206

But we need a new lib release to move to that picks this up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Smoother and more accurate FLAC playback timing, better handling of chunk boundaries, and more robust header processing and decoder lifecycle for steadier audio.

* **Chores**
  * Added conditional pyFLAC support (Python 3.12+), widened availability checks to include native-library load failures, and bundled pyFLAC native libraries in Windows and macOS builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->