### PR TITLE
Fix: refresh state before power for lifx ceiling light

### DIFF
--- a/ledfx/devices/lifx.py
+++ b/ledfx/devices/lifx.py
@@ -333,6 +333,8 @@ class LifxDevice(NetworkedDevice):
                 else:
                     self._device = await device_cls.from_ip(ip)
 
+                # CeilingLight.set_power() requires populated state
+                await self._device.refresh_state()
                 await self._device.set_power(True)
                 self._animator = await Animator.for_matrix(self._device)
 


### PR DESCRIPTION
See issue raised in 

https://github.com/LedFx/LedFx/issues/1782

Speculate fix

The ceiling light override for set_power requires state to be known.

This call should be passive for normal matrix lights.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * LIFX ceiling light devices now refresh their state before powering on during initialization, improving device startup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->