### PR TITLE
Fix: address sendspin client vol support

### DIFF
--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -485,9 +485,7 @@ class SendspinAudioStream:
         """Update the silence gate based on current MA volume/mute state."""
         self._effective_silenced = self._ma_muted or self._ma_volume <= 0
 
-    def _server_command_handler(
-        self, payload: "ServerCommandPayload"
-    ) -> None:
+    def _server_command_handler(self, payload: "ServerCommandPayload") -> None:
         """Handle volume/mute commands from the Sendspin server (Music Assistant).
 
         LedFx is a raw audio consumer — volume is maintained purely for

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -21,7 +21,7 @@ except (ImportError, OSError):
 
 try:
     from aiosendspin.client import AudioFormat, SendspinClient
-    from aiosendspin.models import AudioCodec, PlayerCommand, Roles
+    from aiosendspin.models import AudioCodec, Roles
     from aiosendspin.models.player import (
         ClientHelloPlayerSupport,
         SupportedAudioFormat,
@@ -621,10 +621,7 @@ class SendspinAudioStream:
             player_support = ClientHelloPlayerSupport(
                 supported_formats=supported_formats,
                 buffer_capacity=buffer_capacity,
-                supported_commands=[
-                    PlayerCommand.VOLUME,
-                    PlayerCommand.MUTE,
-                ],
+                supported_commands=[],
             )
 
             # Build a collision-safe client_id using the first 8 chars of

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -22,8 +22,11 @@ except (ImportError, OSError):
 try:
     from aiosendspin.client import AudioFormat, SendspinClient
     from aiosendspin.models import AudioCodec, Roles
+    from aiosendspin.models.core import ServerCommandPayload
     from aiosendspin.models.player import (
         ClientHelloPlayerSupport,
+        PlayerCommand,
+        PlayerStateType,
         SupportedAudioFormat,
     )
 except ImportError:
@@ -101,6 +104,17 @@ class SendspinAudioStream:
         # callback receives exactly _SUB_CHUNK_SAMPLES samples.
         self._leftover = np.array([], dtype=np.float32)
         self._leftover_ts = 0  # play-time (us) of leftover samples
+
+        # --- Music Assistant volume/mute compatibility state ---
+        # LedFx is a raw audio consumer: it auto-levels and normalizes
+        # audio internally, so volume must NEVER be used as a gain
+        # multiplier.  These fields exist solely for Music Assistant
+        # compatibility.  Only mute=True or volume=0 produces actual
+        # silence (by gating audio delivery); all other volume values
+        # (1-100) are tracked/reported but do not affect processing.
+        self._ma_volume: int = 100
+        self._ma_muted: bool = False
+        self._effective_silenced: bool = False
 
         _LOGGER.info(
             "Sendspin stream initialized for server: %s",
@@ -463,6 +477,54 @@ class SendspinAudioStream:
             "Playback buffer cleared (stream/clear, roles=%s)", roles
         )
 
+    # ------------------------------------------------------------------
+    # Music Assistant volume / mute handling
+    # ------------------------------------------------------------------
+
+    def _recompute_effective_silenced(self) -> None:
+        """Update the silence gate based on current MA volume/mute state."""
+        self._effective_silenced = self._ma_muted or self._ma_volume <= 0
+
+    def _server_command_handler(
+        self, payload: "ServerCommandPayload"
+    ) -> None:
+        """Handle volume/mute commands from the Sendspin server (Music Assistant).
+
+        LedFx is a raw audio consumer — volume is maintained purely for
+        Music Assistant compatibility.  Only mute=True or volume=0
+        triggers actual silence; other volume values are tracked/reported
+        but never used as a gain multiplier.
+        """
+        cmd = payload.player
+        if cmd is None:
+            return
+
+        if cmd.command == PlayerCommand.VOLUME:
+            self._ma_volume = max(0, min(100, cmd.volume))
+            _LOGGER.debug("MA volume set to %d", self._ma_volume)
+        elif cmd.command == PlayerCommand.MUTE:
+            self._ma_muted = cmd.mute
+            _LOGGER.debug("MA mute set to %s", self._ma_muted)
+
+        self._recompute_effective_silenced()
+        self._report_player_state()
+
+    def _report_player_state(self) -> None:
+        """Report current player state (volume/mute) to the Sendspin server."""
+        if self._client is None or self._loop is None:
+            return
+        try:
+            asyncio.run_coroutine_threadsafe(
+                self._client.send_player_state(
+                    state=PlayerStateType.SYNCHRONIZED,
+                    volume=self._ma_volume,
+                    muted=self._ma_muted,
+                ),
+                self._loop,
+            )
+        except Exception as e:
+            _LOGGER.warning("Failed to report player state: %s", e)
+
     async def _playback_scheduler(self):
         """Release buffered chunks to LedFx at their scheduled play time."""
         while self._active:
@@ -476,6 +538,9 @@ class SendspinAudioStream:
 
             if chunk is not None:
                 try:
+                    if self._effective_silenced:
+                        # Feed silence so effects decay naturally
+                        chunk = np.zeros_like(chunk)
                     self.callback(chunk, len(chunk), None, None)
                 except Exception as e:
                     _LOGGER.error(
@@ -621,7 +686,10 @@ class SendspinAudioStream:
             player_support = ClientHelloPlayerSupport(
                 supported_formats=supported_formats,
                 buffer_capacity=buffer_capacity,
-                supported_commands=[],
+                supported_commands=[
+                    PlayerCommand.VOLUME,
+                    PlayerCommand.MUTE,
+                ],
             )
 
             # Build a collision-safe client_id using the first 8 chars of
@@ -639,11 +707,17 @@ class SendspinAudioStream:
             self._client.add_audio_chunk_listener(self._audio_chunk_handler)
             self._client.add_stream_start_listener(self._stream_start_handler)
             self._client.add_stream_clear_listener(self._stream_clear_handler)
+            self._client.add_server_command_listener(
+                self._server_command_handler
+            )
 
             # Connect to server
             await self._client.connect(server_url)
 
             _LOGGER.info("Connected to Sendspin server successfully")
+
+            # Report initial player state so MA knows our volume/mute
+            self._report_player_state()
 
             # Start the playback scheduler that drains the buffer at the
             # correct timestamps.

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -525,6 +525,13 @@ class SendspinAudioStream:
         except Exception as e:
             _LOGGER.warning("Failed to report player state: %s", e)
 
+    def _deliver_chunk(self, chunk: np.ndarray) -> None:
+        """Apply silence gate and deliver a chunk to LedFx's callback."""
+        if self._effective_silenced:
+            # Feed silence so effects decay naturally
+            chunk = np.zeros_like(chunk)
+        self.callback(chunk, len(chunk), None, None)
+
     async def _playback_scheduler(self):
         """Release buffered chunks to LedFx at their scheduled play time."""
         while self._active:
