### PR TITLE
Fix: Normalise lifx RGB to 0-1

### DIFF
--- a/ledfx/devices/lifx.py
+++ b/ledfx/devices/lifx.py
@@ -630,7 +630,7 @@ class LifxDevice(NetworkedDevice):
             pixels = data.astype(np.dtype("B")).reshape(-1, 3)
             if len(pixels) > 0:
                 r, g, b = pixels[0]
-                color = HSBK.from_rgb(int(r), int(g), int(b)).to_protocol()
+                color = HSBK.from_rgb(r / 255.0, g / 255.0, b / 255.0).to_protocol()
                 packet = packets.Light.SetColor(
                     color=color, duration=self.frame_duration_ms
                 )

--- a/ledfx/devices/lifx.py
+++ b/ledfx/devices/lifx.py
@@ -630,7 +630,9 @@ class LifxDevice(NetworkedDevice):
             pixels = data.astype(np.dtype("B")).reshape(-1, 3)
             if len(pixels) > 0:
                 r, g, b = pixels[0]
-                color = HSBK.from_rgb(r / 255.0, g / 255.0, b / 255.0).to_protocol()
+                color = HSBK.from_rgb(
+                    r / 255.0, g / 255.0, b / 255.0
+                ).to_protocol()
                 packet = packets.Light.SetColor(
                     color=color, duration=self.frame_duration_ms
                 )


### PR DESCRIPTION
Specific issue to single pixel lights.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed color rendering on LIFX devices to display colors more accurately and reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->