### PR TITLE
Feat: Sendspin always on option

### DIFF
--- a/docs/settings/sendspin.md
+++ b/docs/settings/sendspin.md
@@ -93,7 +93,7 @@ When activated, LedFx will:
 
 By default, Sendspin audio (like all other audio sources) only starts when an audio-reactive effect is active. If you want the Sendspin connection to stay active regardless of whether any effects are running, enable the **Sendspin Always On** setting.
 
-This is a global setting found in the sendspin server management dialog (`sendspin_always_on`).  
+This is a global setting found in the sendspin server management dialog (`sendspin_always_on`).
 
 When enabled:
 

--- a/docs/settings/sendspin.md
+++ b/docs/settings/sendspin.md
@@ -89,4 +89,18 @@ When activated, LedFx will:
 4. Feed the audio into the visualization pipeline synchronized with all other sendspin audio end points.
 5. If the connection drops, LedFx will automatically attempt to reconnect with exponential backoff.
 
+## Always-On Mode
+
+By default, Sendspin audio (like all other audio sources) only starts when an audio-reactive effect is active. If you want the Sendspin connection to stay active regardless of whether any effects are running, enable the **Sendspin Always On** setting.
+
+This is a global setting found in the sendspin server management dialog (`sendspin_always_on`).  
+
+When enabled:
+
+- The Sendspin audio stream starts immediately when a Sendspin device is selected, even without active effects.
+- The stream remains active if all effects are removed.
+- On boot, if a Sendspin device was previously selected and this setting is `true`, the stream starts automatically.
+
+This is useful for integrations where you want LedFx to be ready to visualize audio the moment playback begins, without requiring an effect to be pre-configured.
+
 

--- a/ledfx/api/utils.py
+++ b/ledfx/api/utils.py
@@ -59,6 +59,7 @@ PERMITTED_KEYS = {
         "startup_playlist_id",
         "lifx_broadcast_address",
         "lifx_discovery_timeout",
+        "sendspin_always_on",
     ),
 }
 

--- a/ledfx/config.py
+++ b/ledfx/config.py
@@ -50,6 +50,7 @@ CORE_CONFIG_KEYS_NO_RESTART = [
     "startup_playlist_id",
     "lifx_broadcast_address",
     "lifx_discovery_timeout",
+    "sendspin_always_on",
 ]
 # Collection of keys that are used for visualisation configuration - used to check if we need to restart the visualisation event listeners
 VISUALISATION_CONFIG_KEYS = [

--- a/ledfx/config.py
+++ b/ledfx/config.py
@@ -5,6 +5,7 @@ import logging
 import os
 import shutil
 import sys
+import uuid
 
 import voluptuous as vol
 from packaging.version import parse as parse_version
@@ -189,11 +190,25 @@ CORE_CONFIG_SCHEMA = vol.Schema(
         vol.Optional("lifx_discovery_timeout", default=30): vol.All(
             int, vol.Range(min=1, max=120)
         ),
+        vol.Optional("instance_id", default=""): str,
         vol.Optional("sendspin_servers", default={}): dict,
         vol.Optional("sendspin_always_on", default=False): bool,
     },
     extra=vol.ALLOW_EXTRA,
 )
+
+
+def ensure_instance_id(config):
+    """
+    Ensure the config has a persistent LedFx instance UUID.
+
+    Generates a random UUID if ``instance_id`` is missing or empty and
+    stores it back in *config* so it is saved on the next
+    :func:`save_config` call.  The value is stable across restarts and
+    uniquely identifies this LedFx installation.
+    """
+    if not config.get("instance_id"):
+        config["instance_id"] = str(uuid.uuid4())
 
 
 def load_logger():

--- a/ledfx/config.py
+++ b/ledfx/config.py
@@ -189,6 +189,7 @@ CORE_CONFIG_SCHEMA = vol.Schema(
             int, vol.Range(min=1, max=120)
         ),
         vol.Optional("sendspin_servers", default={}): dict,
+        vol.Optional("sendspin_always_on", default=False): bool,
     },
     extra=vol.ALLOW_EXTRA,
 )

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -31,6 +31,7 @@ from ledfx.consts import PROJECT_VERSION
 from ledfx.devices import Devices
 from ledfx.effects import Effects
 from ledfx.effects.audio import AudioInputSource