@@ -538,10 +545,7 @@ class SendspinAudioStream:
 
             if chunk is not None:
                 try:
-                    if self._effective_silenced:
-                        # Feed silence so effects decay naturally
-                        chunk = np.zeros_like(chunk)
-                    self.callback(chunk, len(chunk), None, None)
+                    self._deliver_chunk(chunk)
                 except Exception as e:
                     _LOGGER.error(
                         "Error in LedFx audio callback: %s", e, exc_info=True

--- a/tests/test_sendspin_volume_mute.py
+++ b/tests/test_sendspin_volume_mute.py
@@ -6,26 +6,17 @@ Verifies the "fake state + silence gate" model:
 - volume values 1-100 do NOT affect audio processing
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+import sys
+
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 
-
-@pytest.fixture
-def mock_aiosendspin():
-    """Patch aiosendspin imports so tests run without Python 3.12+."""
-    with patch.dict(
-        "sys.modules",
-        {
-            "aiosendspin": MagicMock(),
-            "aiosendspin.client": MagicMock(),
-            "aiosendspin.models": MagicMock(),
-            "aiosendspin.models.core": MagicMock(),
-            "aiosendspin.models.player": MagicMock(),
-        },
-    ):
-        yield
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="sendspin requires Python 3.12+",
+)
 
 
 @pytest.fixture
