### PR TITLE
Fix: Lifx ceiling refresh state before power 

### DIFF
--- a/ledfx/devices/lifx.py
+++ b/ledfx/devices/lifx.py
@@ -333,6 +333,8 @@ class LifxDevice(NetworkedDevice):
                 else:
                     self._device = await device_cls.from_ip(ip)
 
+                # CeilingLight.set_power() requires populated state
+                await self._device.refresh_state()
                 await self._device.set_power(True)
                 self._animator = await Animator.for_matrix(self._device)
 

--- a/ledfx/devices/lifx.py
+++ b/ledfx/devices/lifx.py
@@ -1,4 +1,3 @@
-from numpy.ma import isin
 import asyncio
 import logging
 
@@ -186,7 +185,9 @@ class LifxDevice(NetworkedDevice):
                     self._lifx_type = "matrix"
                     self._device_type = "LIFX Matrix"
                     tiles = await device.get_device_chain()
-                    self._tiles, self._total_pixels = self._collect_tile_info(tiles)
+                    self._tiles, self._total_pixels = self._collect_tile_info(
+                        tiles
+                    )
 
                     if self._tiles:
                         self._perm = self._build_permutation(tiles)
@@ -234,7 +235,9 @@ class LifxDevice(NetworkedDevice):
                     _LOGGER.info("LIFX %s: Single bulb", self._config["name"])
 
         except (LifxError, OSError) as e:
-            _LOGGER.warning("LIFX %s: Detection failed: %s", self._config["name"], e)
+            _LOGGER.warning(
+                "LIFX %s: Detection failed: %s", self._config["name"], e
+            )
 
     @property
     def pixel_count(self):
@@ -634,13 +637,17 @@ class LifxDevice(NetworkedDevice):
             pixels = data.astype(np.dtype("B")).reshape(-1, 3)
             if len(pixels) > 0:
                 r, g, b = pixels[0]
-                color = HSBK.from_rgb(r / 255.0, g / 255.0, b / 255.0).to_protocol()
+                color = HSBK.from_rgb(
+                    r / 255.0, g / 255.0, b / 255.0
+                ).to_protocol()
                 packet = packets.Light.SetColor(
                     color=color, duration=self.frame_duration_ms
                 )
                 await self._device.connection.send_packet(packet)
         except (LifxError, OSError) as e:
-            _LOGGER.warning("LIFX %s: Light flush error: %s", self._config["name"], e)
+            _LOGGER.warning(
+                "LIFX %s: Light flush error: %s", self._config["name"], e
+            )
 
     def flush(self, data):
         if self._animator:

--- a/ledfx/devices/lifx.py
+++ b/ledfx/devices/lifx.py
@@ -1,3 +1,4 @@
+from numpy.ma import isin
 import asyncio
 import logging
 
@@ -185,9 +186,7 @@ class LifxDevice(NetworkedDevice):
                     self._lifx_type = "matrix"
                     self._device_type = "LIFX Matrix"
                     tiles = await device.get_device_chain()
-                    self._tiles, self._total_pixels = self._collect_tile_info(
-                        tiles
-                    )
+                    self._tiles, self._total_pixels = self._collect_tile_info(tiles)
 
                     if self._tiles:
                         self._perm = self._build_permutation(tiles)
@@ -235,9 +234,7 @@ class LifxDevice(NetworkedDevice):
                     _LOGGER.info("LIFX %s: Single bulb", self._config["name"])
 
         except (LifxError, OSError) as e:
-            _LOGGER.warning(
-                "LIFX %s: Detection failed: %s", self._config["name"], e
-            )
+            _LOGGER.warning("LIFX %s: Detection failed: %s", self._config["name"], e)
 
     @property
     def pixel_count(self):
@@ -333,9 +330,14 @@ class LifxDevice(NetworkedDevice):
                 else:
                     self._device = await device_cls.from_ip(ip)
 
-                # CeilingLight.set_power() requires populated state
-                await self._device.refresh_state()
+                # This is usually handled by instantiating CeilingLight via an async context manager
+                # but for performance reasons, we instantiate directly, so we have to manually update
+                # the state before calling set_power.
+                if device_cls is CeilingLight:
+                    await self._device.refresh_state()
+
                 await self._device.set_power(True)
+
                 self._animator = await Animator.for_matrix(self._device)
 
             elif self._lifx_type == "strip":
@@ -632,17 +634,13 @@ class LifxDevice(NetworkedDevice):
             pixels = data.astype(np.dtype("B")).reshape(-1, 3)
             if len(pixels) > 0:
                 r, g, b = pixels[0]
-                color = HSBK.from_rgb(
-                    r / 255.0, g / 255.0, b / 255.0
-                ).to_protocol()
+                color = HSBK.from_rgb(r / 255.0, g / 255.0, b / 255.0).to_protocol()
                 packet = packets.Light.SetColor(
                     color=color, duration=self.frame_duration_ms
                 )
                 await self._device.connection.send_packet(packet)
         except (LifxError, OSError) as e:
-            _LOGGER.warning(
-                "LIFX %s: Light flush error: %s", self._config["name"], e
-            )
+            _LOGGER.warning("LIFX %s: Light flush error: %s", self._config["name"], e)
 
     def flush(self, data):
         if self._animator:


### PR DESCRIPTION
Almost identical to #1785 but it restricts the refresh to Ceiling devices only, because they need special handling that other Matrix devices do not.

Tested with a couple of Ceilings, a Luna, and two sets of Tiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization for LIFX CeilingLight devices: the device state is now refreshed before powering on, reducing connection issues and ensuring more reliable, consistent startup behavior.
  * Minor startup sequencing adjustments to improve responsiveness and reduce false offline/unsynced states during power-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->