+from ledfx.sendspin.config import eager_start as sendspin_eager_start
 from ledfx.events import (
     AudioDeviceListChangedEvent,
     Event,
@@ -502,6 +503,10 @@ class LedFxCore:
         # virtuals, since virtuals with active effects trigger audio
         # initialization which validates the audio_device index.
         self._load_sendspin_servers()
+
+        # Eagerly start the Sendspin audio stream at boot when configured,
+        # even if no audio-reactive effect is active yet.
+        sendspin_eager_start(self)
 
         self.zeroconf = ZeroConfRunner(ledfx=self)
         self.virtuals.create_from_config(

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -31,7 +31,6 @@ from ledfx.consts import PROJECT_VERSION
 from ledfx.devices import Devices
 from ledfx.effects import Effects
 from ledfx.effects.audio import AudioInputSource
-from ledfx.sendspin.config import eager_start as sendspin_eager_start
 from ledfx.events import (
     AudioDeviceListChangedEvent,
     Event,
@@ -45,6 +44,7 @@ from ledfx.mdns_manager import ZeroConfRunner
 from ledfx.playlists import PlaylistManager
 from ledfx.presets import ledfx_presets
 from ledfx.scenes import Scenes
+from ledfx.sendspin.config import eager_start as sendspin_eager_start
 from ledfx.tools.ts_generator import generate_typescript_types
 from ledfx.utils import (
     RollingQueueHandler,

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -520,7 +520,10 @@ class LedFxCore:
 
         # Eagerly start the Sendspin audio stream at boot when configured,
         # even if no audio-reactive effect is active yet.
-        sendspin_eager_start(self)
+        try:
+            sendspin_eager_start(self)
+        except Exception as e:
+            _LOGGER.error("Failed to eagerly start Sendspin audio: %s", e)
 
         self.zeroconf = ZeroConfRunner(ledfx=self)
         self.virtuals.create_from_config(

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -159,7 +159,8 @@ class LedFxCore:
         """
         Handles the update of the base configuration where there are specific things that need to be done.
 
-        Currently, only visualisation configuration is handled this way, since they require the creation of new event listeners.
+        Currently handles visualisation configuration (requires new event listeners)
+        and sendspin_always_on toggling (requires audio stream deactivation check).
 
         Args:
             event (Event): The event that triggered the update - this will always be a BaseConfigUpdateEvent.
@@ -170,6 +171,17 @@ class LedFxCore:
                 "Visualisation configuration updated - resetting visualisation event listeners."
             )
             self.setup_visualisation_events()
+
+        if (
+            "sendspin_always_on" in event.config
+            and not event.config["sendspin_always_on"]
+            and hasattr(self, "audio")
+            and self.audio is not None
+        ):
+            _LOGGER.debug(
+                "sendspin_always_on toggled off - checking if audio stream should deactivate."
+            )
+            self.audio.check_and_deactivate()
 
     def dev_enabled(self):
         return self.config["dev_mode"]

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -523,7 +523,7 @@ class LedFxCore:
         try:
             sendspin_eager_start(self)
         except Exception as e:
-            _LOGGER.error("Failed to eagerly start Sendspin audio: %s", e)
+            _LOGGER.warning("Failed to eagerly start Sendspin audio: %s", e)
 
         self.zeroconf = ZeroConfRunner(ledfx=self)
         self.virtuals.create_from_config(

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -22,6 +22,7 @@ from ledfx.config import (
     VISUALISATION_CONFIG_KEYS,
     Transmission,
     create_backup,
+    ensure_instance_id,
     get_ssl_certs,
     load_config,
     remove_virtuals_active_effects,
@@ -98,6 +99,7 @@ class LedFxCore:
             create_backup(config_dir, "DELETE")
 
         self.config = load_config(config_dir)
+        ensure_instance_id(self.config)
         self.config["hosts"] = get_sorted_physical_ips()
 
         if clear_effects:

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -742,7 +742,8 @@ class AudioInputSource:
                 AudioInputSource._stream = SendspinAudioStream(
                     device["sendspin_config"],
                     self._audio_sample_callback,
-                    server_id=device["name"],
+                    sendspin_entry_id=device["name"],
+                    instance_id=self._ledfx.config.get("instance_id", ""),
                 )
             else:
                 AudioInputSource._stream = self._audio.InputStream(

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -350,6 +350,11 @@ class AudioInputSource:
         apis = sd.query_hostapis() + ({"name": "WEB AUDIO"},)
         if SENDSPIN_AVAILABLE:
             apis = apis + ({"name": "SENDSPIN"},)
+        _LOGGER.debug(
+            "[SENDSPIN] query_hostapis: SENDSPIN_AVAILABLE=%s, hostapi_count=%s",
+            SENDSPIN_AVAILABLE,
+            len(apis),
+        )
         return apis
 
     @staticmethod
@@ -371,7 +376,7 @@ class AudioInputSource:
             sendspin_idx = next(
                 i for i, h in enumerate(hostapis) if h["name"] == "SENDSPIN"
             )
-            devices = devices + tuple(
+            sendspin_devices = tuple(
                 {
                     "hostapi": sendspin_idx,
                     "name": name,
@@ -379,6 +384,12 @@ class AudioInputSource:
                     "sendspin_config": config,
                 }
                 for name, config in SENDSPIN_SERVERS.items()
+            )
+            devices = devices + sendspin_devices
+            _LOGGER.debug(
+                "[SENDSPIN] query_devices: added %s sendspin device(s): %s",
+                len(sendspin_devices),
+                [d["name"] for d in sendspin_devices],
             )
         return devices
 
@@ -512,7 +523,14 @@ class AudioInputSource:
             last_active = AudioInputSource._last_active
 
         # Activate outside the lock to avoid deadlock
-        if len(self._callbacks) != 0 or self._should_always_keep_active():
+        should_always_on = self._should_always_keep_active()
+        _LOGGER.debug(
+            "[SENDSPIN] update_config: callbacks=%s, should_always_keep_active=%s, stream_active=%s",
+            len(self._callbacks),
+            should_always_on,
+            AudioInputSource._audio_stream_active,
+        )
+        if len(self._callbacks) != 0 or should_always_on:
             self.activate()
 
         # Check if device changed and fire event if needed
@@ -717,6 +735,10 @@ class AudioInputSource:
             ):
                 from ledfx.sendspin.stream import SendspinAudioStream
 
+                _LOGGER.debug(
+                    "[SENDSPIN] open_audio_stream: opening SendspinAudioStream for '%s'",
+                    device["name"],
+                )
                 AudioInputSource._stream = SendspinAudioStream(
                     device["sendspin_config"],
                     self._audio_sample_callback,
@@ -833,6 +855,11 @@ class AudioInputSource:
         self.deactivate()
 
     def deactivate(self):
+        _LOGGER.debug(
+            "[SENDSPIN] deactivate: stream_active=%s, stream_type=%s",
+            AudioInputSource._audio_stream_active,
+            type(AudioInputSource._stream).__name__ if AudioInputSource._stream else None,
+        )
         # Stop the stream outside the lock to avoid deadlock with audio callback
         # The audio callback thread may be waiting to complete, and if it needs
         # any locks, holding the lock while calling stop() creates a circular wait
@@ -848,20 +875,38 @@ class AudioInputSource:
             stream_to_close.stop()
             stream_to_close.close()
             _LOGGER.info("Audio source closed.")
+            _LOGGER.debug("[SENDSPIN] deactivate: stream closed, type was %s", type(stream_to_close).__name__)
 
     def _should_always_keep_active(self):
         """Check if the current audio source should stay active regardless of subscribers."""
-        if not self._ledfx.config.get("sendspin_always_on", False):
+        always_on_config = self._ledfx.config.get("sendspin_always_on", False)
+        if not always_on_config:
+            _LOGGER.debug(
+                "[SENDSPIN] _should_always_keep_active: sendspin_always_on config=%s, returning False",
+                always_on_config,
+            )
             return False
-        return is_sendspin_always_on(
-            self._config.get("audio_device"),
+        device_idx = self._config.get("audio_device")
+        result = is_sendspin_always_on(
+            device_idx,
             self.query_devices,
             self.query_hostapis,
         )
+        _LOGGER.debug(
+            "[SENDSPIN] _should_always_keep_active: sendspin_always_on=True, device_idx=%s, is_sendspin=%s",
+            device_idx,
+            result,
+        )
+        return result
 
     def subscribe(self, callback):
         """Registers a callback with the input source"""
         self._callbacks.append(callback)
+        _LOGGER.debug(
+            "[SENDSPIN] subscribe: callbacks=%s, stream_active=%s",
+            len(self._callbacks),
+            AudioInputSource._audio_stream_active,
+        )
         if (
             len(self._callbacks) > 0
             and not AudioInputSource._audio_stream_active
@@ -875,12 +920,21 @@ class AudioInputSource:
         """Unregisters a callback with the input source"""
         if callback in self._callbacks:
             self._callbacks.remove(callback)
-        if self._should_always_keep_active():
+        always_on = self._should_always_keep_active()
+        _LOGGER.debug(
+            "[SENDSPIN] unsubscribe: callbacks=%s, always_keep_active=%s, stream_active=%s",
+            len(self._callbacks),
+            always_on,
+            AudioInputSource._audio_stream_active,
+        )
+        if always_on:
+            _LOGGER.debug("[SENDSPIN] unsubscribe: always-on active, skipping deactivate timer")
             return
         if (
             len(self._callbacks) <= self._subscriber_threshold
             and AudioInputSource._audio_stream_active
         ):
+            _LOGGER.debug("[SENDSPIN] unsubscribe: starting 5s deactivate timer")
             if self._timer is not None:
                 self._timer.cancel()
             self._timer = threading.Timer(5.0, self.check_and_deactivate)
@@ -890,12 +944,21 @@ class AudioInputSource:
         if self._timer is not None:
             self._timer.cancel()
         self._timer = None
-        if self._should_always_keep_active():
+        always_on = self._should_always_keep_active()
+        _LOGGER.debug(
+            "[SENDSPIN] check_and_deactivate: callbacks=%s, always_keep_active=%s, stream_active=%s",
+            len(self._callbacks),
+            always_on,
+            AudioInputSource._audio_stream_active,
+        )
+        if always_on:
+            _LOGGER.debug("[SENDSPIN] check_and_deactivate: always-on active, skipping deactivate")
             return
         if (
             len(self._callbacks) <= self._subscriber_threshold
             and AudioInputSource._audio_stream_active
         ):
+            _LOGGER.debug("[SENDSPIN] check_and_deactivate: deactivating audio stream")
             self.deactivate()
 
     def get_device_index_by_name(self, device_name: str):

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -901,9 +901,7 @@ class AudioInputSource:
             self._timer.cancel()
         self._timer = None
         if self._should_always_keep_active():
-            _LOGGER.debug(
-                "Sendspin always-on active, skipping deactivate"
-            )
+            _LOGGER.debug("Sendspin always-on active, skipping deactivate")
             return
         if (
             len(self._callbacks) <= self._subscriber_threshold

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -350,11 +350,6 @@ class AudioInputSource:
         apis = sd.query_hostapis() + ({"name": "WEB AUDIO"},)
         if SENDSPIN_AVAILABLE:
             apis = apis + ({"name": "SENDSPIN"},)
-        _LOGGER.debug(
-            "[SENDSPIN] query_hostapis: SENDSPIN_AVAILABLE=%s, hostapi_count=%s",
-            SENDSPIN_AVAILABLE,
-            len(apis),
-        )
         return apis
 
     @staticmethod
@@ -386,11 +381,6 @@ class AudioInputSource:
                 for name, config in SENDSPIN_SERVERS.items()
             )
             devices = devices + sendspin_devices
-            _LOGGER.debug(
-                "[SENDSPIN] query_devices: added %s sendspin device(s): %s",
-                len(sendspin_devices),
-                [d["name"] for d in sendspin_devices],
-            )
         return devices
 
     @staticmethod
@@ -524,12 +514,6 @@ class AudioInputSource:
 
         # Activate outside the lock to avoid deadlock
         should_always_on = self._should_always_keep_active()
-        _LOGGER.debug(
-            "[SENDSPIN] update_config: callbacks=%s, should_always_keep_active=%s, stream_active=%s",
-            len(self._callbacks),
-            should_always_on,
-            AudioInputSource._audio_stream_active,
-        )
         if len(self._callbacks) != 0 or should_always_on:
             self.activate()
 
@@ -736,7 +720,7 @@ class AudioInputSource:
                 from ledfx.sendspin.stream import SendspinAudioStream
 
                 _LOGGER.debug(
-                    "[SENDSPIN] open_audio_stream: opening SendspinAudioStream for '%s'",
+                    "Opening SendspinAudioStream for '%s'",
                     device["name"],
                 )
                 AudioInputSource._stream = SendspinAudioStream(
@@ -855,15 +839,6 @@ class AudioInputSource:
         self.deactivate()
 
     def deactivate(self):
-        _LOGGER.debug(
-            "[SENDSPIN] deactivate: stream_active=%s, stream_type=%s",
-            AudioInputSource._audio_stream_active,
-            (
-                type(AudioInputSource._stream).__name__
-                if AudioInputSource._stream
-                else None
-            ),
-        )
         # Stop the stream outside the lock to avoid deadlock with audio callback
         # The audio callback thread may be waiting to complete, and if it needs
         # any locks, holding the lock while calling stop() creates a circular wait
@@ -879,41 +854,21 @@ class AudioInputSource:
             stream_to_close.stop()
             stream_to_close.close()
             _LOGGER.info("Audio source closed.")
-            _LOGGER.debug(
-                "[SENDSPIN] deactivate: stream closed, type was %s",
-                type(stream_to_close).__name__,
-            )
 
     def _should_always_keep_active(self):
         """Check if the current audio source should stay active regardless of subscribers."""
-        always_on_config = self._ledfx.config.get("sendspin_always_on", False)
-        if not always_on_config:
-            _LOGGER.debug(
-                "[SENDSPIN] _should_always_keep_active: sendspin_always_on config=%s, returning False",
-                always_on_config,
-            )
+        if not self._ledfx.config.get("sendspin_always_on", False):
             return False
         device_idx = self._config.get("audio_device")
-        result = is_sendspin_always_on(
+        return is_sendspin_always_on(
             device_idx,
             self.query_devices,
             self.query_hostapis,
         )
-        _LOGGER.debug(
-            "[SENDSPIN] _should_always_keep_active: sendspin_always_on=True, device_idx=%s, is_sendspin=%s",
-            device_idx,
-            result,
-        )
-        return result
 
     def subscribe(self, callback):
         """Registers a callback with the input source"""
         self._callbacks.append(callback)
-        _LOGGER.debug(
-            "[SENDSPIN] subscribe: callbacks=%s, stream_active=%s",
-            len(self._callbacks),
-            AudioInputSource._audio_stream_active,
-        )
         if (
             len(self._callbacks) > 0
             and not AudioInputSource._audio_stream_active
@@ -927,25 +882,15 @@ class AudioInputSource:
         """Unregisters a callback with the input source"""
         if callback in self._callbacks:
             self._callbacks.remove(callback)
-        always_on = self._should_always_keep_active()
-        _LOGGER.debug(
-            "[SENDSPIN] unsubscribe: callbacks=%s, always_keep_active=%s, stream_active=%s",
-            len(self._callbacks),
-            always_on,
-            AudioInputSource._audio_stream_active,
-        )
-        if always_on:
+        if self._should_always_keep_active():
             _LOGGER.debug(
-                "[SENDSPIN] unsubscribe: always-on active, skipping deactivate timer"
+                "Sendspin always-on active, skipping deactivate timer"
             )
             return
         if (
             len(self._callbacks) <= self._subscriber_threshold
             and AudioInputSource._audio_stream_active
         ):
-            _LOGGER.debug(
-                "[SENDSPIN] unsubscribe: starting 5s deactivate timer"
-            )
             if self._timer is not None:
                 self._timer.cancel()
             self._timer = threading.Timer(5.0, self.check_and_deactivate)
@@ -955,25 +900,15 @@ class AudioInputSource:
         if self._timer is not None:
             self._timer.cancel()
         self._timer = None
-        always_on = self._should_always_keep_active()
-        _LOGGER.debug(
-            "[SENDSPIN] check_and_deactivate: callbacks=%s, always_keep_active=%s, stream_active=%s",
-            len(self._callbacks),
-            always_on,
-            AudioInputSource._audio_stream_active,
-        )
-        if always_on:
+        if self._should_always_keep_active():
             _LOGGER.debug(
-                "[SENDSPIN] check_and_deactivate: always-on active, skipping deactivate"
+                "Sendspin always-on active, skipping deactivate"
             )
             return
         if (
             len(self._callbacks) <= self._subscriber_threshold
             and AudioInputSource._audio_stream_active
         ):
-            _LOGGER.debug(
-                "[SENDSPIN] check_and_deactivate: deactivating audio stream"
-            )
             self.deactivate()
 
     def get_device_index_by_name(self, device_name: str):

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -19,6 +19,7 @@ from ledfx.effects.math import ExpFilter
 from ledfx.effects.melbank import FFT_SIZE, MIC_RATE, Melbanks
 from ledfx.events import AudioDeviceChangeEvent, Event
 from ledfx.sendspin import SENDSPIN_AVAILABLE
+from ledfx.sendspin.config import is_always_on as is_sendspin_always_on
 
 # Sendspin server configurations discovered or configured
 SENDSPIN_SERVERS = {}
@@ -511,7 +512,7 @@ class AudioInputSource:
             last_active = AudioInputSource._last_active
 
         # Activate outside the lock to avoid deadlock
-        if len(self._callbacks) != 0:
+        if len(self._callbacks) != 0 or self._should_always_keep_active():
             self.activate()
 
         # Check if device changed and fire event if needed
@@ -848,6 +849,16 @@ class AudioInputSource:
             stream_to_close.close()
             _LOGGER.info("Audio source closed.")
 
+    def _should_always_keep_active(self):
+        """Check if the current audio source should stay active regardless of subscribers."""
+        if not self._ledfx.config.get("sendspin_always_on", False):
+            return False
+        return is_sendspin_always_on(
+            self._config.get("audio_device"),
+            self.query_devices,
+            self.query_hostapis,
+        )
+
     def subscribe(self, callback):
         """Registers a callback with the input source"""
         self._callbacks.append(callback)
@@ -864,6 +875,8 @@ class AudioInputSource:
         """Unregisters a callback with the input source"""
         if callback in self._callbacks:
             self._callbacks.remove(callback)
+        if self._should_always_keep_active():
+            return
         if (
             len(self._callbacks) <= self._subscriber_threshold
             and AudioInputSource._audio_stream_active
@@ -877,6 +890,8 @@ class AudioInputSource:
         if self._timer is not None:
             self._timer.cancel()
         self._timer = None
+        if self._should_always_keep_active():
+            return
         if (
             len(self._callbacks) <= self._subscriber_threshold
             and AudioInputSource._audio_stream_active

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -742,7 +742,6 @@ class AudioInputSource:
                 AudioInputSource._stream = SendspinAudioStream(
                     device["sendspin_config"],
                     self._audio_sample_callback,
-                    sendspin_entry_id=device["name"],
                     instance_id=self._ledfx.config.get("instance_id", ""),
                 )
             else:

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -858,7 +858,11 @@ class AudioInputSource:
         _LOGGER.debug(
             "[SENDSPIN] deactivate: stream_active=%s, stream_type=%s",
             AudioInputSource._audio_stream_active,
-            type(AudioInputSource._stream).__name__ if AudioInputSource._stream else None,
+            (
+                type(AudioInputSource._stream).__name__
+                if AudioInputSource._stream
+                else None
+            ),
         )
         # Stop the stream outside the lock to avoid deadlock with audio callback
         # The audio callback thread may be waiting to complete, and if it needs
@@ -875,7 +879,10 @@ class AudioInputSource:
             stream_to_close.stop()
             stream_to_close.close()
             _LOGGER.info("Audio source closed.")
-            _LOGGER.debug("[SENDSPIN] deactivate: stream closed, type was %s", type(stream_to_close).__name__)
+            _LOGGER.debug(
+                "[SENDSPIN] deactivate: stream closed, type was %s",
+                type(stream_to_close).__name__,
+            )
 
     def _should_always_keep_active(self):
         """Check if the current audio source should stay active regardless of subscribers."""
@@ -928,13 +935,17 @@ class AudioInputSource:
             AudioInputSource._audio_stream_active,
         )
         if always_on:
-            _LOGGER.debug("[SENDSPIN] unsubscribe: always-on active, skipping deactivate timer")
+            _LOGGER.debug(
+                "[SENDSPIN] unsubscribe: always-on active, skipping deactivate timer"
+            )
             return
         if (
             len(self._callbacks) <= self._subscriber_threshold
             and AudioInputSource._audio_stream_active
         ):
-            _LOGGER.debug("[SENDSPIN] unsubscribe: starting 5s deactivate timer")
+            _LOGGER.debug(
+                "[SENDSPIN] unsubscribe: starting 5s deactivate timer"
+            )
             if self._timer is not None:
                 self._timer.cancel()
             self._timer = threading.Timer(5.0, self.check_and_deactivate)
@@ -952,13 +963,17 @@ class AudioInputSource:
             AudioInputSource._audio_stream_active,
         )
         if always_on:
-            _LOGGER.debug("[SENDSPIN] check_and_deactivate: always-on active, skipping deactivate")
+            _LOGGER.debug(
+                "[SENDSPIN] check_and_deactivate: always-on active, skipping deactivate"
+            )
             return
         if (
             len(self._callbacks) <= self._subscriber_threshold
             and AudioInputSource._audio_stream_active
         ):
-            _LOGGER.debug("[SENDSPIN] check_and_deactivate: deactivating audio stream")
+            _LOGGER.debug(
+                "[SENDSPIN] check_and_deactivate: deactivating audio stream"
+            )
             self.deactivate()
 
     def get_device_index_by_name(self, device_name: str):

--- a/ledfx/sendspin/__init__.py
+++ b/ledfx/sendspin/__init__.py
@@ -17,28 +17,20 @@ _LOGGER = logging.getLogger(__name__)
 
 # Only expose Sendspin functionality on Python 3.12+
 if sys.version_info >= (3, 12):
-    _LOGGER.debug(
-        "[SENDSPIN] Python %s >= 3.12, attempting import", sys.version_info
-    )
     try:
         from ledfx.sendspin.stream import SendspinAudioStream  # noqa: F401
 
         __all__ = ["SendspinAudioStream"]
         SENDSPIN_AVAILABLE = True
-        _LOGGER.debug("[SENDSPIN] Import succeeded, SENDSPIN_AVAILABLE=True")
     except (ImportError, OSError) as _exc:
         # aiosendspin not available, or native library (e.g. libFLAC.dll) failed to load
         SENDSPIN_AVAILABLE = False
         __all__ = []
         _LOGGER.warning(
-            "[SENDSPIN] Import failed, SENDSPIN_AVAILABLE=False: %s",
+            "Sendspin import failed: %s",
             _exc,
             exc_info=_exc,
         )
 else:
     SENDSPIN_AVAILABLE = False
     __all__ = []
-    _LOGGER.debug(
-        "[SENDSPIN] Python %s < 3.12, SENDSPIN_AVAILABLE=False",
-        sys.version_info,
-    )

--- a/ledfx/sendspin/__init__.py
+++ b/ledfx/sendspin/__init__.py
@@ -10,19 +10,26 @@ For Python < 3.12, the module will gracefully no-op and Sendspin won't appear
 as an available audio source.
 """
 
+import logging
 import sys
+
+_LOGGER = logging.getLogger(__name__)
 
 # Only expose Sendspin functionality on Python 3.12+
 if sys.version_info >= (3, 12):
+    _LOGGER.debug("[SENDSPIN] Python %s >= 3.12, attempting import", sys.version_info)
     try:
         from ledfx.sendspin.stream import SendspinAudioStream  # noqa: F401
 
         __all__ = ["SendspinAudioStream"]
         SENDSPIN_AVAILABLE = True
-    except (ImportError, OSError):
+        _LOGGER.debug("[SENDSPIN] Import succeeded, SENDSPIN_AVAILABLE=True")
+    except (ImportError, OSError) as _exc:
         # aiosendspin not available, or native library (e.g. libFLAC.dll) failed to load
         SENDSPIN_AVAILABLE = False
         __all__ = []
+        _LOGGER.debug("[SENDSPIN] Import failed (%s), SENDSPIN_AVAILABLE=False", _exc)
 else:
     SENDSPIN_AVAILABLE = False
     __all__ = []
+    _LOGGER.debug("[SENDSPIN] Python %s < 3.12, SENDSPIN_AVAILABLE=False", sys.version_info)

--- a/ledfx/sendspin/__init__.py
+++ b/ledfx/sendspin/__init__.py
@@ -30,8 +30,10 @@ if sys.version_info >= (3, 12):
         # aiosendspin not available, or native library (e.g. libFLAC.dll) failed to load
         SENDSPIN_AVAILABLE = False
         __all__ = []
-        _LOGGER.debug(
-            "[SENDSPIN] Import failed (%s), SENDSPIN_AVAILABLE=False", _exc
+        _LOGGER.warning(
+            "[SENDSPIN] Import failed, SENDSPIN_AVAILABLE=False: %s",
+            _exc,
+            exc_info=_exc,
         )
 else:
     SENDSPIN_AVAILABLE = False

--- a/ledfx/sendspin/__init__.py
+++ b/ledfx/sendspin/__init__.py
@@ -17,7 +17,9 @@ _LOGGER = logging.getLogger(__name__)
 
 # Only expose Sendspin functionality on Python 3.12+
 if sys.version_info >= (3, 12):
-    _LOGGER.debug("[SENDSPIN] Python %s >= 3.12, attempting import", sys.version_info)
+    _LOGGER.debug(
+        "[SENDSPIN] Python %s >= 3.12, attempting import", sys.version_info
+    )
     try:
         from ledfx.sendspin.stream import SendspinAudioStream  # noqa: F401
 
@@ -28,8 +30,13 @@ if sys.version_info >= (3, 12):
         # aiosendspin not available, or native library (e.g. libFLAC.dll) failed to load
         SENDSPIN_AVAILABLE = False
         __all__ = []
-        _LOGGER.debug("[SENDSPIN] Import failed (%s), SENDSPIN_AVAILABLE=False", _exc)
+        _LOGGER.debug(
+            "[SENDSPIN] Import failed (%s), SENDSPIN_AVAILABLE=False", _exc
+        )
 else:
     SENDSPIN_AVAILABLE = False
     __all__ = []
-    _LOGGER.debug("[SENDSPIN] Python %s < 3.12, SENDSPIN_AVAILABLE=False", sys.version_info)
+    _LOGGER.debug(
+        "[SENDSPIN] Python %s < 3.12, SENDSPIN_AVAILABLE=False",
+        sys.version_info,
+    )

--- a/ledfx/sendspin/config.py
+++ b/ledfx/sendspin/config.py
@@ -87,33 +87,19 @@ def is_always_on(device_idx, query_devices, query_hostapis):
         True if the device is a Sendspin server.
     """
     if not isinstance(device_idx, int) or device_idx < 0:
-        _LOGGER.debug(
-            "[SENDSPIN] is_always_on: device_idx=%r is not a valid non-negative int, returning False",
-            device_idx,
-        )
         return False
     try:
         devices = query_devices()
         hostapis = query_hostapis()
         if device_idx >= len(devices):
-            _LOGGER.debug(
-                "[SENDSPIN] is_always_on: device_idx=%s >= len(devices)=%s, returning False",
-                device_idx,
-                len(devices),
-            )
             return False
         hostapi_name = hostapis[devices[device_idx]["hostapi"]]["name"]
-        result = hostapi_name == "SENDSPIN"
-        _LOGGER.debug(
-            "[SENDSPIN] is_always_on: device_idx=%s hostapi=%r -> %s",
-            device_idx,
-            hostapi_name,
-            result,
-        )
-        return result
+        return hostapi_name == "SENDSPIN"
     except Exception as exc:
         _LOGGER.debug(
-            "[SENDSPIN] is_always_on: exception %s, returning False", exc
+            "is_always_on: exception checking device %s: %s",
+            device_idx,
+            exc,
         )
         return False
 
@@ -127,9 +113,6 @@ def eager_start(ledfx):
     effect is active yet.
     """
     if not ledfx.config.get("sendspin_always_on", False):
-        _LOGGER.debug(
-            "[SENDSPIN] eager_start: sendspin_always_on is False, skipping"
-        )
         return
 
     audio_config = ledfx.config.get("audio", {})
@@ -144,14 +127,10 @@ def eager_start(ledfx):
         AudioInputSource.query_devices,
         AudioInputSource.query_hostapis,
     ):
-        _LOGGER.debug(
-            "[SENDSPIN] eager_start: audio_device=%s is not a Sendspin device, skipping",
-            device_idx,
-        )
         return
 
-    _LOGGER.debug(
-        "[SENDSPIN] eager_start: audio_device=%s is Sendspin, eagerly initializing audio subsystem",
+    _LOGGER.info(
+        "Sendspin always-on: eagerly starting audio (device %s)",
         device_idx,
     )
     ledfx.audio = AudioAnalysisSource(ledfx, audio_config)

--- a/ledfx/sendspin/config.py
+++ b/ledfx/sendspin/config.py
@@ -83,11 +83,6 @@ def is_always_on(device_idx, query_devices, query_hostapis):
     Returns:
         True if the device is a Sendspin server.
     """
-    if device_idx is None:
-        return False
-
-
-def is_always_on(device_idx, query_devices, query_hostapis):
     if not isinstance(device_idx, int) or device_idx < 0:
         return False
     try:
@@ -98,4 +93,3 @@ def is_always_on(device_idx, query_devices, query_hostapis):
         return hostapis[devices[device_idx]["hostapi"]]["name"] == "SENDSPIN"
     except Exception:
         return False
-    return False

--- a/ledfx/sendspin/config.py
+++ b/ledfx/sendspin/config.py
@@ -92,8 +92,7 @@ def is_always_on(device_idx, query_devices, query_hostapis):
         hostapis = query_hostapis()
         if (
             device_idx < len(devices)
-            and hostapis[devices[device_idx]["hostapi"]]["name"]
-            == "SENDSPIN"
+            and hostapis[devices[device_idx]["hostapi"]]["name"] == "SENDSPIN"
         ):
             return True
     except (IndexError, KeyError):

--- a/ledfx/sendspin/config.py
+++ b/ledfx/sendspin/config.py
@@ -4,6 +4,8 @@ import urllib.parse
 
 import voluptuous as vol
 
+from ledfx.sendspin import SENDSPIN_AVAILABLE
+
 # Default Sendspin server configuration
 DEFAULT_SERVER_URL = "ws://192.168.1.12:8927/sendspin"
 DEFAULT_CLIENT_NAME = "LedFx"
@@ -70,3 +72,30 @@ def validate_sendspin_server_url(url) -> tuple[bool, str]:
         return False, "server_url path contains path-traversal sequence"
 
     return True, ""
+
+
+def is_always_on(device_idx, query_devices, query_hostapis):
+    """Check if the audio device at device_idx is a Sendspin device.
+
+    Args:
+        device_idx: The audio device index to check.
+        query_devices: Callable returning the full device tuple.
+        query_hostapis: Callable returning the host API tuple.
+
+    Returns:
+        True if the device is a Sendspin server.
+    """
+    if not SENDSPIN_AVAILABLE or device_idx is None:
+        return False
+    try:
+        devices = query_devices()
+        hostapis = query_hostapis()
+        if (
+            device_idx < len(devices)
+            and hostapis[devices[device_idx]["hostapi"]]["name"]
+            == "SENDSPIN"
+        ):
+            return True
+    except (IndexError, KeyError):
+        pass
+    return False

--- a/ledfx/sendspin/config.py
+++ b/ledfx/sendspin/config.py
@@ -112,5 +112,7 @@ def is_always_on(device_idx, query_devices, query_hostapis):
         )
         return result
     except Exception as exc:
-        _LOGGER.debug("[SENDSPIN] is_always_on: exception %s, returning False", exc)
+        _LOGGER.debug(
+            "[SENDSPIN] is_always_on: exception %s, returning False", exc
+        )
         return False

--- a/ledfx/sendspin/config.py
+++ b/ledfx/sendspin/config.py
@@ -4,8 +4,6 @@ import urllib.parse
 
 import voluptuous as vol
 
-from ledfx.sendspin import SENDSPIN_AVAILABLE
-
 # Default Sendspin server configuration
 DEFAULT_SERVER_URL = "ws://192.168.1.12:8927/sendspin"
 DEFAULT_CLIENT_NAME = "LedFx"
@@ -85,7 +83,7 @@ def is_always_on(device_idx, query_devices, query_hostapis):
     Returns:
         True if the device is a Sendspin server.
     """
-    if not SENDSPIN_AVAILABLE or device_idx is None:
+    if device_idx is None:
         return False
     try:
         devices = query_devices()

--- a/ledfx/sendspin/config.py
+++ b/ledfx/sendspin/config.py
@@ -1,8 +1,11 @@
 """Sendspin configuration schema and constants."""
 
+import logging
 import urllib.parse
 
 import voluptuous as vol
+
+_LOGGER = logging.getLogger(__name__)
 
 # Default Sendspin server configuration
 DEFAULT_SERVER_URL = "ws://192.168.1.12:8927/sendspin"
@@ -84,12 +87,30 @@ def is_always_on(device_idx, query_devices, query_hostapis):
         True if the device is a Sendspin server.
     """
     if not isinstance(device_idx, int) or device_idx < 0:
+        _LOGGER.debug(
+            "[SENDSPIN] is_always_on: device_idx=%r is not a valid non-negative int, returning False",
+            device_idx,
+        )
         return False
     try:
         devices = query_devices()
         hostapis = query_hostapis()
         if device_idx >= len(devices):
+            _LOGGER.debug(
+                "[SENDSPIN] is_always_on: device_idx=%s >= len(devices)=%s, returning False",
+                device_idx,
+                len(devices),
+            )
             return False
-        return hostapis[devices[device_idx]["hostapi"]]["name"] == "SENDSPIN"
-    except Exception:
+        hostapi_name = hostapis[devices[device_idx]["hostapi"]]["name"]
+        result = hostapi_name == "SENDSPIN"
+        _LOGGER.debug(
+            "[SENDSPIN] is_always_on: device_idx=%s hostapi=%r -> %s",
+            device_idx,
+            hostapi_name,
+            result,
+        )
+        return result
+    except Exception as exc:
+        _LOGGER.debug("[SENDSPIN] is_always_on: exception %s, returning False", exc)
         return False

--- a/ledfx/sendspin/config.py
+++ b/ledfx/sendspin/config.py
@@ -114,3 +114,42 @@ def is_always_on(device_idx, query_devices, query_hostapis):
     except Exception as exc:
         _LOGGER.debug("[SENDSPIN] is_always_on: exception %s, returning False", exc)
         return False
+
+
+def eager_start(ledfx):
+    """Eagerly start the audio subsystem if sendspin_always_on is enabled
+    and the configured audio device is a Sendspin source.
+
+    Called from core startup after sendspin servers are loaded so the
+    Sendspin audio stream begins immediately, even when no audio-reactive
+    effect is active yet.
+    """
+    if not ledfx.config.get("sendspin_always_on", False):
+        _LOGGER.debug(
+            "[SENDSPIN] eager_start: sendspin_always_on is False, skipping"
+        )
+        return
+
+    audio_config = ledfx.config.get("audio", {})
+    device_idx = audio_config.get("audio_device")
+
+    # Lazy import to break circular dependency:
+    # audio.py → sendspin/config.py → audio.py
+    from ledfx.effects.audio import AudioAnalysisSource, AudioInputSource
+
+    if not is_always_on(
+        device_idx,
+        AudioInputSource.query_devices,
+        AudioInputSource.query_hostapis,
+    ):
+        _LOGGER.debug(
+            "[SENDSPIN] eager_start: audio_device=%s is not a Sendspin device, skipping",
+            device_idx,
+        )
+        return
+
+    _LOGGER.debug(
+        "[SENDSPIN] eager_start: audio_device=%s is Sendspin, eagerly initializing audio subsystem",
+        device_idx,
+    )
+    ledfx.audio = AudioAnalysisSource(ledfx, audio_config)

--- a/ledfx/sendspin/config.py
+++ b/ledfx/sendspin/config.py
@@ -87,14 +87,15 @@ def is_always_on(device_idx, query_devices, query_hostapis):
     """
     if not SENDSPIN_AVAILABLE or device_idx is None:
         return False
+def is_always_on(device_idx, query_devices, query_hostapis):
+    if not isinstance(device_idx, int) or device_idx < 0:
+        return False
     try:
         devices = query_devices()
         hostapis = query_hostapis()
-        if (
-            device_idx < len(devices)
-            and hostapis[devices[device_idx]["hostapi"]]["name"] == "SENDSPIN"
-        ):
-            return True
-    except (IndexError, KeyError):
-        pass
+        if device_idx >= len(devices):
+            return False
+        return hostapis[devices[device_idx]["hostapi"]]["name"] == "SENDSPIN"
+    except Exception:
+        return False
     return False

--- a/ledfx/sendspin/config.py
+++ b/ledfx/sendspin/config.py
@@ -87,6 +87,8 @@ def is_always_on(device_idx, query_devices, query_hostapis):
     """
     if not SENDSPIN_AVAILABLE or device_idx is None:
         return False
+
+
 def is_always_on(device_idx, query_devices, query_hostapis):
     if not isinstance(device_idx, int) or device_idx < 0:
         return False

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -51,19 +51,15 @@ class SendspinAudioStream:
     Args:
         config: Configuration dict with server_url, client_name, etc.
         callback: LedFx's _audio_sample_callback(data, frame_count, time_info, status)
-        sendspin_entry_id: The local Sendspin config entry name (key from
-            ``sendspin_servers`` in LedFx config).  Distinguishes multiple
-            Sendspin connections within the same LedFx installation.
         instance_id: Persistent LedFx installation UUID from top-level config.
-            Combined with *sendspin_entry_id* to form a globally unique,
-            collision-safe ``client_id`` sent to the Sendspin server.
+            Used to form a stable, collision-safe ``client_id`` sent to the
+            Sendspin server.
     """
 
     def __init__(
         self,
         config: dict,
         callback: Callable,
-        sendspin_entry_id: str = "",
         instance_id: str = "",
     ):
         if SendspinClient is None:
@@ -73,7 +69,6 @@ class SendspinAudioStream:
 
         self.config = config
         self.callback = callback
-        self._sendspin_entry_id = sendspin_entry_id
         self._instance_id = instance_id
         self._active = False
         self._client: Optional[SendspinClient] = None

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -70,6 +70,8 @@ class SendspinAudioStream:
         self.config = config
         self.callback = callback
         self._instance_id = instance_id
+        if not instance_id:
+            raise ValueError("instance_id must be provided and non-empty")
         self._active = False
         self._client: Optional[SendspinClient] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -51,11 +51,21 @@ class SendspinAudioStream:
     Args:
         config: Configuration dict with server_url, client_name, etc.
         callback: LedFx's _audio_sample_callback(data, frame_count, time_info, status)
-        server_id: Stable identifier for this server config entry, used to
-            generate a persistent client_id across reconnections (spec requirement).
+        sendspin_entry_id: The local Sendspin config entry name (key from
+            ``sendspin_servers`` in LedFx config).  Distinguishes multiple
+            Sendspin connections within the same LedFx installation.
+        instance_id: Persistent LedFx installation UUID from top-level config.
+            Combined with *sendspin_entry_id* to form a globally unique,
+            collision-safe ``client_id`` sent to the Sendspin server.
     """
 
-    def __init__(self, config: dict, callback: Callable, server_id: str = ""):
+    def __init__(
+        self,
+        config: dict,
+        callback: Callable,
+        sendspin_entry_id: str = "",
+        instance_id: str = "",
+    ):
         if SendspinClient is None:
             raise ImportError(
                 "aiosendspin not available (requires Python 3.12+)"
@@ -63,7 +73,8 @@ class SendspinAudioStream:
 
         self.config = config
         self.callback = callback
-        self._server_id = server_id
+        self._sendspin_entry_id = sendspin_entry_id
+        self._instance_id = instance_id
         self._active = False
         self._client: Optional[SendspinClient] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
@@ -619,14 +630,10 @@ class SendspinAudioStream:
                 ],
             )
 
-            # Create Sendspin client
-            # client_id must be persistent across reconnections so the server
-            # can associate this client with previous sessions (spec requirement).
-            client_id = (
-                f"ledfx-{self._server_id}"
-                if self._server_id
-                else f"ledfx-{id(self)}"
-            )
+            # Build a collision-safe client_id using the first 8 chars of
+            # the persistent LedFx installation UUID.  Stable across
+            # reconnections and restarts; unique across installations.
+            client_id = f"ledfx-{self._instance_id[:8]}"
             self._client = SendspinClient(
                 client_id=client_id,
                 client_name=client_name,

--- a/tests/test_instance_id.py
+++ b/tests/test_instance_id.py
@@ -113,7 +113,6 @@ class TestSendspinClientId:
         from ledfx.sendspin.stream import SendspinAudioStream
 
         instance_id = str(uuid.uuid4())
-        entry_id = "TestEntry"
 
         with patch("ledfx.sendspin.stream.SendspinClient", MagicMock()):
             stream = SendspinAudioStream(
@@ -122,9 +121,7 @@ class TestSendspinClientId:
                     "client_name": "LedFx",
                 },
                 callback=lambda *a: None,
-                sendspin_entry_id=entry_id,
                 instance_id=instance_id,
             )
 
         assert stream._instance_id == instance_id
-        assert stream._sendspin_entry_id == entry_id

--- a/tests/test_instance_id.py
+++ b/tests/test_instance_id.py
@@ -60,7 +60,7 @@ class TestBackwardCompatibility:
 
     def test_old_config_without_instance_id(self):
         old_config = {
-            "host": "0.0.0.0",
+            "host": "127.0.0.1",
             "port": 8888,
             "sendspin_servers": {"MyServer": {"server_url": "ws://host:1234"}},
         }

--- a/tests/test_instance_id.py
+++ b/tests/test_instance_id.py
@@ -1,0 +1,130 @@
+"""Tests for persistent LedFx instance_id and Sendspin client_id construction."""
+
+import uuid
+
+import pytest
+
+from ledfx.config import CORE_CONFIG_SCHEMA, ensure_instance_id
+
+
+# ---------------------------------------------------------------------------
+# Config bootstrap: ensure_instance_id
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureInstanceId:
+    """Tests for ensure_instance_id config helper."""
+
+    def test_generates_uuid_when_missing(self):
+        config = {}
+        ensure_instance_id(config)
+        # Must be a valid UUID string
+        val = uuid.UUID(config["instance_id"])
+        assert str(val) == config["instance_id"]
+
+    def test_generates_uuid_when_empty_string(self):
+        config = {"instance_id": ""}
+        ensure_instance_id(config)
+        uuid.UUID(config["instance_id"])  # valid UUID
+
+    def test_preserves_existing_instance_id(self):
+        existing = str(uuid.uuid4())
+        config = {"instance_id": existing}
+        ensure_instance_id(config)
+        assert config["instance_id"] == existing
+
+    def test_generated_ids_are_unique(self):
+        configs = [{}, {}]
+        for c in configs:
+            ensure_instance_id(c)
+        assert configs[0]["instance_id"] != configs[1]["instance_id"]
+
+    def test_schema_accepts_instance_id(self):
+        test_id = str(uuid.uuid4())
+        config = CORE_CONFIG_SCHEMA({"instance_id": test_id})
+        assert config["instance_id"] == test_id
+
+    def test_schema_defaults_instance_id_to_empty(self):
+        config = CORE_CONFIG_SCHEMA({})
+        assert config["instance_id"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: existing config without instance_id
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatibility:
+    """Ensure old configs without instance_id load and validate fine."""
+
+    def test_old_config_without_instance_id(self):
+        old_config = {
+            "host": "0.0.0.0",
+            "port": 8888,
+            "sendspin_servers": {"MyServer": {"server_url": "ws://host:1234"}},
+        }
+        validated = CORE_CONFIG_SCHEMA(old_config)
+        assert validated["instance_id"] == ""
+        # ensure_instance_id fills it in
+        ensure_instance_id(validated)
+        uuid.UUID(validated["instance_id"])
+
+
+# ---------------------------------------------------------------------------
+# Sendspin client_id construction
+# ---------------------------------------------------------------------------
+
+
+class TestSendspinClientId:
+    """Tests for client_id built in SendspinAudioStream."""
+
+    @pytest.fixture()
+    def _skip_if_no_aiosendspin(self):
+        """Skip tests if aiosendspin is not available."""
+        try:
+            from aiosendspin.client import SendspinClient  # noqa: F401
+        except ImportError:
+            pytest.skip("aiosendspin not available")
+
+    @pytest.mark.usefixtures("_skip_if_no_aiosendspin")
+    def test_client_id_uses_short_instance_id(self):
+        instance_id = str(uuid.uuid4())
+
+        client_id = f"ledfx-{instance_id[:8]}"
+        assert client_id == f"ledfx-{instance_id[:8]}"
+        assert len(instance_id[:8]) == 8
+
+    @pytest.mark.usefixtures("_skip_if_no_aiosendspin")
+    def test_client_id_deterministic(self):
+        instance_id = str(uuid.uuid4())
+        id1 = f"ledfx-{instance_id[:8]}"
+        id2 = f"ledfx-{instance_id[:8]}"
+        assert id1 == id2
+
+    @pytest.mark.usefixtures("_skip_if_no_aiosendspin")
+    def test_client_id_differs_across_instances(self):
+        id1 = f"ledfx-{str(uuid.uuid4())[:8]}"
+        id2 = f"ledfx-{str(uuid.uuid4())[:8]}"
+        assert id1 != id2
+
+    @pytest.mark.usefixtures("_skip_if_no_aiosendspin")
+    def test_stream_constructor_stores_ids(self):
+        from unittest.mock import MagicMock, patch
+
+        from ledfx.sendspin.stream import SendspinAudioStream
+
+        instance_id = str(uuid.uuid4())
+        entry_id = "TestEntry"
+
+        with patch(
+            "ledfx.sendspin.stream.SendspinClient", MagicMock()
+        ):
+            stream = SendspinAudioStream(
+                config={"server_url": "ws://localhost:1234", "client_name": "LedFx"},
+                callback=lambda *a: None,
+                sendspin_entry_id=entry_id,
+                instance_id=instance_id,
+            )
+
+        assert stream._instance_id == instance_id
+        assert stream._sendspin_entry_id == entry_id

--- a/tests/test_instance_id.py
+++ b/tests/test_instance_id.py
@@ -1,6 +1,8 @@
 """Tests for persistent LedFx instance_id and Sendspin client_id construction."""
 
+import asyncio
 import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -85,26 +87,57 @@ class TestSendspinClientId:
         except ImportError:
             pytest.skip("aiosendspin not available")
 
+    def _run_connect_and_capture(self, instance_id):
+        """Run _connect_and_receive with a mocked SendspinClient, return the mock class."""
+        from ledfx.sendspin.stream import SendspinAudioStream
+
+        mock_client_cls = MagicMock()
+        mock_inst = mock_client_cls.return_value
+        mock_inst.connect = AsyncMock(side_effect=Exception("stop"))
+        mock_inst.add_audio_chunk_listener = MagicMock()
+        mock_inst.add_stream_start_listener = MagicMock()
+        mock_inst.add_stream_clear_listener = MagicMock()
+
+        with patch("ledfx.sendspin.stream.SendspinClient", mock_client_cls):
+            stream = SendspinAudioStream(
+                config={
+                    "server_url": "ws://localhost:1234",
+                    "client_name": "LedFx",
+                },
+                callback=lambda *a: None,
+                instance_id=instance_id,
+            )
+            with pytest.raises(Exception, match="stop"):
+                asyncio.run(stream._connect_and_receive())
+
+        return mock_client_cls
+
     @pytest.mark.usefixtures("_skip_if_no_aiosendspin")
     def test_client_id_uses_short_instance_id(self):
         instance_id = str(uuid.uuid4())
-
-        client_id = f"ledfx-{instance_id[:8]}"
-        assert client_id == f"ledfx-{instance_id[:8]}"
+        mock_cls = self._run_connect_and_capture(instance_id)
+        client_id = mock_cls.call_args.kwargs["client_id"]
+        assert client_id.startswith(f"ledfx-{instance_id[:8]}")
         assert len(instance_id[:8]) == 8
 
     @pytest.mark.usefixtures("_skip_if_no_aiosendspin")
     def test_client_id_deterministic(self):
         instance_id = str(uuid.uuid4())
-        id1 = f"ledfx-{instance_id[:8]}"
-        id2 = f"ledfx-{instance_id[:8]}"
-        assert id1 == id2
+        mock1 = self._run_connect_and_capture(instance_id)
+        mock2 = self._run_connect_and_capture(instance_id)
+        assert (
+            mock1.call_args.kwargs["client_id"]
+            == mock2.call_args.kwargs["client_id"]
+        )
 
     @pytest.mark.usefixtures("_skip_if_no_aiosendspin")
     def test_client_id_differs_across_instances(self):
-        id1 = f"ledfx-{str(uuid.uuid4())[:8]}"
-        id2 = f"ledfx-{str(uuid.uuid4())[:8]}"
-        assert id1 != id2
+        mock1 = self._run_connect_and_capture(str(uuid.uuid4()))
+        mock2 = self._run_connect_and_capture(str(uuid.uuid4()))
+        assert (
+            mock1.call_args.kwargs["client_id"]
+            != mock2.call_args.kwargs["client_id"]
+        )
 
     @pytest.mark.usefixtures("_skip_if_no_aiosendspin")
     def test_stream_constructor_stores_ids(self):

--- a/tests/test_instance_id.py
+++ b/tests/test_instance_id.py
@@ -6,7 +6,6 @@ import pytest
 
 from ledfx.config import CORE_CONFIG_SCHEMA, ensure_instance_id
 
-
 # ---------------------------------------------------------------------------
 # Config bootstrap: ensure_instance_id
 # ---------------------------------------------------------------------------
@@ -116,11 +115,12 @@ class TestSendspinClientId:
         instance_id = str(uuid.uuid4())
         entry_id = "TestEntry"
 
-        with patch(
-            "ledfx.sendspin.stream.SendspinClient", MagicMock()
-        ):
+        with patch("ledfx.sendspin.stream.SendspinClient", MagicMock()):
             stream = SendspinAudioStream(
-                config={"server_url": "ws://localhost:1234", "client_name": "LedFx"},
+                config={
+                    "server_url": "ws://localhost:1234",
+                    "client_name": "LedFx",
+                },
                 callback=lambda *a: None,
                 sendspin_entry_id=entry_id,
                 instance_id=instance_id,


### PR DESCRIPTION
Needs update to cover details of final

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sendspin "Always On" option (off by default): compatible devices start on selection, remain active without effects, and can auto-start on boot.
  * Persistent instance ID to provide a stable Sendspin client identity across restarts.
  * Early Sendspin startup when Always On is enabled for faster readiness.
* **Bug Fixes**
  * Disabling Always On correctly stops the Sendspin stream when appropriate.
* **Documentation**
  * Added Always-On Mode section to Sendspin settings docs.
* **Tests**
  * Added tests for instance ID behavior and Sendspin client identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->