@@ -205,75 +196,26 @@ class TestServerCommandHandler:
 
 
 class TestSilenceGate:
-    """Test that the silence gate in _playback_scheduler feeds zeros."""
+    """Test that the silence gate in _deliver_chunk feeds zeros."""
 
-    @pytest.mark.asyncio
-    async def test_silenced_feeds_zeros(self, stream):
+    def test_silenced_feeds_zeros(self, stream):
         """When silenced, callback receives zeros instead of real audio."""
-        import asyncio
-
-        stream._active = True
-        stream._loop = asyncio.get_event_loop()
         stream._effective_silenced = True
-
-        # Pre-load buffer with real audio
         real_audio = np.ones(800, dtype=np.float32) * 0.5
-        now_us = int(stream._loop.time() * 1_000_000)
-        stream._chunk_buffer = [(now_us - 1000, 1, real_audio)]
 
-        # Run one iteration of the scheduler
-        stream._active = False  # Will exit after processing one chunk
-        # Manually execute the scheduler logic inline
-        chunk = None
-        with stream._buffer_lock:
-            if stream._chunk_buffer:
-                play_time_us = stream._chunk_buffer[0][0]
-                check_us = int(stream._loop.time() * 1_000_000)
-                if play_time_us <= check_us:
-                    import heapq
+        stream._deliver_chunk(real_audio)
 
-                    _, _, chunk = heapq.heappop(stream._chunk_buffer)
-
-        if chunk is not None:
-            if stream._effective_silenced:
-                chunk = np.zeros_like(chunk)
-            stream.callback(chunk, len(chunk), None, None)
-
-        # Verify callback received zeros
         stream.callback.assert_called_once()
         delivered = stream.callback.call_args[0][0]
         np.testing.assert_array_equal(delivered, np.zeros(800, dtype=np.float32))
 
-    @pytest.mark.asyncio
-    async def test_not_silenced_passes_audio(self, stream):
+    def test_not_silenced_passes_audio(self, stream):
         """When not silenced, callback receives the real audio."""
-        import asyncio
-
-        stream._active = True
-        stream._loop = asyncio.get_event_loop()
         stream._effective_silenced = False
-
         real_audio = np.ones(800, dtype=np.float32) * 0.5
-        now_us = int(stream._loop.time() * 1_000_000)
-        stream._chunk_buffer = [(now_us - 1000, 1, real_audio)]
 
-        # Process one chunk
-        chunk = None
-        with stream._buffer_lock:
-            if stream._chunk_buffer:
-                import heapq
+        stream._deliver_chunk(real_audio)
 
-                play_time_us = stream._chunk_buffer[0][0]
-                check_us = int(stream._loop.time() * 1_000_000)
-                if play_time_us <= check_us:
-                    _, _, chunk = heapq.heappop(stream._chunk_buffer)
-
-        if chunk is not None:
-            if stream._effective_silenced:
-                chunk = np.zeros_like(chunk)
-            stream.callback(chunk, len(chunk), None, None)
-
-        # Verify callback received the original audio
         stream.callback.assert_called_once()
         delivered = stream.callback.call_args[0][0]
         np.testing.assert_array_equal(delivered, real_audio)

--- a/tests/test_sendspin_volume_mute.py
+++ b/tests/test_sendspin_volume_mute.py
@@ -1,0 +1,279 @@
+"""Unit tests for Sendspin MA-compatible volume/mute handling.
+
+Verifies the "fake state + silence gate" model:
+- volume/mute are tracked and reported for Music Assistant compatibility
+- only mute=True or volume=0 actually silences audio (feeds zeros)
+- volume values 1-100 do NOT affect audio processing
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def mock_aiosendspin():
+    """Patch aiosendspin imports so tests run without Python 3.12+."""
+    with patch.dict(
+        "sys.modules",
+        {
+            "aiosendspin": MagicMock(),
+            "aiosendspin.client": MagicMock(),
+            "aiosendspin.models": MagicMock(),
+            "aiosendspin.models.core": MagicMock(),
+            "aiosendspin.models.player": MagicMock(),
+        },
+    ):
+        yield
+
+
+@pytest.fixture
+def stream():
+    """Create a SendspinAudioStream instance with mocked dependencies."""
+    with patch(
+        "ledfx.sendspin.stream.SendspinClient"
+    ) as mock_client_cls:
+        mock_client_cls.return_value = MagicMock()
+        from ledfx.sendspin.stream import SendspinAudioStream
+
+        callback = MagicMock()
+        s = SendspinAudioStream(
+            config={"server_url": "ws://test:8927/sendspin"},
+            callback=callback,
+            instance_id="abcdef01-2345-6789-abcd-ef0123456789",
+        )
+        yield s
+
+
+class TestInitialState:
+    """Test that initial volume/mute state is correct."""
+
+    def test_default_volume(self, stream):
+        assert stream._ma_volume == 100
+
+    def test_default_muted(self, stream):
+        assert stream._ma_muted is False
+
+    def test_default_not_silenced(self, stream):
+        assert stream._effective_silenced is False
+
+
+class TestRecomputeEffectiveSilenced:
+    """Test effective_silenced logic."""
+
+    def test_volume_100_not_muted(self, stream):
+        stream._ma_volume = 100
+        stream._ma_muted = False
+        stream._recompute_effective_silenced()
+        assert stream._effective_silenced is False
+
+    def test_volume_50_not_muted(self, stream):
+        """Volume 1-100 with no mute → not silenced."""
+        stream._ma_volume = 50
+        stream._ma_muted = False
+        stream._recompute_effective_silenced()
+        assert stream._effective_silenced is False
+
+    def test_volume_1_not_muted(self, stream):
+        """Volume 1 → not silenced (only 0 silences)."""
+        stream._ma_volume = 1
+        stream._ma_muted = False
+        stream._recompute_effective_silenced()
+        assert stream._effective_silenced is False
+
+    def test_volume_0_silences(self, stream):
+        """Volume 0 → silenced."""
+        stream._ma_volume = 0
+        stream._ma_muted = False
+        stream._recompute_effective_silenced()
+        assert stream._effective_silenced is True
+
+    def test_muted_silences(self, stream):
+        """Mute=True → silenced regardless of volume."""
+        stream._ma_volume = 100
+        stream._ma_muted = True
+        stream._recompute_effective_silenced()
+        assert stream._effective_silenced is True
+
+    def test_muted_and_volume_0(self, stream):
+        """Both muted and volume=0 → silenced."""
+        stream._ma_volume = 0
+        stream._ma_muted = True
+        stream._recompute_effective_silenced()
+        assert stream._effective_silenced is True
+
+    def test_unmute_with_volume_restores(self, stream):
+        """Unmuting with volume>0 → not silenced."""
+        stream._ma_volume = 75
+        stream._ma_muted = True
+        stream._recompute_effective_silenced()
+        assert stream._effective_silenced is True
+
+        stream._ma_muted = False
+        stream._recompute_effective_silenced()
+        assert stream._effective_silenced is False
+
+
+class TestServerCommandHandler:
+    """Test _server_command_handler processes MA commands correctly."""
+
+    def _make_volume_payload(self, volume):
+        """Create a mock ServerCommandPayload for a volume command."""
+        from ledfx.sendspin.stream import PlayerCommand
+
+        payload = MagicMock()
+        payload.player.command = PlayerCommand.VOLUME
+        payload.player.volume = volume
+        payload.player.mute = None
+        return payload
+
+    def _make_mute_payload(self, mute):
+        """Create a mock ServerCommandPayload for a mute command."""
+        from ledfx.sendspin.stream import PlayerCommand
+
+        payload = MagicMock()
+        payload.player.command = PlayerCommand.MUTE
+        payload.player.mute = mute
+        payload.player.volume = None
+        return payload
+
+    def test_volume_command_updates_state(self, stream):
+        stream._report_player_state = MagicMock()
+        payload = self._make_volume_payload(50)
+        stream._server_command_handler(payload)
+        assert stream._ma_volume == 50
+        assert stream._effective_silenced is False
+        stream._report_player_state.assert_called_once()
+
+    def test_volume_0_silences(self, stream):
+        stream._report_player_state = MagicMock()
+        payload = self._make_volume_payload(0)
+        stream._server_command_handler(payload)
+        assert stream._ma_volume == 0
+        assert stream._effective_silenced is True
+
+    def test_volume_clamped_above_100(self, stream):
+        """Volume values above 100 are clamped."""
+        stream._report_player_state = MagicMock()
+        payload = self._make_volume_payload(150)
+        stream._server_command_handler(payload)
+        assert stream._ma_volume == 100
+
+    def test_volume_clamped_below_0(self, stream):
+        """Negative volume values are clamped to 0."""
+        stream._report_player_state = MagicMock()
+        payload = self._make_volume_payload(-10)
+        stream._server_command_handler(payload)
+        assert stream._ma_volume == 0
+        assert stream._effective_silenced is True
+
+    def test_mute_command_sets_muted(self, stream):
+        stream._report_player_state = MagicMock()
+        payload = self._make_mute_payload(True)
+        stream._server_command_handler(payload)
+        assert stream._ma_muted is True
+        assert stream._effective_silenced is True
+        stream._report_player_state.assert_called_once()
+
+    def test_unmute_command(self, stream):
+        stream._report_player_state = MagicMock()
+        stream._ma_muted = True
+        stream._recompute_effective_silenced()
+
+        payload = self._make_mute_payload(False)
+        stream._server_command_handler(payload)
+        assert stream._ma_muted is False
+        assert stream._effective_silenced is False
+
+    def test_no_player_payload_ignored(self, stream):
+        """Payload with player=None is safely ignored."""
+        stream._report_player_state = MagicMock()
+        payload = MagicMock()
+        payload.player = None
+        stream._server_command_handler(payload)
+        stream._report_player_state.assert_not_called()
+
+    def test_audio_not_scaled_at_volume_50(self, stream):
+        """Volume 50 must NOT affect audio - just track state."""
+        stream._report_player_state = MagicMock()
+        payload = self._make_volume_payload(50)
+        stream._server_command_handler(payload)
+        # effective_silenced should be False - audio passes through unchanged
+        assert stream._effective_silenced is False
+        assert stream._ma_volume == 50
+
+
+class TestSilenceGate:
+    """Test that the silence gate in _playback_scheduler feeds zeros."""
+
+    @pytest.mark.asyncio
+    async def test_silenced_feeds_zeros(self, stream):
+        """When silenced, callback receives zeros instead of real audio."""
+        import asyncio
+
+        stream._active = True
+        stream._loop = asyncio.get_event_loop()
+        stream._effective_silenced = True
+
+        # Pre-load buffer with real audio
+        real_audio = np.ones(800, dtype=np.float32) * 0.5
+        now_us = int(stream._loop.time() * 1_000_000)
+        stream._chunk_buffer = [(now_us - 1000, 1, real_audio)]
+
+        # Run one iteration of the scheduler
+        stream._active = False  # Will exit after processing one chunk
+        # Manually execute the scheduler logic inline
+        chunk = None
+        with stream._buffer_lock:
+            if stream._chunk_buffer:
+                play_time_us = stream._chunk_buffer[0][0]
+                check_us = int(stream._loop.time() * 1_000_000)
+                if play_time_us <= check_us:
+                    import heapq
+
+                    _, _, chunk = heapq.heappop(stream._chunk_buffer)
+
+        if chunk is not None:
+            if stream._effective_silenced:
+                chunk = np.zeros_like(chunk)
+            stream.callback(chunk, len(chunk), None, None)
+
+        # Verify callback received zeros
+        stream.callback.assert_called_once()
+        delivered = stream.callback.call_args[0][0]
+        np.testing.assert_array_equal(delivered, np.zeros(800, dtype=np.float32))
+
+    @pytest.mark.asyncio
+    async def test_not_silenced_passes_audio(self, stream):
+        """When not silenced, callback receives the real audio."""
+        import asyncio
+
+        stream._active = True
+        stream._loop = asyncio.get_event_loop()
+        stream._effective_silenced = False
+
+        real_audio = np.ones(800, dtype=np.float32) * 0.5
+        now_us = int(stream._loop.time() * 1_000_000)
+        stream._chunk_buffer = [(now_us - 1000, 1, real_audio)]
+
+        # Process one chunk
+        chunk = None
+        with stream._buffer_lock:
+            if stream._chunk_buffer:
+                import heapq
+
+                play_time_us = stream._chunk_buffer[0][0]
+                check_us = int(stream._loop.time() * 1_000_000)
+                if play_time_us <= check_us:
+                    _, _, chunk = heapq.heappop(stream._chunk_buffer)
+
+        if chunk is not None:
+            if stream._effective_silenced:
+                chunk = np.zeros_like(chunk)
+            stream.callback(chunk, len(chunk), None, None)
+
+        # Verify callback received the original audio
+        stream.callback.assert_called_once()
+        delivered = stream.callback.call_args[0][0]
+        np.testing.assert_array_equal(delivered, real_audio)

--- a/tests/test_sendspin_volume_mute.py
+++ b/tests/test_sendspin_volume_mute.py
@@ -7,7 +7,6 @@ Verifies the "fake state + silence gate" model:
 """
 
 import sys
-
 from unittest.mock import MagicMock, patch
 
 import numpy as np

--- a/tests/test_sendspin_volume_mute.py
+++ b/tests/test_sendspin_volume_mute.py
@@ -31,9 +31,7 @@ def mock_aiosendspin():
 @pytest.fixture
 def stream():
     """Create a SendspinAudioStream instance with mocked dependencies."""
-    with patch(
-        "ledfx.sendspin.stream.SendspinClient"
-    ) as mock_client_cls:
+    with patch("ledfx.sendspin.stream.SendspinClient") as mock_client_cls:
         mock_client_cls.return_value = MagicMock()
         from ledfx.sendspin.stream import SendspinAudioStream
 
@@ -242,7 +240,9 @@ class TestSilenceGate:
         # Verify callback received zeros
         stream.callback.assert_called_once()
         delivered = stream.callback.call_args[0][0]
-        np.testing.assert_array_equal(delivered, np.zeros(800, dtype=np.float32))
+        np.testing.assert_array_equal(
+            delivered, np.zeros(800, dtype=np.float32)
+        )
 
     @pytest.mark.asyncio
     async def test_not_silenced_passes_audio(self, stream):

--- a/uv.lock
+++ b/uv.lock
@@ -1151,7 +1151,7 @@ wheels = [
 
 [[package]]
 name = "ledfx"
-version = "2.1.7"
+version = "2.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
See issue https://github.com/LedFx/LedFx/issues/1798

Reworked to track and fake report volume while observing mute

## MA-Compatible Volume/Mute for Sendspin Player

Implements a "fake state + silence gate" model so Music Assistant can control LedFx as a proper Sendspin player without interfering with LedFx's internal audio normalization.

### What this does

- **Advertises `VOLUME` and `MUTE` commands** in the ClientHello handshake
- **Tracks and reports** volume (0–100) and mute state back to the server
- **Silence gate**: only `mute=True` or `volume=0` produces actual silence (feeds zeros to the effect pipeline so effects decay naturally)
- **Volume 1–100 is never used as a gain multiplier** — LedFx auto-levels internally

### Why

Music Assistant expects any Sendspin player to support volume/mute. Without this, MA cannot properly control or display the LedFx player. However, scaling audio by volume would break LedFx's FFT/beat detection which relies on raw signal levels.

### Changes

- `ledfx/sendspin/stream.py` — Added `_ma_volume`, `_ma_muted`, `_effective_silenced` state; command handler; state reporting; silence gate in playback scheduler; advertise supported commands
- `tests/test_sendspin_volume_mute.py` — 20 unit tests covering initial state, silence logic, command handling, clamping, and gate behavior

### Testing

All 20 new tests pass. Existing sendspin API tests unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds Music Assistant-compatible volume and mute handling, treating mute or volume=0 as silenced and replacing audio with silence when active.
  * Sends player state (synchronized, volume, muted) to the server on connect and after server command updates.

* **Bug Fixes**
  * Ensures server-originated volume/mute commands update local state consistently and are reflected in playback.

* **Tests**
  * Adds tests validating volume/mute behavior, value clamping, state reporting, and the effective-silence gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->