### PR TITLE
fix: sendspin pyFlac lifecycle hardening

### DIFF
--- a/docs/developer/dev_notes/sendspin_network_resilience_test_plan.md
+++ b/docs/developer/dev_notes/sendspin_network_resilience_test_plan.md
@@ -1,0 +1,567 @@
+# Sendspin Network Resilience Test Plan
+
+## Purpose
+
+Test whether poor connectivity between the LedFx host and the Sendspin server can trigger Sendspin stream failures, reconnect storms, forced event-loop shutdowns, or `Connector is closed` errors.
+
+This plan is tailored to the current test setup:
+
+- LedFx host: Windows notebook
+- LedFx notebook IP: `192.168.1.146`
+- Sendspin server host: Ubuntu VM inside Proxmox on the NUC
+- Sendspin container: `sendspin-demo`
+- Docker network mode: `host`
+- Ubuntu VM interface toward notebook: `ens18`
+- Sendspin port: `8927`
+
+---
+
+## Known Failure Pattern to Watch For
+
+Look for these LedFx log lines during or after each test:
+
+```text
+Stopping Sendspin stream...
+Sendspin thread did not exit within 5 s; force-stopping event loop
+RuntimeError: Event loop stopped before Future completed.
+Sendspin connection attempt failed: Connector is closed.
+Audio source opened
+Audio source closed
+Starting Sendspin stream...
+```
+
+A failure is especially interesting if LedFx does not recover after the network is restored.
+
+---
+
+## Setup Variables
+
+Run these on the Ubuntu VM before testing:
+
+```bash
+IFACE=ens18
+NOTEBOOK_IP=192.168.1.146
+PORT=8927
+CONTAINER=sendspin-demo
+```
+
+---
+
+## Pre-Test Checklist
+
+### 1. Confirm route to notebook
+
+```bash
+ip route get $NOTEBOOK_IP
+```
+
+Expected:
+
+```text
+192.168.1.146 dev ens18 src 192.168.1.12
+```
+
+Checklist:
+
+- [ ] Output uses `dev ens18`
+- [ ] Source IP is the Sendspin VM IP, currently `192.168.1.12`
+
+---
+
+### 2. Confirm Sendspin container is running
+
+```bash
+docker ps | grep $CONTAINER
+```
+
+Checklist:
+
+- [ ] `sendspin-demo` is running
+- [ ] Sendspin server is reachable from LedFx before starting tests
+
+---
+
+### 3. Confirm Docker network mode
+
+```bash
+docker inspect $CONTAINER | grep -i networkmode
+```
+
+Expected:
+
+```text
+"NetworkMode": "host"
+```
+
+Checklist:
+
+- [ ] Network mode is `host`
+
+---
+
+### 4. Confirm Sendspin is listening
+
+```bash
+ss -tulpen | grep $PORT
+```
+
+Checklist:
+
+- [ ] Port `8927` is listening
+- [ ] Sendspin is currently available to the notebook
+
+---
+
+### 5. Confirm no old network impairments are active
+
+```bash
+tc qdisc show dev $IFACE
+sudo iptables -S INPUT | grep $PORT
+```
+
+Checklist:
+
+- [ ] No existing `netem` rule is active on `ens18`
+- [ ] No old `iptables` DROP or REJECT rule exists for port `8927`
+
+If needed, cleanup first:
+
+```bash
+sudo tc qdisc del dev $IFACE root 2>/dev/null || true
+sudo iptables -D INPUT -p tcp --dport $PORT -s $NOTEBOOK_IP -j DROP 2>/dev/null || true
+sudo iptables -D INPUT -p tcp --dport $PORT -s $NOTEBOOK_IP -j REJECT 2>/dev/null || true
+```
+
+---
+
+## Test 0 — Baseline Stability
+
+### Goal
+
+Confirm Sendspin is stable before introducing faults.
+
+### Steps
+
+1. Start LedFx using Sendspin.
+2. Select the Sendspin source.
+3. Use PCM first.
+4. Let playback run normally for 5–10 minutes.
+
+Checklist:
+
+- [ ] Audio data is flowing
+- [ ] No reconnects
+- [ ] No `Stopping Sendspin stream...`
+- [ ] No `Connector is closed`
+- [ ] No forced event-loop shutdown
+
+Notes:
+
+```text
+Baseline result:
+```
+
+---
+
+## Test 1 — Moderate Latency and Jitter
+
+### Goal
+
+Simulate a poor but still connected network.
+
+### Inject
+
+```bash
+sudo tc qdisc add dev $IFACE root netem delay 150ms 75ms
+```
+
+### Observe for 2–5 minutes
+
+Checklist:
+
+- [ ] Audio continues
+- [ ] LedFx does not enter restart storm
+- [ ] No forced event-loop shutdown
+- [ ] No `Connector is closed`
+
+### Cleanup
+
+```bash
+sudo tc qdisc del dev $IFACE root
+```
+
+### Verify cleanup
+
+```bash
+tc qdisc show dev $IFACE
+```
+
+Notes:
+
+```text
+Test 1 result:
+```
+
+---
+
+## Test 2 — Severe Latency and Jitter
+
+### Goal
+
+Simulate a much worse connection while keeping the socket alive.
+
+### Inject
+
+```bash
+sudo tc qdisc add dev $IFACE root netem delay 400ms 200ms
+```
+
+### Observe for 2–5 minutes
+
+Checklist:
+
+- [ ] Does audio continue with delay?
+- [ ] Does LedFx stall silently?
+- [ ] Does LedFx reconnect?
+- [ ] Any buffer-related warnings?
+- [ ] Any `Stopping Sendspin stream...` entries?
+
+### Cleanup
+
+```bash
+sudo tc qdisc del dev $IFACE root
+```
+
+Notes:
+
+```text
+Test 2 result:
+```
+
+---
+
+## Test 3 — Packet Loss
+
+### Goal
+
+Simulate lossy Wi-Fi or intermittent packet drops.
+
+### Inject 5% loss
+
+```bash
+sudo tc qdisc add dev $IFACE root netem loss 5%
+```
+
+### Observe for 2–5 minutes
+
+Checklist:
+
+- [ ] Stream survives
+- [ ] No restart storm
+- [ ] No silent stall
+- [ ] No forced event-loop shutdown
+
+### Escalate to 15% loss
+
+```bash
+sudo tc qdisc change dev $IFACE root netem loss 15%
+```
+
+### Observe for 2–5 minutes
+
+Checklist:
+
+- [ ] Stream survives or reconnects cleanly
+- [ ] No `Connector is closed` loop
+- [ ] No permanent failure after cleanup
+
+### Cleanup
+
+```bash
+sudo tc qdisc del dev $IFACE root
+```
+
+Notes:
+
+```text
+Test 3 result:
+```
+
+---
+
+## Test 4 — Combined Bad Network
+
+### Goal
+
+Simulate a very poor connection with latency, jitter, loss, and packet reordering.
+
+### Inject
+
+```bash
+sudo tc qdisc add dev $IFACE root netem delay 300ms 150ms loss 10% reorder 5%
+```
+
+### Observe for 5 minutes
+
+Checklist:
+
+- [ ] Does audio keep flowing?
+- [ ] Does LedFx detect problems?
+- [ ] Does LedFx reconnect?
+- [ ] Does LedFx stall without reconnecting?
+- [ ] Any `Stopping Sendspin stream...`?
+- [ ] Any `Connector is closed`?
+
+### Cleanup
+
+```bash
+sudo tc qdisc del dev $IFACE root
+```
+
+Notes:
+
+```text
+Test 4 result:
+```
+
+---
+
+## Test 5 — Hard Blackhole
+
+### Goal
+
+Simulate a Wi-Fi dropout or server becoming unreachable without a clean TCP close.
+
+This is the most important reproduction test.
+
+### Inject
+
+```bash
+sudo iptables -A INPUT -p tcp --dport $PORT -s $NOTEBOOK_IP -j DROP
+```
+
+### Hold the fault for 30 seconds
+
+```bash
+sleep 30
+```
+
+### Restore
+
+```bash
+sudo iptables -D INPUT -p tcp --dport $PORT -s $NOTEBOOK_IP -j DROP
+```
+
+### Observe after restore
+
+Checklist:
+
+- [ ] Does LedFx recover automatically?
+- [ ] Does audio resume?
+- [ ] Is there a reconnect attempt?
+- [ ] Is there a rapid open/close storm?
+- [ ] Do logs show `Sendspin thread did not exit within 5 s`?
+- [ ] Do logs show `Event loop stopped before Future completed`?
+- [ ] Do logs show `Connector is closed`?
+
+Notes:
+
+```text
+Test 5 result:
+```
+
+---
+
+## Test 6 — Fast Reject
+
+### Goal
+
+Simulate a hard failure where the server immediately rejects traffic instead of silently dropping it.
+
+### Inject
+
+```bash
+sudo iptables -A INPUT -p tcp --dport $PORT -s $NOTEBOOK_IP -j REJECT
+```
+
+### Hold for 10 seconds
+
+```bash
+sleep 10
+```
+
+### Restore
+
+```bash
+sudo iptables -D INPUT -p tcp --dport $PORT -s $NOTEBOOK_IP -j REJECT
+```
+
+### Observe
+
+Checklist:
+
+- [ ] Does LedFx fail quickly?
+- [ ] Does it reconnect cleanly?
+- [ ] Any restart storm?
+- [ ] Any `Connector is closed` after restore?
+
+Notes:
+
+```text
+Test 6 result:
+```
+
+---
+
+## Test 7 — Repeated Network Flap
+
+### Goal
+
+Simulate an unstable Wi-Fi path that repeatedly drops and returns.
+
+### Start flapping
+
+```bash
+while true; do
+  echo "DROP on"
+  sudo iptables -A INPUT -p tcp --dport $PORT -s $NOTEBOOK_IP -j DROP
+  sleep 10
+
+  echo "DROP off"
+  sudo iptables -D INPUT -p tcp --dport $PORT -s $NOTEBOOK_IP -j DROP
+  sleep 10
+done
+```
+
+Stop with `Ctrl+C`.
+
+### Cleanup after stopping
+
+```bash
+sudo iptables -D INPUT -p tcp --dport $PORT -s $NOTEBOOK_IP -j DROP 2>/dev/null || true
+```
+
+### Observe
+
+Checklist:
+
+- [ ] LedFx survives multiple flaps
+- [ ] No accumulation of errors
+- [ ] No permanent `Connector is closed`
+- [ ] No forced event-loop shutdown
+- [ ] No rapid audio source open/close loop
+
+Notes:
+
+```text
+Test 7 result:
+```
+
+---
+
+## Test 8 — Bandwidth-Limited Link
+
+### Goal
+
+Simulate a connection that stays alive but cannot keep up with the audio stream.
+
+### Inject
+
+```bash
+sudo tc qdisc add dev $IFACE root netem rate 256kbit
+```
+
+### Observe for 2–5 minutes
+
+Checklist:
+
+- [ ] Does audio lag?
+- [ ] Does buffering grow?
+- [ ] Does the stream recover after cleanup?
+- [ ] Any silent stall?
+
+### Cleanup
+
+```bash
+sudo tc qdisc del dev $IFACE root
+```
+
+Notes:
+
+```text
+Test 8 result:
+```
+
+---
+
+## Emergency Cleanup
+
+Run this if a test is interrupted or the network remains impaired:
+
+```bash
+sudo tc qdisc del dev $IFACE root 2>/dev/null || true
+sudo iptables -D INPUT -p tcp --dport $PORT -s $NOTEBOOK_IP -j DROP 2>/dev/null || true
+sudo iptables -D INPUT -p tcp --dport $PORT -s $NOTEBOOK_IP -j REJECT 2>/dev/null || true
+```
+
+Verify:
+
+```bash
+tc qdisc show dev $IFACE
+sudo iptables -S INPUT | grep $PORT
+```
+
+---
+
+## Interpreting Results
+
+### If only FLAC fails
+
+Likely FLAC decoder lifecycle, callback, or buffering issue.
+
+### If PCM and FLAC both fail
+
+Likely shared Sendspin lifecycle issue, such as:
+
+- stop during connect/reconnect
+- forced event-loop shutdown
+- connector/session reuse after shutdown
+- audio source open/close churn
+- always-on guard not being respected
+- stall not detected by watchdog
+
+### If blackhole causes the exact failure
+
+Strong evidence that poor connectivity triggers the Sendspin shutdown/reconnect race.
+
+### If latency/loss causes silent audio death
+
+Look for missing audio-stall detection or playback scheduler failure.
+
+---
+
+## Log Bundle to Save After Each Failure
+
+Save:
+
+- LedFx logs from 2 minutes before fault injection through 2 minutes after recovery
+- Sendspin server logs
+- Test number
+- Exact command used
+- Whether PCM or FLAC was active
+- Whether `sendspin_always_on` was enabled
+- Whether the stream recovered without manually restarting LedFx
+
+Template:
+
+```text
+Test number:
+Codec:
+Fault command:
+Fault duration:
+Recovered automatically:
+Manual restart required:
+Key LedFx log lines:
+Key Sendspin log lines:
+Notes:
+```

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -505,17 +505,28 @@ class AudioInputSource:
 
         # Determine if the audio device is actually changing.  For Sendspin
         # always-on, avoid a destructive deactivate/reactivate cycle when
-        # only non-device settings changed (e.g. sample_rate, delay_ms).
+        # only non-pipeline settings changed (e.g. min_volume).
+        has_old_config = hasattr(self, "_config")
         old_device = (
-            self._config.get("audio_device")
-            if hasattr(self, "_config")
-            else None
+            self._config.get("audio_device") if has_old_config else None
         )
         new_device = new_config.get("audio_device")
         device_changing = old_device != new_device
 
+        # Pipeline-affecting keys require rebuilding internal audio objects
+        # (delay_queue, _raw_audio_sample, _phase_vocoder, etc.) even when
+        # the audio stream should stay active.
+        _PIPELINE_KEYS = ("delay_ms", "sample_rate", "fft_size")
+        pipeline_changing = has_old_config and any(
+            self._config.get(k) != new_config.get(k) for k in _PIPELINE_KEYS
+        )
+
         if AudioInputSource._audio_stream_active:
-            if device_changing or not self._should_always_keep_active():
+            if (
+                device_changing
+                or pipeline_changing
+                or not self._should_always_keep_active()
+            ):
                 self.deactivate()
 
         self._config = new_config

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -2,7 +2,6 @@ import logging
 import queue
 import threading
 import time
-import traceback
 from collections import deque
 from functools import cached_property, lru_cache
 
@@ -874,15 +873,12 @@ class AudioInputSource:
         self.deactivate()
 
     def deactivate(self):
-        # Log every deactivation with caller context for debugging
-        caller = "".join(traceback.format_stack(limit=4)[:-1]).strip()
         _LOGGER.info(
             "deactivate() called (stream_active=%s, subscribers=%d, "
-            "always_on=%s)\n  Caller: %s",
+            "always_on=%s)",
             AudioInputSource._audio_stream_active,
             len(self._callbacks),
             self._should_always_keep_active(),
-            caller,
         )
 
         # Stop the stream outside the lock to avoid deadlock with audio callback

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -516,21 +516,7 @@ class AudioInputSource:
 
         if AudioInputSource._audio_stream_active:
             if device_changing or not self._should_always_keep_active():
-                _LOGGER.info(
-                    "update_config: deactivating (device_changing=%s, "
-                    "old=%s, new=%s, always_on=%s)",
-                    device_changing,
-                    old_device,
-                    new_device,
-                    self._should_always_keep_active(),
-                )
                 self.deactivate()
-            else:
-                _LOGGER.debug(
-                    "update_config: skipping deactivate (sendspin always-on, "
-                    "device unchanged at %s)",
-                    old_device,
-                )
 
         self._config = new_config
         # Resolve device by name if available (handles index drift across restarts)
@@ -546,10 +532,6 @@ class AudioInputSource:
         if len(self._callbacks) != 0 or should_always_on:
             if not AudioInputSource._audio_stream_active:
                 self.activate()
-            else:
-                _LOGGER.debug(
-                    "update_config: stream already active, skipping activate"
-                )
 
         # Check if device changed and fire event if needed
         with AudioInputSource._class_lock:
@@ -873,14 +855,6 @@ class AudioInputSource:
         self.deactivate()
 
     def deactivate(self):
-        _LOGGER.info(
-            "deactivate() called (stream_active=%s, subscribers=%d, "
-            "always_on=%s)",
-            AudioInputSource._audio_stream_active,
-            len(self._callbacks),
-            self._should_always_keep_active(),
-        )
-
         # Stop the stream outside the lock to avoid deadlock with audio callback
         # The audio callback thread may be waiting to complete, and if it needs
         # any locks, holding the lock while calling stop() creates a circular wait
@@ -914,26 +888,11 @@ class AudioInputSource:
             self.query_devices,
             self.query_hostapis,
         )
-        if not result:
-            _LOGGER.debug(
-                "_should_always_keep_active: False "
-                "(sendspin_always_on=%s, device_idx=%s, "
-                "is_sendspin_always_on=%s)",
-                sendspin_always_on,
-                device_idx,
-                result,
-            )
         return result
 
     def subscribe(self, callback):
         """Registers a callback with the input source"""
         self._callbacks.append(callback)
-        _LOGGER.debug(
-            "subscribe: count=%d, stream_active=%s, threshold=%d",
-            len(self._callbacks),
-            AudioInputSource._audio_stream_active,
-            self._subscriber_threshold,
-        )
         if (
             len(self._callbacks) > 0
             and not AudioInputSource._audio_stream_active
@@ -947,14 +906,6 @@ class AudioInputSource:
         """Unregisters a callback with the input source"""
         if callback in self._callbacks:
             self._callbacks.remove(callback)
-        _LOGGER.debug(
-            "unsubscribe: count=%d, stream_active=%s, threshold=%d, "
-            "always_on=%s",
-            len(self._callbacks),
-            AudioInputSource._audio_stream_active,
-            self._subscriber_threshold,
-            self._should_always_keep_active(),
-        )
         if self._should_always_keep_active():
             _LOGGER.debug(
                 "Sendspin always-on active, skipping deactivate timer"

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -2,6 +2,7 @@ import logging
 import queue
 import threading
 import time
+import traceback
 from collections import deque
 from functools import cached_property, lru_cache
 
@@ -9,7 +10,6 @@ import aubio
 import numpy as np
 import samplerate
 import sounddevice as sd
-import traceback
 import voluptuous as vol
 
 import ledfx.api.websocket

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -506,7 +506,11 @@ class AudioInputSource:
         # Determine if the audio device is actually changing.  For Sendspin
         # always-on, avoid a destructive deactivate/reactivate cycle when
         # only non-device settings changed (e.g. sample_rate, delay_ms).
-        old_device = self._config.get("audio_device") if hasattr(self, "_config") else None
+        old_device = (
+            self._config.get("audio_device")
+            if hasattr(self, "_config")
+            else None
+        )
         new_device = new_config.get("audio_device")
         device_changing = old_device != new_device
 
@@ -900,10 +904,16 @@ class AudioInputSource:
 
     def _should_always_keep_active(self):
         """Check if the current audio source should stay active regardless of subscribers."""
-        sendspin_always_on = self._ledfx.config.get("sendspin_always_on", False)
+        sendspin_always_on = self._ledfx.config.get(
+            "sendspin_always_on", False
+        )
         if not sendspin_always_on:
             return False
-        device_idx = self._config.get("audio_device") if hasattr(self, "_config") else None
+        device_idx = (
+            self._config.get("audio_device")
+            if hasattr(self, "_config")
+            else None
+        )
         result = is_sendspin_always_on(
             device_idx,
             self.query_devices,

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -9,6 +9,7 @@ import aubio
 import numpy as np
 import samplerate
 import sounddevice as sd
+import traceback
 import voluptuous as vol
 
 import ledfx.api.websocket
@@ -873,8 +874,6 @@ class AudioInputSource:
         self.deactivate()
 
     def deactivate(self):
-        import traceback
-
         # Log every deactivation with caller context for debugging
         caller = "".join(traceback.format_stack(limit=4)[:-1]).strip()
         _LOGGER.info(

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -501,9 +501,34 @@ class AudioInputSource:
 
     def update_config(self, config):
         """Deactivate the audio, update the config, the reactivate"""
+        new_config = self.AUDIO_CONFIG_SCHEMA.fget()(config)
+
+        # Determine if the audio device is actually changing.  For Sendspin
+        # always-on, avoid a destructive deactivate/reactivate cycle when
+        # only non-device settings changed (e.g. sample_rate, delay_ms).
+        old_device = self._config.get("audio_device") if hasattr(self, "_config") else None
+        new_device = new_config.get("audio_device")
+        device_changing = old_device != new_device
+
         if AudioInputSource._audio_stream_active:
-            self.deactivate()
-        self._config = self.AUDIO_CONFIG_SCHEMA.fget()(config)
+            if device_changing or not self._should_always_keep_active():
+                _LOGGER.info(
+                    "update_config: deactivating (device_changing=%s, "
+                    "old=%s, new=%s, always_on=%s)",
+                    device_changing,
+                    old_device,
+                    new_device,
+                    self._should_always_keep_active(),
+                )
+                self.deactivate()
+            else:
+                _LOGGER.debug(
+                    "update_config: skipping deactivate (sendspin always-on, "
+                    "device unchanged at %s)",
+                    old_device,
+                )
+
+        self._config = new_config
         # Resolve device by name if available (handles index drift across restarts)
         self._resolve_device_from_name()
 
@@ -515,7 +540,12 @@ class AudioInputSource:
         # Activate outside the lock to avoid deadlock
         should_always_on = self._should_always_keep_active()
         if len(self._callbacks) != 0 or should_always_on:
-            self.activate()
+            if not AudioInputSource._audio_stream_active:
+                self.activate()
+            else:
+                _LOGGER.debug(
+                    "update_config: stream already active, skipping activate"
+                )
 
         # Check if device changed and fire event if needed
         with AudioInputSource._class_lock:
@@ -839,6 +869,19 @@ class AudioInputSource:
         self.deactivate()
 
     def deactivate(self):
+        import traceback
+
+        # Log every deactivation with caller context for debugging
+        caller = "".join(traceback.format_stack(limit=4)[:-1]).strip()
+        _LOGGER.info(
+            "deactivate() called (stream_active=%s, subscribers=%d, "
+            "always_on=%s)\n  Caller: %s",
+            AudioInputSource._audio_stream_active,
+            len(self._callbacks),
+            self._should_always_keep_active(),
+            caller,
+        )
+
         # Stop the stream outside the lock to avoid deadlock with audio callback
         # The audio callback thread may be waiting to complete, and if it needs
         # any locks, holding the lock while calling stop() creates a circular wait
@@ -857,18 +900,35 @@ class AudioInputSource:
 
     def _should_always_keep_active(self):
         """Check if the current audio source should stay active regardless of subscribers."""
-        if not self._ledfx.config.get("sendspin_always_on", False):
+        sendspin_always_on = self._ledfx.config.get("sendspin_always_on", False)
+        if not sendspin_always_on:
             return False
-        device_idx = self._config.get("audio_device")
-        return is_sendspin_always_on(
+        device_idx = self._config.get("audio_device") if hasattr(self, "_config") else None
+        result = is_sendspin_always_on(
             device_idx,
             self.query_devices,
             self.query_hostapis,
         )
+        if not result:
+            _LOGGER.debug(
+                "_should_always_keep_active: False "
+                "(sendspin_always_on=%s, device_idx=%s, "
+                "is_sendspin_always_on=%s)",
+                sendspin_always_on,
+                device_idx,
+                result,
+            )
+        return result
 
     def subscribe(self, callback):
         """Registers a callback with the input source"""
         self._callbacks.append(callback)
+        _LOGGER.debug(
+            "subscribe: count=%d, stream_active=%s, threshold=%d",
+            len(self._callbacks),
+            AudioInputSource._audio_stream_active,
+            self._subscriber_threshold,
+        )
         if (
             len(self._callbacks) > 0
             and not AudioInputSource._audio_stream_active
@@ -882,6 +942,14 @@ class AudioInputSource:
         """Unregisters a callback with the input source"""
         if callback in self._callbacks:
             self._callbacks.remove(callback)
+        _LOGGER.debug(
+            "unsubscribe: count=%d, stream_active=%s, threshold=%d, "
+            "always_on=%s",
+            len(self._callbacks),
+            AudioInputSource._audio_stream_active,
+            self._subscriber_threshold,
+            self._should_always_keep_active(),
+        )
         if self._should_always_keep_active():
             _LOGGER.debug(
                 "Sendspin always-on active, skipping deactivate timer"

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -14,7 +14,6 @@ from typing import Callable, Optional
 import numpy as np
 
 from ledfx.sendspin.config import BUFFER_CAPACITY
-from ledfx.utils import Teleplot
 
 try:
     import pyflac
@@ -111,14 +110,6 @@ class SendspinAudioStream:
         self._leftover = np.array([], dtype=np.float32)
         self._leftover_ts = 0  # play-time (us) of leftover samples
 
-        # --- FLAC investigation: packets-per-second teleplot counter ---
-        self._pps_count = 0  # type: int
-        self._pps_last_report = time.monotonic()  # type: float
-        # Total FLAC chunks decoded since last lifecycle reset.
-        self._flac_chunks_decoded = 0  # type: int
-        # Total FLAC decode errors since last lifecycle reset.
-        self._flac_decode_errors = 0  # type: int
-
         # Heartbeat/watchdog state
         self._last_audio_chunk_time = time.monotonic()  # type: float
         self._heartbeat_task = None  # type: Optional[asyncio.Task]
@@ -146,17 +137,8 @@ class SendspinAudioStream:
         if not self._active or self._client is None:
             return
 
-        # --- FLAC investigation: packets-per-second teleplot ---
-        self._pps_count += 1
-        now_mono = time.monotonic()
-        elapsed = now_mono - self._pps_last_report
-        if elapsed >= 1.0:
-            pps = self._pps_count / elapsed
-            Teleplot.send(f"sendspin_pps:{pps:.1f}")
-            self._pps_count = 0
-            self._pps_last_report = now_mono
-
         # Heartbeat/watchdog: update last audio chunk time
+        now_mono = time.monotonic()
         self._last_audio_chunk_time = now_mono
 
         try:
@@ -184,15 +166,9 @@ class SendspinAudioStream:
                 self._flac_pending_samples_emitted = 0
                 try:
                     self._flac_decoder.process(chunk_data)
-                    self._flac_chunks_decoded += 1
                 except Exception as e:
-                    self._flac_decode_errors += 1
                     _LOGGER.warning(
-                        "Error processing FLAC audio chunk (#%d errs, "
-                        "#%d decoded so far, decoder=%s): %s",
-                        self._flac_decode_errors,
-                        self._flac_chunks_decoded,
-                        "alive" if self._flac_decoder is not None else "None",
+                        "Error processing FLAC audio chunk: %s",
                         e,
                         exc_info=True,
                     )
@@ -206,11 +182,8 @@ class SendspinAudioStream:
                 )
         except Exception as e:
             _LOGGER.warning(
-                "Error processing audio chunk (codec=%s, flac_decoded=%d, flac_errors=%d, decoder=%s): %s",
+                "Error processing audio chunk (codec=%s): %s",
                 getattr(audio_format, "codec", "unknown"),
-                self._flac_chunks_decoded,
-                self._flac_decode_errors,
-                "alive" if self._flac_decoder is not None else "None",
                 e,
                 exc_info=True,
             )
@@ -354,8 +327,6 @@ class SendspinAudioStream:
             write_callback=self._flac_write_callback,
         )
         self._flac_decoder = decoder
-        self._flac_chunks_decoded = 0
-        self._flac_decode_errors = 0
 
         # Prime the decoder with the FLAC stream header (fLaC marker +
         # STREAMINFO block) that Sendspin sends ahead of audio frames.
@@ -478,11 +449,8 @@ class SendspinAudioStream:
         if self._flac_decoder is None:
             return
         _LOGGER.info(
-            "Finishing FLAC decoder (reason=%s, "
-            "chunks_decoded=%d, decode_errors=%d)",
+            "Finishing FLAC decoder (reason=%s)",
             reason,
-            self._flac_chunks_decoded,
-            self._flac_decode_errors,
         )
         try:
             self._flac_decoder.finish()
@@ -626,11 +594,8 @@ class SendspinAudioStream:
 
         _LOGGER.info(
             "Stopping Sendspin stream "
-            "(id=%s, chunks_decoded=%d, decode_errors=%d, decoder=%s, "
-            "thread=%s, loop_running=%s)",
+            "(id=%s, decoder=%s, thread=%s, loop_running=%s)",
             id(self),
-            self._flac_chunks_decoded,
-            self._flac_decode_errors,
             "alive" if self._flac_decoder is not None else "None",
             threading.current_thread().name,
             self._loop.is_running() if self._loop else "no-loop",
@@ -826,11 +791,10 @@ class SendspinAudioStream:
                 _LOGGER.warning(
                     "Sendspin connection lost (attempt=%d), "
                     "retrying in %.0fs (decoder=%s, "
-                    "chunks_decoded=%d, exc_type=%s): %s",
+                    "exc_type=%s): %s",
                     attempt,
                     backoff,
                     "alive" if self._flac_decoder is not None else "None",
-                    self._flac_chunks_decoded,
                     type(e).__name__,
                     e,
                 )
@@ -950,10 +914,8 @@ class SendspinAudioStream:
         except Exception as e:
             _LOGGER.warning(
                 "Sendspin connection attempt failed "
-                "(decoder=%s, chunks_decoded=%d, id=%s, "
-                "exc_type=%s): %s",
+                "(decoder=%s, id=%s, exc_type=%s): %s",
                 "alive" if self._flac_decoder is not None else "None",
-                self._flac_chunks_decoded,
                 id(self),
                 type(e).__name__,
                 e,

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -346,8 +346,7 @@ class SendspinAudioStream:
         self._flac_bit_depth = pcm.bit_depth
 
         _LOGGER.info(
-            "Creating pyFLAC StreamDecoder "
-            "(bit_depth=%d, pyflac=%s)",
+            "Creating pyFLAC StreamDecoder " "(bit_depth=%d, pyflac=%s)",
             self._flac_bit_depth,
             getattr(pyflac, "__version__", "unknown"),
         )
@@ -489,9 +488,7 @@ class SendspinAudioStream:
             self._flac_decoder.finish()
             _LOGGER.debug("FLAC decoder finish() succeeded")
         except Exception as e:
-            _LOGGER.warning(
-                "FLAC decoder finish(%s) failed: %s", reason, e
-            )
+            _LOGGER.warning("FLAC decoder finish(%s) failed: %s", reason, e)
         self._flac_decoder = None
         self._flac_fmt_logged = False
         self._flac_pending_play_time_us = 0
@@ -925,8 +922,7 @@ class SendspinAudioStream:
             await self._client.connect(server_url)
 
             _LOGGER.info(
-                "Connected to Sendspin server "
-                "(pyflac=%s, id=%s)",
+                "Connected to Sendspin server " "(pyflac=%s, id=%s)",
                 "available" if pyflac is not None else "NOT available",
                 id(self),
             )
@@ -949,9 +945,7 @@ class SendspinAudioStream:
                     pass
 
         except asyncio.CancelledError:
-            _LOGGER.debug(
-                "_connect_and_receive cancelled (id=%s)", id(self)
-            )
+            _LOGGER.debug("_connect_and_receive cancelled (id=%s)", id(self))
             raise
         except Exception as e:
             _LOGGER.warning(

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -43,9 +43,6 @@ _LOGGER = logging.getLogger(__name__)
 _SUB_CHUNK_SAMPLES = 800  # ~16.7 ms at 48 kHz → 60 Hz update rate
 
 
-# TODO(FLAC-DBG): Downgrade all [FLAC-DBG] _LOGGER.warning calls to
-# _LOGGER.debug / _LOGGER.info before tagging a release.
-# See: https://github.com/LedFx/LedFx/pull/1801
 class SendspinAudioStream:
     """
     Audio stream that receives Sendspin audio chunks and feeds LedFx.
@@ -173,8 +170,8 @@ class SendspinAudioStream:
                 # callback can timestamp each decoded PCM block correctly,
                 # even when one compressed chunk produces multiple blocks.
                 if self._flac_decoder is None:
-                    _LOGGER.warning(
-                        "[FLAC-DBG] Lazy-initialising FLAC decoder on first chunk "
+                    _LOGGER.info(
+                        "Initialising FLAC decoder on first chunk "
                         "(codec=%s rate=%d bit_depth=%d channels=%d)",
                         audio_format.codec,
                         audio_format.pcm_format.sample_rate,
@@ -191,7 +188,7 @@ class SendspinAudioStream:
                 except Exception as e:
                     self._flac_decode_errors += 1
                     _LOGGER.warning(
-                        "[FLAC-DBG] Error processing FLAC audio chunk (#%d errs, "
+                        "Error processing FLAC audio chunk (#%d errs, "
                         "#%d decoded so far, decoder=%s): %s",
                         self._flac_decode_errors,
                         self._flac_chunks_decoded,
@@ -348,8 +345,8 @@ class SendspinAudioStream:
         pcm = audio_format.pcm_format
         self._flac_bit_depth = pcm.bit_depth
 
-        _LOGGER.warning(
-            "[FLAC-DBG] Creating new pyFLAC StreamDecoder "
+        _LOGGER.info(
+            "Creating pyFLAC StreamDecoder "
             "(bit_depth=%d, pyflac=%s)",
             self._flac_bit_depth,
             getattr(pyflac, "__version__", "unknown"),
@@ -387,21 +384,21 @@ class SendspinAudioStream:
             self._flac_pending_samples_emitted = 0
             try:
                 decoder.process(codec_header)
-                _LOGGER.warning(
-                    "[FLAC-DBG] Stream header processed OK (%d bytes)",
+                _LOGGER.debug(
+                    "FLAC stream header processed OK (%d bytes)",
                     len(codec_header),
                 )
             except Exception as e:
                 _LOGGER.warning(
-                    "[FLAC-DBG] pyFLAC: ignoring %s while processing "
+                    "pyFLAC: ignoring %s while processing "
                     "stream header (%d bytes): %s",
                     type(e).__name__,
                     len(codec_header),
                     e,
                 )
 
-        _LOGGER.warning(
-            "[FLAC-DBG] Decoder initialized: %dHz %dch %dbit " "(header=%s)",
+        _LOGGER.info(
+            "FLAC decoder initialized: %dHz %dch %dbit (header=%s)",
             pcm.sample_rate,
             pcm.channels,
             pcm.bit_depth,
@@ -481,8 +478,8 @@ class SendspinAudioStream:
         """
         if self._flac_decoder is None:
             return
-        _LOGGER.warning(
-            "[FLAC-DBG] Finishing decoder (reason=%s, "
+        _LOGGER.info(
+            "Finishing FLAC decoder (reason=%s, "
             "chunks_decoded=%d, decode_errors=%d)",
             reason,
             self._flac_chunks_decoded,
@@ -490,10 +487,10 @@ class SendspinAudioStream:
         )
         try:
             self._flac_decoder.finish()
-            _LOGGER.warning("[FLAC-DBG] Decoder finish() succeeded")
+            _LOGGER.debug("FLAC decoder finish() succeeded")
         except Exception as e:
             _LOGGER.warning(
-                "[FLAC-DBG] Decoder finish(%s) failed: %s", reason, e
+                "FLAC decoder finish(%s) failed: %s", reason, e
             )
         self._flac_decoder = None
         self._flac_fmt_logged = False
@@ -534,15 +531,15 @@ class SendspinAudioStream:
         """
         player = stream_start_msg.payload.player
         if player:
-            _LOGGER.warning(
-                "[FLAC-DBG] Stream started: %s %dHz %dbit %dch",
+            _LOGGER.info(
+                "Sendspin stream started: %s %dHz %dbit %dch",
                 player.codec.value,
                 player.sample_rate,
                 player.bit_depth,
                 player.channels,
             )
         else:
-            _LOGGER.warning("[FLAC-DBG] Stream started (no player info)")
+            _LOGGER.info("Sendspin stream started (no player info)")
 
         # Reset pyFLAC decoder on new stream (format may have changed).
         self._finish_flac_decoder("stream start")
@@ -563,8 +560,8 @@ class SendspinAudioStream:
         with self._buffer_lock:
             buf_len = len(self._chunk_buffer)
             self._chunk_buffer.clear()
-        _LOGGER.warning(
-            "[FLAC-DBG] Playback buffer cleared (stream/clear, "
+        _LOGGER.info(
+            "Playback buffer cleared (stream/clear, "
             "roles=%s, discarded_chunks=%d)",
             roles,
             buf_len,
@@ -602,8 +599,8 @@ class SendspinAudioStream:
             _LOGGER.warning("Sendspin stream already active")
             return
 
-        _LOGGER.warning(
-            "[FLAC-DBG] Starting Sendspin stream (id=%s, thread=%s)...",
+        _LOGGER.info(
+            "Starting Sendspin stream (id=%s, thread=%s)...",
             id(self),
             threading.current_thread().name,
         )
@@ -630,8 +627,8 @@ class SendspinAudioStream:
             )
             return
 
-        _LOGGER.warning(
-            "[FLAC-DBG] Stopping Sendspin stream "
+        _LOGGER.info(
+            "Stopping Sendspin stream "
             "(id=%s, chunks_decoded=%d, decode_errors=%d, decoder=%s, "
             "thread=%s, loop_running=%s)",
             id(self),
@@ -677,9 +674,7 @@ class SendspinAudioStream:
 
         if not self._thread or not self._thread.is_alive():
             self._finish_flac_decoder("close")
-            _LOGGER.warning(
-                "[FLAC-DBG] Sendspin stream closed (thread already gone)"
-            )
+            _LOGGER.info("Sendspin stream closed (thread already gone)")
             return
 
         # Wait for the thread to exit.  The reconnect_task cancellation
@@ -712,7 +707,7 @@ class SendspinAudioStream:
         self._loop = None
         self._heartbeat_task = None
 
-        _LOGGER.warning("[FLAC-DBG] Sendspin stream closed (id=%s)", id(self))
+        _LOGGER.info("Sendspin stream closed (id=%s)", id(self))
 
     def _run_client(self):
         """Background thread running asyncio event loop with reconnect.
@@ -776,8 +771,8 @@ class SendspinAudioStream:
             now = time.monotonic()
             since_last = now - self._last_audio_chunk_time
             if since_last > self._WATCHDOG_TIMEOUT:
-                _LOGGER.error(
-                    "[FLAC-DBG] Sendspin watchdog: No audio received for %.1fs (id=%s). Triggering reconnect.",
+                _LOGGER.warning(
+                    "Sendspin watchdog: No audio received for %.1fs (id=%s). Triggering reconnect.",
                     since_last,
                     id(self),
                 )
@@ -788,8 +783,8 @@ class SendspinAudioStream:
                 # Reset timer so we don't spam
                 self._last_audio_chunk_time = now
             else:
-                _LOGGER.info(
-                    "[FLAC-DBG] Sendspin heartbeat: last audio %.1fs ago (id=%s)",
+                _LOGGER.debug(
+                    "Sendspin heartbeat: last audio %.1fs ago (id=%s)",
                     since_last,
                     id(self),
                 )
@@ -814,15 +809,15 @@ class SendspinAudioStream:
                 # Only exit if self._active is False (i.e., explicit stop/close)
                 if not self._active:
                     _LOGGER.info(
-                        "[FLAC-DBG] Reconnect loop cancelled (attempt=%d, active=%s)",
+                        "Reconnect loop cancelled (attempt=%d, active=%s)",
                         attempt,
                         self._active,
                     )
                     raise  # Propagate so _run_client sees CancelledError
                 else:
                     # Watchdog or internal reconnect: just continue loop
-                    _LOGGER.warning(
-                        "[FLAC-DBG] Reconnect task cancelled by watchdog or reconnect (attempt=%d, id=%s), restarting connect.",
+                    _LOGGER.info(
+                        "Reconnect task cancelled by watchdog (attempt=%d, id=%s), restarting connect.",
                         attempt,
                         id(self),
                     )
@@ -832,7 +827,7 @@ class SendspinAudioStream:
                 if not self._active:
                     break
                 _LOGGER.warning(
-                    "[FLAC-DBG] Connection lost (attempt=%d), "
+                    "Sendspin connection lost (attempt=%d), "
                     "retrying in %.0fs (decoder=%s, "
                     "chunks_decoded=%d, exc_type=%s): %s",
                     attempt,
@@ -871,8 +866,8 @@ class SendspinAudioStream:
         if self._stop_event is None:
             self._stop_event = asyncio.Event()
 
-        _LOGGER.warning(
-            "[FLAC-DBG] Connecting to Sendspin server: %s as '%s' (id=%s)",
+        _LOGGER.info(
+            "Connecting to Sendspin server: %s as '%s' (id=%s)",
             server_url,
             client_name,
             id(self),
@@ -929,8 +924,8 @@ class SendspinAudioStream:
             # Connect to server
             await self._client.connect(server_url)
 
-            _LOGGER.warning(
-                "[FLAC-DBG] Connected to Sendspin server "
+            _LOGGER.info(
+                "Connected to Sendspin server "
                 "(pyflac=%s, id=%s)",
                 "available" if pyflac is not None else "NOT available",
                 id(self),
@@ -954,13 +949,13 @@ class SendspinAudioStream:
                     pass
 
         except asyncio.CancelledError:
-            _LOGGER.info(
-                "[FLAC-DBG] _connect_and_receive cancelled (id=%s)", id(self)
+            _LOGGER.debug(
+                "_connect_and_receive cancelled (id=%s)", id(self)
             )
             raise
         except Exception as e:
             _LOGGER.warning(
-                "[FLAC-DBG] Connection attempt failed "
+                "Sendspin connection attempt failed "
                 "(decoder=%s, chunks_decoded=%d, id=%s, "
                 "exc_type=%s): %s",
                 "alive" if self._flac_decoder is not None else "None",

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -57,8 +57,8 @@ class SendspinAudioStream:
             Sendspin server.
     """
 
-    # Heartbeat/watchdog constants
-    _HEARTBEAT_INTERVAL = 10.0  # seconds between heartbeat logs
+    # Watchdog constants
+    _HEARTBEAT_INTERVAL = 10.0  # seconds between watchdog checks
     _WATCHDOG_TIMEOUT = 15.0  # seconds without audio before auto-reconnect
     DEFAULT_SAMPLE_RATE = 48000
 
@@ -319,7 +319,7 @@ class SendspinAudioStream:
         self._flac_bit_depth = pcm.bit_depth
 
         _LOGGER.info(
-            "Creating pyFLAC StreamDecoder " "(bit_depth=%d, pyflac=%s)",
+            "Creating pyFLAC StreamDecoder (bit_depth=%d, pyflac=%s)",
             self._flac_bit_depth,
             getattr(pyflac, "__version__", "unknown"),
         )
@@ -728,7 +728,7 @@ class SendspinAudioStream:
             _LOGGER.debug("Sendspin event loop closed (id=%s)", id(self))
 
     async def _heartbeat_watchdog_loop(self):
-        """Periodically log heartbeat and check for audio chunk receipt."""
+        """Periodically check for audio chunk receipt and reconnect if stale."""
         while self._active:
             now = time.monotonic()
             since_last = now - self._last_audio_chunk_time
@@ -744,12 +744,6 @@ class SendspinAudioStream:
                     self._reconnect_task.cancel()
                 # Reset timer so we don't spam
                 self._last_audio_chunk_time = now
-            else:
-                _LOGGER.debug(
-                    "Sendspin heartbeat: last audio %.1fs ago (id=%s)",
-                    since_last,
-                    id(self),
-                )
             await asyncio.sleep(self._HEARTBEAT_INTERVAL)
 
     async def _create_stop_event(self):
@@ -886,9 +880,7 @@ class SendspinAudioStream:
             await self._client.connect(server_url)
 
             _LOGGER.info(
-                "Connected to Sendspin server " "(pyflac=%s, id=%s)",
-                "available" if pyflac is not None else "NOT available",
-                id(self),
+                "Connected to Sendspin server",
             )
 
             # Start the playback scheduler that drains the buffer at the

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -393,6 +393,29 @@ class SendspinAudioStream:
                 "Error in pyFLAC write callback: %s", e, exc_info=True
             )
 
+    def _finish_flac_decoder(self, reason: str) -> None:
+        """Finish and discard the pyFLAC decoder if one is active.
+
+        Calls ``finish()`` to release libFLAC resources, logs any error
+        without propagating, and resets all FLAC-related bookkeeping so the
+        next FLAC chunk triggers a fresh ``_init_flac_decoder()``.
+
+        Safe to call when no decoder exists (returns immediately).
+        """
+        if self._flac_decoder is None:
+            return
+        try:
+            self._flac_decoder.finish()
+        except Exception as e:
+            _LOGGER.warning(
+                "FLAC decoder finish (%s) failed: %s", reason, e
+            )
+        self._flac_decoder = None
+        self._flac_fmt_logged = False
+        self._flac_pending_play_time_us = 0
+        self._flac_pending_sample_rate = 48000
+        self._flac_pending_samples_emitted = 0
+
     @staticmethod
     def _unpack_int24(data: bytes) -> np.ndarray:
         """
@@ -437,24 +460,19 @@ class SendspinAudioStream:
             _LOGGER.info("Sendspin stream started (no player info)")
 
         # Reset pyFLAC decoder on new stream (format may have changed).
-        # Call finish() to free libFLAC resources before discarding the instance.
-        if self._flac_decoder is not None:
-            try:
-                self._flac_decoder.finish()
-            except Exception as e:
-                _LOGGER.warning(
-                    "Error finishing FLAC decoder on stream reset: %s", e
-                )
-            self._flac_decoder = None
-        self._flac_fmt_logged = False
-        self._flac_pending_play_time_us = 0
-        self._flac_pending_sample_rate = 48000
-        self._flac_pending_samples_emitted = 0
+        self._finish_flac_decoder("stream start")
         self._leftover = np.array([], dtype=np.float32)
         self._leftover_ts = 0
 
     def _stream_clear_handler(self, roles):
-        """Called on stream/clear (e.g. seek). Flush the playback buffer."""
+        """Called on stream/clear (e.g. seek). Flush the playback buffer.
+
+        Also finishes the FLAC decoder so a subsequent audio chunk triggers
+        a fresh ``_init_flac_decoder()`` with the new stream header.
+        Without this the decoder can accumulate stale internal state across
+        seeks/discontinuities, eventually causing decode failures.
+        """
+        self._finish_flac_decoder("stream clear")
         self._leftover = np.array([], dtype=np.float32)
         self._leftover_ts = 0
         with self._buffer_lock:
@@ -540,14 +558,7 @@ class SendspinAudioStream:
             self._thread.join(timeout=2.0)
 
         # Clean up pyFLAC decoder once the stream thread has fully stopped.
-        if self._flac_decoder is not None:
-            try:
-                self._flac_decoder.finish()
-            except Exception as e:
-                _LOGGER.debug(
-                    "FLAC decoder finish failed (%s): %s", type(e).__name__, e
-                )
-            self._flac_decoder = None
+        self._finish_flac_decoder("close")
 
         _LOGGER.info("Sendspin stream closed")
 

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -407,9 +407,7 @@ class SendspinAudioStream:
         try:
             self._flac_decoder.finish()
         except Exception as e:
-            _LOGGER.warning(
-                "FLAC decoder finish (%s) failed: %s", reason, e
-            )
+            _LOGGER.warning("FLAC decoder finish (%s) failed: %s", reason, e)
         self._flac_decoder = None
         self._flac_fmt_logged = False
         self._flac_pending_play_time_us = 0

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -43,7 +43,6 @@ _LOGGER = logging.getLogger(__name__)
 _SUB_CHUNK_SAMPLES = 800  # ~16.7 ms at 48 kHz → 60 Hz update rate
 
 
-
 # TODO(FLAC-DBG): Downgrade all [FLAC-DBG] _LOGGER.warning calls to
 # _LOGGER.debug / _LOGGER.info before tagging a release.
 # See: https://github.com/LedFx/LedFx/pull/1801
@@ -61,6 +60,7 @@ class SendspinAudioStream:
             Used to form a stable, collision-safe ``client_id`` sent to the
             Sendspin server.
     """
+
     # Heartbeat/watchdog constants
     _HEARTBEAT_INTERVAL = 10.0  # seconds between heartbeat logs
     _WATCHDOG_TIMEOUT = 15.0  # seconds without audio before auto-reconnect

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -78,6 +78,8 @@ class SendspinAudioStream:
         self._client: Optional[SendspinClient] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._thread: Optional[threading.Thread] = None
+        self._stop_event: Optional[asyncio.Event] = None
+        self._reconnect_task: Optional[asyncio.Task] = None
 
         # Timestamp-sorted playback buffer: heap of (play_time_us, seq, audio)
         self._chunk_buffer: list[tuple[int, int, np.ndarray]] = []
@@ -113,8 +115,9 @@ class SendspinAudioStream:
         self._flac_decode_errors: int = 0
 
         _LOGGER.info(
-            "Sendspin stream initialized for server: %s",
+            "Sendspin stream initialized for server: %s (id=%s)",
             config.get("server_url", "unknown"),
+            id(self),
         )
 
     def _audio_chunk_handler(
@@ -579,8 +582,14 @@ class SendspinAudioStream:
             _LOGGER.warning("Sendspin stream already active")
             return
 
-        _LOGGER.warning("[FLAC-DBG] Starting Sendspin stream...")
+        _LOGGER.warning(
+            "[FLAC-DBG] Starting Sendspin stream (id=%s, thread=%s)...",
+            id(self),
+            threading.current_thread().name,
+        )
         self._active = True
+        self._stop_event: Optional[asyncio.Event] = None
+        self._reconnect_task: Optional[asyncio.Task] = None
 
         # Start background thread with asyncio event loop
         self._thread = threading.Thread(
@@ -589,83 +598,194 @@ class SendspinAudioStream:
         self._thread.start()
 
     def stop(self):
-        """Stop receiving audio."""
+        """Stop receiving audio.
+
+        Idempotent — safe to call multiple times or when not active.
+        Signals the background event loop to cancel the reconnect task
+        gracefully rather than relying on force-stopping the loop.
+        """
         if not self._active:
+            _LOGGER.debug(
+                "stop() called but stream not active (id=%s)", id(self)
+            )
             return
 
         _LOGGER.warning(
             "[FLAC-DBG] Stopping Sendspin stream "
-            "(chunks_decoded=%d, decode_errors=%d, decoder=%s)",
+            "(id=%s, chunks_decoded=%d, decode_errors=%d, decoder=%s, "
+            "thread=%s, loop_running=%s)",
+            id(self),
             self._flac_chunks_decoded,
             self._flac_decode_errors,
             "alive" if self._flac_decoder is not None else "None",
+            threading.current_thread().name,
+            self._loop.is_running() if self._loop else "no-loop",
         )
         self._active = False
 
-        if self._client and self._loop:
-            # Schedule disconnect in the event loop
-            asyncio.run_coroutine_threadsafe(
-                self._client.disconnect(), self._loop
-            )
+        # Signal the stop event so sleeping coroutines wake immediately.
+        if self._stop_event and self._loop and self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._stop_event.set)
+
+        # Cancel the reconnect task so blocked connect() / sleep() are
+        # interrupted via CancelledError rather than waiting for timeout.
+        if self._reconnect_task and self._loop and self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._reconnect_task.cancel)
 
     def close(self):
-        """Clean shutdown of the stream."""
+        """Clean shutdown of the stream.
+
+        Idempotent — safe to call multiple times or after stop().
+        Waits for the background thread to exit gracefully.  Only
+        force-stops the event loop as a last resort, and never reuses
+        client/session state after a forced shutdown.
+        """
         self.stop()
 
-        # Give the thread up to 5 s to finish the scheduled disconnect cleanly
-        # before force-stopping the loop.  Calling loop.stop() immediately would
-        # abort the run_coroutine_threadsafe(disconnect()) future before it
-        # completes and produce "event loop stopped before Future completed".
-        if self._thread and self._thread.is_alive():
-            self._thread.join(timeout=5.0)
+        if not self._thread or not self._thread.is_alive():
+            self._finish_flac_decoder("close")
+            _LOGGER.warning("[FLAC-DBG] Sendspin stream closed (thread already gone)")
+            return
 
-        if self._thread and self._thread.is_alive():
-            # Thread did not finish in time; force-stop the loop so the thread
-            # can exit and then wait briefly for cleanup.
+        # Wait for the thread to exit.  The reconnect_task cancellation
+        # from stop() should cause _run_client → run_until_complete to
+        # finish promptly.
+        self._thread.join(timeout=7.0)
+
+        if self._thread.is_alive():
+            # Thread did not finish — force-stop the loop.
             _LOGGER.warning(
-                "Sendspin thread did not exit within 5 s; force-stopping event loop"
+                "Sendspin thread did not exit within 7 s; "
+                "force-stopping event loop (id=%s)",
+                id(self),
             )
             if self._loop and self._loop.is_running():
                 self._loop.call_soon_threadsafe(self._loop.stop)
-            self._thread.join(timeout=2.0)
+            self._thread.join(timeout=3.0)
+            if self._thread.is_alive():
+                _LOGGER.error(
+                    "Sendspin thread still alive after force-stop (id=%s). "
+                    "Abandoning thread.",
+                    id(self),
+                )
 
         # Clean up pyFLAC decoder once the stream thread has fully stopped.
         self._finish_flac_decoder("close")
 
-        _LOGGER.warning("[FLAC-DBG] Sendspin stream closed")
+        # Ensure no stale client/loop references survive.
+        self._client = None
+        self._loop = None
+
+        _LOGGER.warning("[FLAC-DBG] Sendspin stream closed (id=%s)", id(self))
 
     def _run_client(self):
-        """Background thread running asyncio event loop with reconnect."""
+        """Background thread running asyncio event loop with reconnect.
+
+        Creates a dedicated event loop, runs the reconnect task, and
+        ensures clean shutdown even if stop() cancels the task mid-flight.
+        """
         self._loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._loop)
 
         try:
-            self._loop.run_until_complete(self._reconnect_loop())
+            # Create a stop event that stop() can signal from another thread.
+            self._stop_event = self._loop.run_until_complete(
+                self._create_stop_event()
+            )
+            # Wrap _reconnect_loop in a task so stop() can cancel it.
+            self._reconnect_task = self._loop.create_task(
+                self._reconnect_loop()
+            )
+            self._loop.run_until_complete(self._reconnect_task)
+        except asyncio.CancelledError:
+            _LOGGER.info(
+                "Sendspin reconnect task cancelled (id=%s)", id(self)
+            )
         except Exception as e:
-            _LOGGER.error("Sendspin client error: %s", e, exc_info=True)
+            if self._active:
+                _LOGGER.error(
+                    "Sendspin client error (id=%s): %s",
+                    id(self),
+                    e,
+                    exc_info=True,
+                )
+            else:
+                _LOGGER.info(
+                    "Sendspin client exiting during shutdown (id=%s): %s",
+                    id(self),
+                    e,
+                )
         finally:
+            # Cancel any remaining tasks before closing the loop.
+            pending = asyncio.all_tasks(self._loop)
+            for task in pending:
+                task.cancel()
+            if pending:
+                try:
+                    self._loop.run_until_complete(
+                        asyncio.gather(*pending, return_exceptions=True)
+                    )
+                except Exception:
+                    pass
             self._loop.close()
+            self._reconnect_task = None
+            _LOGGER.debug(
+                "Sendspin event loop closed (id=%s)", id(self)
+            )
+
+    async def _create_stop_event(self):
+        """Create an asyncio.Event inside the event loop context."""
+        return asyncio.Event()
 
     async def _reconnect_loop(self):
-        """Reconnect to Sendspin server with exponential backoff."""
+        """Reconnect to Sendspin server with exponential backoff.
+
+        Respects cancellation from stop() — CancelledError propagates
+        cleanly without leaving stale connector/session state.
+        """
         backoff = 1.0
         max_backoff = 30.0
+        attempt = 0
         while self._active:
+            attempt += 1
             try:
                 await self._connect_and_receive()
                 backoff = 1.0  # reset on clean exit
+                attempt = 0
+            except asyncio.CancelledError:
+                _LOGGER.info(
+                    "[FLAC-DBG] Reconnect loop cancelled "
+                    "(attempt=%d, active=%s)",
+                    attempt,
+                    self._active,
+                )
+                raise  # Propagate so _run_client sees CancelledError
             except Exception as e:
                 if not self._active:
                     break
                 _LOGGER.warning(
-                    "[FLAC-DBG] Connection lost, retrying in %.0fs "
-                    "(decoder=%s, chunks_decoded=%d): %s",
+                    "[FLAC-DBG] Connection lost (attempt=%d), "
+                    "retrying in %.0fs (decoder=%s, "
+                    "chunks_decoded=%d, exc_type=%s): %s",
+                    attempt,
                     backoff,
                     "alive" if self._flac_decoder is not None else "None",
                     self._flac_chunks_decoded,
+                    type(e).__name__,
                     e,
                 )
-                await asyncio.sleep(backoff)
+                # Use stop_event.wait with timeout so stop() can wake us
+                # immediately instead of waiting the full backoff period.
+                try:
+                    await asyncio.wait_for(
+                        self._stop_event.wait(), timeout=backoff
+                    )
+                    # If we get here, stop_event was set → exit
+                    break
+                except asyncio.TimeoutError:
+                    pass  # Normal: backoff elapsed, retry
+                except asyncio.CancelledError:
+                    raise
                 backoff = min(backoff * 2, max_backoff)
 
     async def _connect_and_receive(self):
@@ -675,10 +795,16 @@ class SendspinAudioStream:
         sample_rate = self.config.get("sample_rate", 48000)
         buffer_capacity = BUFFER_CAPACITY
 
+        # Ensure stop_event exists (needed when called from _run_client
+        # but also when called directly in tests).
+        if self._stop_event is None:
+            self._stop_event = asyncio.Event()
+
         _LOGGER.warning(
-            "[FLAC-DBG] Connecting to Sendspin server: %s as '%s'",
+            "[FLAC-DBG] Connecting to Sendspin server: %s as '%s' (id=%s)",
             server_url,
             client_name,
+            id(self),
         )
 
         try:
@@ -734,8 +860,9 @@ class SendspinAudioStream:
 
             _LOGGER.warning(
                 "[FLAC-DBG] Connected to Sendspin server "
-                "(pyflac=%s)",
+                "(pyflac=%s, id=%s)",
                 "available" if pyflac is not None else "NOT available",
+                id(self),
             )
 
             # Start the playback scheduler that drains the buffer at the
@@ -744,16 +871,31 @@ class SendspinAudioStream:
                 self._playback_scheduler()
             )
 
-            # Keep connection alive
+            # Keep connection alive — use stop_event so stop() wakes us
+            # immediately instead of waiting up to 0.1s.
             while self._active:
-                await asyncio.sleep(0.1)
+                try:
+                    await asyncio.wait_for(
+                        self._stop_event.wait(), timeout=0.1
+                    )
+                    break  # stop_event set
+                except asyncio.TimeoutError:
+                    pass
 
+        except asyncio.CancelledError:
+            _LOGGER.info(
+                "[FLAC-DBG] _connect_and_receive cancelled (id=%s)", id(self)
+            )
+            raise
         except Exception as e:
             _LOGGER.warning(
                 "[FLAC-DBG] Connection attempt failed "
-                "(decoder=%s, chunks_decoded=%d): %s",
+                "(decoder=%s, chunks_decoded=%d, id=%s, "
+                "exc_type=%s): %s",
                 "alive" if self._flac_decoder is not None else "None",
                 self._flac_chunks_decoded,
+                id(self),
+                type(e).__name__,
                 e,
             )
             raise
@@ -772,6 +914,8 @@ class SendspinAudioStream:
             if self._client:
                 try:
                     await self._client.disconnect()
+                except asyncio.CancelledError:
+                    pass
                 except Exception as e:
                     _LOGGER.warning(
                         "Sendspin disconnect failed during teardown: %s",

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -43,7 +43,12 @@ _LOGGER = logging.getLogger(__name__)
 _SUB_CHUNK_SAMPLES = 800  # ~16.7 ms at 48 kHz → 60 Hz update rate
 
 
+
 class SendspinAudioStream:
+    # Heartbeat/watchdog constants
+    _HEARTBEAT_INTERVAL = 10.0  # seconds between heartbeat logs
+    _WATCHDOG_TIMEOUT = 15.0    # seconds without audio before auto-reconnect
+
     """
     Audio stream that receives Sendspin audio chunks and feeds LedFx.
 
@@ -75,31 +80,31 @@ class SendspinAudioStream:
         if not instance_id:
             raise ValueError("instance_id must be provided and non-empty")
         self._active = False
-        self._client: Optional[SendspinClient] = None
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
-        self._thread: Optional[threading.Thread] = None
-        self._stop_event: Optional[asyncio.Event] = None
-        self._reconnect_task: Optional[asyncio.Task] = None
+        self._client = None  # SendspinClient instance or None
+        self._loop = None  # asyncio event loop or None
+        self._thread = None  # background thread or None
+        self._stop_event = None  # asyncio.Event or None
+        self._reconnect_task = None  # asyncio.Task or None
 
         # Timestamp-sorted playback buffer: heap of (play_time_us, seq, audio)
-        self._chunk_buffer: list[tuple[int, int, np.ndarray]] = []
+        self._chunk_buffer = []  # list of (play_time_us, seq, audio)
         self._chunk_seq = 0
         self._buffer_lock = threading.Lock()
-        self._scheduler_task: Optional[asyncio.Task] = None
+        self._scheduler_task = None  # asyncio.Task or None
 
         # FLAC decoder (persistent across chunks within a stream).
         # Recreated on _stream_start_handler; None until first FLAC chunk.
         self._flac_decoder = None  # pyflac.StreamDecoder instance
-        self._flac_bit_depth: int = 16  # bit depth negotiated with server
-        self._flac_fmt_logged: bool = False
+        self._flac_bit_depth = 16  # bit depth negotiated with server
+        self._flac_fmt_logged = False
         # Timing context for the pyFLAC write callback.
         # These are set immediately before each decoder.process() call so
         # the callback can stamp every decoded PCM block with the correct
         # play timestamp, even when one compressed chunk yields multiple
         # callback invocations.
-        self._flac_pending_play_time_us: int = 0
-        self._flac_pending_sample_rate: int = 48000
-        self._flac_pending_samples_emitted: int = 0
+        self._flac_pending_play_time_us = 0  # type: int
+        self._flac_pending_sample_rate = 48000  # type: int
+        self._flac_pending_samples_emitted = 0  # type: int
 
         # Leftover samples from previous frame, carried over so every
         # callback receives exactly _SUB_CHUNK_SAMPLES samples.
@@ -107,12 +112,16 @@ class SendspinAudioStream:
         self._leftover_ts = 0  # play-time (us) of leftover samples
 
         # --- FLAC investigation: packets-per-second teleplot counter ---
-        self._pps_count: int = 0
-        self._pps_last_report: float = time.monotonic()
+        self._pps_count = 0  # type: int
+        self._pps_last_report = time.monotonic()  # type: float
         # Total FLAC chunks decoded since last lifecycle reset.
-        self._flac_chunks_decoded: int = 0
+        self._flac_chunks_decoded = 0  # type: int
         # Total FLAC decode errors since last lifecycle reset.
-        self._flac_decode_errors: int = 0
+        self._flac_decode_errors = 0  # type: int
+
+        # Heartbeat/watchdog state
+        self._last_audio_chunk_time = time.monotonic()  # type: float
+        self._heartbeat_task = None  # type: Optional[asyncio.Task]
 
         _LOGGER.info(
             "Sendspin stream initialized for server: %s (id=%s)",
@@ -120,9 +129,7 @@ class SendspinAudioStream:
             id(self),
         )
 
-    def _audio_chunk_handler(
-        self, timestamp: int, chunk_data: bytes, audio_format: AudioFormat
-    ):
+    def _audio_chunk_handler(self, timestamp, chunk_data, audio_format):
         """
         Called by aiosendspin when an audio chunk arrives.
 
@@ -148,6 +155,9 @@ class SendspinAudioStream:
             Teleplot.send(f"sendspin_pps:{pps:.1f}")
             self._pps_count = 0
             self._pps_last_report = now_mono
+
+        # Heartbeat/watchdog: update last audio chunk time
+        self._last_audio_chunk_time = now_mono
 
         try:
             play_time_us = self._client.compute_play_time(timestamp)
@@ -260,9 +270,7 @@ class SendspinAudioStream:
             self._leftover = samples[n_full * _SUB_CHUNK_SAMPLES :].copy()
             self._leftover_ts = base_ts + n_full * sub_duration_us
 
-    def _convert_to_float32_mono(
-        self, data: bytes, audio_format: AudioFormat
-    ) -> np.ndarray:
+    def _convert_to_float32_mono(self, data, audio_format):
         """
         Convert Sendspin PCM audio to LedFx format (float32 mono).
 
@@ -311,7 +319,7 @@ class SendspinAudioStream:
 
         return audio_float.astype(np.float32)
 
-    def _init_flac_decoder(self, audio_format: AudioFormat) -> None:
+    def _init_flac_decoder(self, audio_format):
         """
         Create a new persistent pyFLAC StreamDecoder for this stream.
 
@@ -631,6 +639,10 @@ class SendspinAudioStream:
         if self._reconnect_task and self._loop and self._loop.is_running():
             self._loop.call_soon_threadsafe(self._reconnect_task.cancel)
 
+        # Cancel heartbeat task if running
+        if self._heartbeat_task and self._loop and self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._heartbeat_task.cancel)
+
     def close(self):
         """Clean shutdown of the stream.
 
@@ -676,6 +688,7 @@ class SendspinAudioStream:
         # Ensure no stale client/loop references survive.
         self._client = None
         self._loop = None
+        self._heartbeat_task = None
 
         _LOGGER.warning("[FLAC-DBG] Sendspin stream closed (id=%s)", id(self))
 
@@ -696,6 +709,10 @@ class SendspinAudioStream:
             # Wrap _reconnect_loop in a task so stop() can cancel it.
             self._reconnect_task = self._loop.create_task(
                 self._reconnect_loop()
+            )
+            # Start heartbeat/watchdog task
+            self._heartbeat_task = self._loop.create_task(
+                self._heartbeat_watchdog_loop()
             )
             self._loop.run_until_complete(self._reconnect_task)
         except asyncio.CancelledError:
@@ -728,18 +745,40 @@ class SendspinAudioStream:
                     pass
             self._loop.close()
             self._reconnect_task = None
+            self._heartbeat_task = None
             _LOGGER.debug("Sendspin event loop closed (id=%s)", id(self))
+
+    async def _heartbeat_watchdog_loop(self):
+        """Periodically log heartbeat and check for audio chunk receipt."""
+        self._force_reconnect = False
+        while self._active:
+            now = time.monotonic()
+            since_last = now - self._last_audio_chunk_time
+            if since_last > self._WATCHDOG_TIMEOUT:
+                _LOGGER.error(
+                    "[FLAC-DBG] Sendspin watchdog: No audio received for %.1fs (id=%s). Triggering reconnect.",
+                    since_last,
+                    id(self),
+                )
+                # Instead of setting a flag, directly cancel the current connect task to force reconnect
+                if self._reconnect_task and not self._reconnect_task.done():
+                    self._loop.call_soon_threadsafe(self._reconnect_task.cancel)
+                # Reset timer so we don't spam
+                self._last_audio_chunk_time = now
+            else:
+                _LOGGER.info(
+                    "[FLAC-DBG] Sendspin heartbeat: last audio %.1fs ago (id=%s)",
+                    since_last,
+                    id(self),
+                )
+            await asyncio.sleep(self._HEARTBEAT_INTERVAL)
 
     async def _create_stop_event(self):
         """Create an asyncio.Event inside the event loop context."""
         return asyncio.Event()
 
     async def _reconnect_loop(self):
-        """Reconnect to Sendspin server with exponential backoff.
-
-        Respects cancellation from stop() — CancelledError propagates
-        cleanly without leaving stale connector/session state.
-        """
+        """Reconnect to Sendspin server with exponential backoff and watchdog support."""
         backoff = 1.0
         max_backoff = 30.0
         attempt = 0
@@ -750,13 +789,23 @@ class SendspinAudioStream:
                 backoff = 1.0  # reset on clean exit
                 attempt = 0
             except asyncio.CancelledError:
-                _LOGGER.info(
-                    "[FLAC-DBG] Reconnect loop cancelled "
-                    "(attempt=%d, active=%s)",
-                    attempt,
-                    self._active,
-                )
-                raise  # Propagate so _run_client sees CancelledError
+                # Only exit if self._active is False (i.e., explicit stop/close)
+                if not self._active:
+                    _LOGGER.info(
+                        "[FLAC-DBG] Reconnect loop cancelled (attempt=%d, active=%s)",
+                        attempt,
+                        self._active,
+                    )
+                    raise  # Propagate so _run_client sees CancelledError
+                else:
+                    # Watchdog or internal reconnect: just continue loop
+                    _LOGGER.warning(
+                        "[FLAC-DBG] Reconnect task cancelled by watchdog or reconnect (attempt=%d, id=%s), restarting connect.",
+                        attempt,
+                        id(self),
+                    )
+                    await asyncio.sleep(0.5)
+                    continue
             except Exception as e:
                 if not self._active:
                     break
@@ -782,7 +831,10 @@ class SendspinAudioStream:
                 except asyncio.TimeoutError:
                     pass  # Normal: backoff elapsed, retry
                 except asyncio.CancelledError:
-                    raise
+                    if not self._active:
+                        raise
+                    # Otherwise, treat as reconnect
+                    continue
                 backoff = min(backoff * 2, max_backoff)
 
     async def _connect_and_receive(self):

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -43,11 +43,10 @@ _LOGGER = logging.getLogger(__name__)
 _SUB_CHUNK_SAMPLES = 800  # ~16.7 ms at 48 kHz → 60 Hz update rate
 
 
-
 class SendspinAudioStream:
     # Heartbeat/watchdog constants
     _HEARTBEAT_INTERVAL = 10.0  # seconds between heartbeat logs
-    _WATCHDOG_TIMEOUT = 15.0    # seconds without audio before auto-reconnect
+    _WATCHDOG_TIMEOUT = 15.0  # seconds without audio before auto-reconnect
 
     """
     Audio stream that receives Sendspin audio chunks and feeds LedFx.
@@ -762,7 +761,9 @@ class SendspinAudioStream:
                 )
                 # Instead of setting a flag, directly cancel the current connect task to force reconnect
                 if self._reconnect_task and not self._reconnect_task.done():
-                    self._loop.call_soon_threadsafe(self._reconnect_task.cancel)
+                    self._loop.call_soon_threadsafe(
+                        self._reconnect_task.cancel
+                    )
                 # Reset timer so we don't spam
                 self._last_audio_chunk_time = now
             else:

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -643,7 +643,9 @@ class SendspinAudioStream:
 
         if not self._thread or not self._thread.is_alive():
             self._finish_flac_decoder("close")
-            _LOGGER.warning("[FLAC-DBG] Sendspin stream closed (thread already gone)")
+            _LOGGER.warning(
+                "[FLAC-DBG] Sendspin stream closed (thread already gone)"
+            )
             return
 
         # Wait for the thread to exit.  The reconnect_task cancellation
@@ -697,9 +699,7 @@ class SendspinAudioStream:
             )
             self._loop.run_until_complete(self._reconnect_task)
         except asyncio.CancelledError:
-            _LOGGER.info(
-                "Sendspin reconnect task cancelled (id=%s)", id(self)
-            )
+            _LOGGER.info("Sendspin reconnect task cancelled (id=%s)", id(self))
         except Exception as e:
             if self._active:
                 _LOGGER.error(
@@ -728,9 +728,7 @@ class SendspinAudioStream:
                     pass
             self._loop.close()
             self._reconnect_task = None
-            _LOGGER.debug(
-                "Sendspin event loop closed (id=%s)", id(self)
-            )
+            _LOGGER.debug("Sendspin event loop closed (id=%s)", id(self))
 
     async def _create_stop_event(self):
         """Create an asyncio.Event inside the event loop context."""

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -43,11 +43,11 @@ _LOGGER = logging.getLogger(__name__)
 _SUB_CHUNK_SAMPLES = 800  # ~16.7 ms at 48 kHz → 60 Hz update rate
 
 
-class SendspinAudioStream:
-    # Heartbeat/watchdog constants
-    _HEARTBEAT_INTERVAL = 10.0  # seconds between heartbeat logs
-    _WATCHDOG_TIMEOUT = 15.0  # seconds without audio before auto-reconnect
 
+# TODO(FLAC-DBG): Downgrade all [FLAC-DBG] _LOGGER.warning calls to
+# _LOGGER.debug / _LOGGER.info before tagging a release.
+# See: https://github.com/LedFx/LedFx/pull/1801
+class SendspinAudioStream:
     """
     Audio stream that receives Sendspin audio chunks and feeds LedFx.
 
@@ -61,6 +61,10 @@ class SendspinAudioStream:
             Used to form a stable, collision-safe ``client_id`` sent to the
             Sendspin server.
     """
+    # Heartbeat/watchdog constants
+    _HEARTBEAT_INTERVAL = 10.0  # seconds between heartbeat logs
+    _WATCHDOG_TIMEOUT = 15.0  # seconds without audio before auto-reconnect
+    DEFAULT_SAMPLE_RATE = 48000
 
     def __init__(
         self,
@@ -102,7 +106,7 @@ class SendspinAudioStream:
         # play timestamp, even when one compressed chunk yields multiple
         # callback invocations.
         self._flac_pending_play_time_us = 0  # type: int
-        self._flac_pending_sample_rate = 48000  # type: int
+        self._flac_pending_sample_rate = self.DEFAULT_SAMPLE_RATE  # type: int
         self._flac_pending_samples_emitted = 0  # type: int
 
         # Leftover samples from previous frame, carried over so every
@@ -181,8 +185,20 @@ class SendspinAudioStream:
                 self._flac_pending_play_time_us = play_time_us
                 self._flac_pending_sample_rate = sample_rate
                 self._flac_pending_samples_emitted = 0
-                self._flac_decoder.process(chunk_data)
-                self._flac_chunks_decoded += 1
+                try:
+                    self._flac_decoder.process(chunk_data)
+                    self._flac_chunks_decoded += 1
+                except Exception as e:
+                    self._flac_decode_errors += 1
+                    _LOGGER.warning(
+                        "[FLAC-DBG] Error processing FLAC audio chunk (#%d errs, "
+                        "#%d decoded so far, decoder=%s): %s",
+                        self._flac_decode_errors,
+                        self._flac_chunks_decoded,
+                        "alive" if self._flac_decoder is not None else "None",
+                        e,
+                        exc_info=True,
+                    )
             else:
                 # PCM path: decode synchronously then schedule.
                 audio_float32 = self._convert_to_float32_mono(
@@ -191,14 +207,12 @@ class SendspinAudioStream:
                 self._schedule_mono_samples(
                     audio_float32, play_time_us, sample_rate
                 )
-
         except Exception as e:
-            self._flac_decode_errors += 1
             _LOGGER.warning(
-                "[FLAC-DBG] Error processing audio chunk (#%d errs, "
-                "#%d decoded so far, decoder=%s): %s",
-                self._flac_decode_errors,
+                "Error processing audio chunk (codec=%s, flac_decoded=%d, flac_errors=%d, decoder=%s): %s",
+                getattr(audio_format, "codec", "unknown"),
                 self._flac_chunks_decoded,
+                self._flac_decode_errors,
                 "alive" if self._flac_decoder is not None else "None",
                 e,
                 exc_info=True,
@@ -484,7 +498,7 @@ class SendspinAudioStream:
         self._flac_decoder = None
         self._flac_fmt_logged = False
         self._flac_pending_play_time_us = 0
-        self._flac_pending_sample_rate = 48000
+        self._flac_pending_sample_rate = self.DEFAULT_SAMPLE_RATE
         self._flac_pending_samples_emitted = 0
 
     @staticmethod
@@ -631,16 +645,25 @@ class SendspinAudioStream:
 
         # Signal the stop event so sleeping coroutines wake immediately.
         if self._stop_event and self._loop and self._loop.is_running():
-            self._loop.call_soon_threadsafe(self._stop_event.set)
+            try:
+                self._loop.call_soon_threadsafe(self._stop_event.set)
+            except Exception as exc:
+                _LOGGER.debug("Exception in stop_event.set: %r", exc)
 
         # Cancel the reconnect task so blocked connect() / sleep() are
         # interrupted via CancelledError rather than waiting for timeout.
         if self._reconnect_task and self._loop and self._loop.is_running():
-            self._loop.call_soon_threadsafe(self._reconnect_task.cancel)
+            try:
+                self._loop.call_soon_threadsafe(self._reconnect_task.cancel)
+            except Exception as exc:
+                _LOGGER.debug("Exception in reconnect_task.cancel: %r", exc)
 
         # Cancel heartbeat task if running
         if self._heartbeat_task and self._loop and self._loop.is_running():
-            self._loop.call_soon_threadsafe(self._heartbeat_task.cancel)
+            try:
+                self._loop.call_soon_threadsafe(self._heartbeat_task.cancel)
+            except Exception as exc:
+                _LOGGER.debug("Exception in heartbeat_task.cancel: %r", exc)
 
     def close(self):
         """Clean shutdown of the stream.
@@ -749,7 +772,6 @@ class SendspinAudioStream:
 
     async def _heartbeat_watchdog_loop(self):
         """Periodically log heartbeat and check for audio chunk receipt."""
-        self._force_reconnect = False
         while self._active:
             now = time.monotonic()
             since_last = now - self._last_audio_chunk_time
@@ -761,9 +783,8 @@ class SendspinAudioStream:
                 )
                 # Instead of setting a flag, directly cancel the current connect task to force reconnect
                 if self._reconnect_task and not self._reconnect_task.done():
-                    self._loop.call_soon_threadsafe(
-                        self._reconnect_task.cancel
-                    )
+                    # Direct cancel (watchdog runs in event loop thread)
+                    self._reconnect_task.cancel()
                 # Reset timer so we don't spam
                 self._last_audio_chunk_time = now
             else:
@@ -842,7 +863,7 @@ class SendspinAudioStream:
         """Connect to Sendspin server and start receiving audio."""
         server_url = self.config.get("server_url")
         client_name = self.config.get("client_name", "LedFx")
-        sample_rate = self.config.get("sample_rate", 48000)
+        sample_rate = self.config.get("sample_rate", self.DEFAULT_SAMPLE_RATE)
         buffer_capacity = BUFFER_CAPACITY
 
         # Ensure stop_event exists (needed when called from _run_client

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -8,11 +8,13 @@ import asyncio
 import heapq
 import logging
 import threading
+import time
 from typing import Callable, Optional
 
 import numpy as np
 
 from ledfx.sendspin.config import BUFFER_CAPACITY
+from ledfx.utils import Teleplot
 
 try:
     import pyflac
@@ -102,6 +104,14 @@ class SendspinAudioStream:
         self._leftover = np.array([], dtype=np.float32)
         self._leftover_ts = 0  # play-time (us) of leftover samples
 
+        # --- FLAC investigation: packets-per-second teleplot counter ---
+        self._pps_count: int = 0
+        self._pps_last_report: float = time.monotonic()
+        # Total FLAC chunks decoded since last lifecycle reset.
+        self._flac_chunks_decoded: int = 0
+        # Total FLAC decode errors since last lifecycle reset.
+        self._flac_decode_errors: int = 0
+
         _LOGGER.info(
             "Sendspin stream initialized for server: %s",
             config.get("server_url", "unknown"),
@@ -126,6 +136,16 @@ class SendspinAudioStream:
         if not self._active or self._client is None:
             return
 
+        # --- FLAC investigation: packets-per-second teleplot ---
+        self._pps_count += 1
+        now_mono = time.monotonic()
+        elapsed = now_mono - self._pps_last_report
+        if elapsed >= 1.0:
+            pps = self._pps_count / elapsed
+            Teleplot.send(f"sendspin_pps:{pps:.1f}")
+            self._pps_count = 0
+            self._pps_last_report = now_mono
+
         try:
             play_time_us = self._client.compute_play_time(timestamp)
             sample_rate = audio_format.pcm_format.sample_rate
@@ -137,11 +157,20 @@ class SendspinAudioStream:
                 # callback can timestamp each decoded PCM block correctly,
                 # even when one compressed chunk produces multiple blocks.
                 if self._flac_decoder is None:
+                    _LOGGER.warning(
+                        "[FLAC-DBG] Lazy-initialising FLAC decoder on first chunk "
+                        "(codec=%s rate=%d bit_depth=%d channels=%d)",
+                        audio_format.codec,
+                        audio_format.pcm_format.sample_rate,
+                        audio_format.pcm_format.bit_depth,
+                        audio_format.pcm_format.channels,
+                    )
                     self._init_flac_decoder(audio_format)
                 self._flac_pending_play_time_us = play_time_us
                 self._flac_pending_sample_rate = sample_rate
                 self._flac_pending_samples_emitted = 0
                 self._flac_decoder.process(chunk_data)
+                self._flac_chunks_decoded += 1
             else:
                 # PCM path: decode synchronously then schedule.
                 audio_float32 = self._convert_to_float32_mono(
@@ -152,7 +181,16 @@ class SendspinAudioStream:
                 )
 
         except Exception as e:
-            _LOGGER.error("Error processing audio chunk: %s", e, exc_info=True)
+            self._flac_decode_errors += 1
+            _LOGGER.warning(
+                "[FLAC-DBG] Error processing audio chunk (#%d errs, "
+                "#%d decoded so far, decoder=%s): %s",
+                self._flac_decode_errors,
+                self._flac_chunks_decoded,
+                "alive" if self._flac_decoder is not None else "None",
+                e,
+                exc_info=True,
+            )
 
     def _schedule_mono_samples(
         self,
@@ -286,10 +324,18 @@ class SendspinAudioStream:
         pcm = audio_format.pcm_format
         self._flac_bit_depth = pcm.bit_depth
 
+        _LOGGER.warning(
+            "[FLAC-DBG] Creating new pyFLAC StreamDecoder "
+            "(bit_depth=%d, pyflac=%s)",
+            self._flac_bit_depth,
+            getattr(pyflac, "__version__", "unknown"),
+        )
         decoder = pyflac.StreamDecoder(
             write_callback=self._flac_write_callback,
         )
         self._flac_decoder = decoder
+        self._flac_chunks_decoded = 0
+        self._flac_decode_errors = 0
 
         # Prime the decoder with the FLAC stream header (fLaC marker +
         # STREAMINFO block) that Sendspin sends ahead of audio frames.
@@ -317,18 +363,26 @@ class SendspinAudioStream:
             self._flac_pending_samples_emitted = 0
             try:
                 decoder.process(codec_header)
+                _LOGGER.warning(
+                    "[FLAC-DBG] Stream header processed OK (%d bytes)",
+                    len(codec_header),
+                )
             except Exception as e:
                 _LOGGER.warning(
-                    "pyFLAC: ignoring %s while processing stream header: %s",
+                    "[FLAC-DBG] pyFLAC: ignoring %s while processing "
+                    "stream header (%d bytes): %s",
                     type(e).__name__,
+                    len(codec_header),
                     e,
                 )
 
-        _LOGGER.info(
-            "FLAC decoder (pyFLAC) initialized: %dHz %dch %dbit",
+        _LOGGER.warning(
+            "[FLAC-DBG] Decoder initialized: %dHz %dch %dbit "
+            "(header=%s)",
             pcm.sample_rate,
             pcm.channels,
             pcm.bit_depth,
+            "present" if audio_format.codec_header else "absent",
         )
 
     def _flac_write_callback(
@@ -404,11 +458,19 @@ class SendspinAudioStream:
         """
         if self._flac_decoder is None:
             return
+        _LOGGER.warning(
+            "[FLAC-DBG] Finishing decoder (reason=%s, "
+            "chunks_decoded=%d, decode_errors=%d)",
+            reason,
+            self._flac_chunks_decoded,
+            self._flac_decode_errors,
+        )
         try:
             self._flac_decoder.finish()
+            _LOGGER.warning("[FLAC-DBG] Decoder finish() succeeded")
         except Exception as e:
             _LOGGER.warning(
-                "FLAC decoder finish (%s) failed: %s", reason, e
+                "[FLAC-DBG] Decoder finish(%s) failed: %s", reason, e
             )
         self._flac_decoder = None
         self._flac_fmt_logged = False
@@ -449,15 +511,15 @@ class SendspinAudioStream:
         """
         player = stream_start_msg.payload.player
         if player:
-            _LOGGER.info(
-                "Sendspin stream started: %s %dHz %dbit %dch",
+            _LOGGER.warning(
+                "[FLAC-DBG] Stream started: %s %dHz %dbit %dch",
                 player.codec.value,
                 player.sample_rate,
                 player.bit_depth,
                 player.channels,
             )
         else:
-            _LOGGER.info("Sendspin stream started (no player info)")
+            _LOGGER.warning("[FLAC-DBG] Stream started (no player info)")
 
         # Reset pyFLAC decoder on new stream (format may have changed).
         self._finish_flac_decoder("stream start")
@@ -476,9 +538,13 @@ class SendspinAudioStream:
         self._leftover = np.array([], dtype=np.float32)
         self._leftover_ts = 0
         with self._buffer_lock:
+            buf_len = len(self._chunk_buffer)
             self._chunk_buffer.clear()
-        _LOGGER.debug(
-            "Playback buffer cleared (stream/clear, roles=%s)", roles
+        _LOGGER.warning(
+            "[FLAC-DBG] Playback buffer cleared (stream/clear, "
+            "roles=%s, discarded_chunks=%d)",
+            roles,
+            buf_len,
         )
 
     async def _playback_scheduler(self):
@@ -513,7 +579,7 @@ class SendspinAudioStream:
             _LOGGER.warning("Sendspin stream already active")
             return
 
-        _LOGGER.info("Starting Sendspin stream...")
+        _LOGGER.warning("[FLAC-DBG] Starting Sendspin stream...")
         self._active = True
 
         # Start background thread with asyncio event loop
@@ -527,7 +593,13 @@ class SendspinAudioStream:
         if not self._active:
             return
 
-        _LOGGER.info("Stopping Sendspin stream...")
+        _LOGGER.warning(
+            "[FLAC-DBG] Stopping Sendspin stream "
+            "(chunks_decoded=%d, decode_errors=%d, decoder=%s)",
+            self._flac_chunks_decoded,
+            self._flac_decode_errors,
+            "alive" if self._flac_decoder is not None else "None",
+        )
         self._active = False
 
         if self._client and self._loop:
@@ -560,7 +632,7 @@ class SendspinAudioStream:
         # Clean up pyFLAC decoder once the stream thread has fully stopped.
         self._finish_flac_decoder("close")
 
-        _LOGGER.info("Sendspin stream closed")
+        _LOGGER.warning("[FLAC-DBG] Sendspin stream closed")
 
     def _run_client(self):
         """Background thread running asyncio event loop with reconnect."""
@@ -586,8 +658,11 @@ class SendspinAudioStream:
                 if not self._active:
                     break
                 _LOGGER.warning(
-                    "Sendspin connection lost, retrying in %.0fs: %s",
+                    "[FLAC-DBG] Connection lost, retrying in %.0fs "
+                    "(decoder=%s, chunks_decoded=%d): %s",
                     backoff,
+                    "alive" if self._flac_decoder is not None else "None",
+                    self._flac_chunks_decoded,
                     e,
                 )
                 await asyncio.sleep(backoff)
@@ -600,8 +675,8 @@ class SendspinAudioStream:
         sample_rate = self.config.get("sample_rate", 48000)
         buffer_capacity = BUFFER_CAPACITY
 
-        _LOGGER.info(
-            "Connecting to Sendspin server: %s as '%s'",
+        _LOGGER.warning(
+            "[FLAC-DBG] Connecting to Sendspin server: %s as '%s'",
             server_url,
             client_name,
         )
@@ -657,7 +732,11 @@ class SendspinAudioStream:
             # Connect to server
             await self._client.connect(server_url)
 
-            _LOGGER.info("Connected to Sendspin server successfully")
+            _LOGGER.warning(
+                "[FLAC-DBG] Connected to Sendspin server "
+                "(pyflac=%s)",
+                "available" if pyflac is not None else "NOT available",
+            )
 
             # Start the playback scheduler that drains the buffer at the
             # correct timestamps.
@@ -670,7 +749,13 @@ class SendspinAudioStream:
                 await asyncio.sleep(0.1)
 
         except Exception as e:
-            _LOGGER.warning("Sendspin connection attempt failed: %s", e)
+            _LOGGER.warning(
+                "[FLAC-DBG] Connection attempt failed "
+                "(decoder=%s, chunks_decoded=%d): %s",
+                "alive" if self._flac_decoder is not None else "None",
+                self._flac_chunks_decoded,
+                e,
+            )
             raise
         finally:
             if self._scheduler_task and not self._scheduler_task.done():

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -377,8 +377,7 @@ class SendspinAudioStream:
                 )
 
         _LOGGER.warning(
-            "[FLAC-DBG] Decoder initialized: %dHz %dch %dbit "
-            "(header=%s)",
+            "[FLAC-DBG] Decoder initialized: %dHz %dch %dbit " "(header=%s)",
             pcm.sample_rate,
             pcm.channels,
             pcm.bit_depth,
@@ -733,8 +732,7 @@ class SendspinAudioStream:
             await self._client.connect(server_url)
 
             _LOGGER.warning(
-                "[FLAC-DBG] Connected to Sendspin server "
-                "(pyflac=%s)",
+                "[FLAC-DBG] Connected to Sendspin server " "(pyflac=%s)",
                 "available" if pyflac is not None else "NOT available",
             )
 

--- a/tests/test_sendspin_stream_flac_lifecycle.py
+++ b/tests/test_sendspin_stream_flac_lifecycle.py
@@ -1,0 +1,154 @@
+"""Tests for FLAC decoder lifecycle in SendspinAudioStream.
+
+Verifies that _finish_flac_decoder is called in all required code paths
+(stream/clear, stream/start, close) and that PCM-only sessions never
+touch the decoder.
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture()
+def _skip_if_no_aiosendspin():
+    try:
+        from aiosendspin.client import SendspinClient  # noqa: F401
+    except ImportError:
+        pytest.skip("aiosendspin not available")
+
+
+@pytest.fixture()
+def stream(_skip_if_no_aiosendspin):
+    """Create a SendspinAudioStream with mocked SendspinClient."""
+    from ledfx.sendspin.stream import SendspinAudioStream
+
+    with patch("ledfx.sendspin.stream.SendspinClient", MagicMock()):
+        s = SendspinAudioStream(
+            config={
+                "server_url": "ws://localhost:1234",
+                "client_name": "LedFx",
+            },
+            callback=lambda *a: None,
+            instance_id=str(uuid.uuid4()),
+        )
+    return s
+
+
+class TestFinishFlacDecoderHelper:
+    """Tests for _finish_flac_decoder helper method."""
+
+    def test_noop_when_no_decoder(self, stream):
+        """Calling _finish_flac_decoder with no active decoder is a no-op."""
+        assert stream._flac_decoder is None
+        stream._finish_flac_decoder("test")  # should not raise
+        assert stream._flac_decoder is None
+
+    def test_finishes_and_nulls_decoder(self, stream):
+        mock_decoder = MagicMock()
+        stream._flac_decoder = mock_decoder
+        stream._flac_fmt_logged = True
+        stream._flac_pending_play_time_us = 99999
+        stream._flac_pending_sample_rate = 44100
+        stream._flac_pending_samples_emitted = 500
+
+        stream._finish_flac_decoder("test reason")
+
+        mock_decoder.finish.assert_called_once()
+        assert stream._flac_decoder is None
+        assert stream._flac_fmt_logged is False
+        assert stream._flac_pending_play_time_us == 0
+        assert stream._flac_pending_sample_rate == 48000
+        assert stream._flac_pending_samples_emitted == 0
+
+    def test_exception_in_finish_is_swallowed(self, stream):
+        mock_decoder = MagicMock()
+        mock_decoder.finish.side_effect = RuntimeError("libFLAC error")
+        stream._flac_decoder = mock_decoder
+
+        stream._finish_flac_decoder("error test")  # should not raise
+
+        assert stream._flac_decoder is None
+        mock_decoder.finish.assert_called_once()
+
+
+class TestStreamClearFinishesDecoder:
+    """_stream_clear_handler must finish the FLAC decoder."""
+
+    def test_flac_decoder_finished_on_stream_clear(self, stream):
+        mock_decoder = MagicMock()
+        stream._flac_decoder = mock_decoder
+
+        stream._stream_clear_handler(roles="player")
+
+        mock_decoder.finish.assert_called_once()
+        assert stream._flac_decoder is None
+
+    def test_buffers_cleared_on_stream_clear(self, stream):
+        stream._leftover = np.ones(100, dtype=np.float32)
+        stream._leftover_ts = 12345
+        with stream._buffer_lock:
+            stream._chunk_buffer.append((0, 0, np.zeros(10)))
+
+        stream._stream_clear_handler(roles="player")
+
+        assert len(stream._leftover) == 0
+        assert stream._leftover_ts == 0
+        assert len(stream._chunk_buffer) == 0
+
+
+class TestStreamStartFinishesDecoder:
+    """_stream_start_handler must finish the FLAC decoder."""
+
+    def test_flac_decoder_finished_on_stream_start(self, stream):
+        mock_decoder = MagicMock()
+        stream._flac_decoder = mock_decoder
+
+        msg = MagicMock()
+        msg.payload.player = None
+        stream._stream_start_handler(msg)
+
+        mock_decoder.finish.assert_called_once()
+        assert stream._flac_decoder is None
+
+
+class TestCloseFinishesDecoder:
+    """close() must finish the FLAC decoder."""
+
+    def test_flac_decoder_finished_on_close(self, stream):
+        mock_decoder = MagicMock()
+        stream._flac_decoder = mock_decoder
+
+        stream.close()
+
+        mock_decoder.finish.assert_called_once()
+        assert stream._flac_decoder is None
+
+
+class TestPcmPathNoDecoderCleanup:
+    """PCM path should only clear buffers, never touch FLAC decoder."""
+
+    def test_stream_clear_pcm_only(self, stream):
+        """When no decoder exists, stream/clear just clears buffers."""
+        assert stream._flac_decoder is None
+        stream._leftover = np.ones(50, dtype=np.float32)
+        with stream._buffer_lock:
+            stream._chunk_buffer.append((0, 0, np.zeros(10)))
+
+        stream._stream_clear_handler(roles="player")
+
+        assert stream._flac_decoder is None
+        assert len(stream._leftover) == 0
+        assert len(stream._chunk_buffer) == 0
+
+    def test_stream_start_pcm_only(self, stream):
+        """When no decoder exists, stream/start just resets leftover state."""
+        assert stream._flac_decoder is None
+
+        msg = MagicMock()
+        msg.payload.player = None
+        stream._stream_start_handler(msg)
+
+        assert stream._flac_decoder is None

--- a/tests/test_sendspin_stream_flac_lifecycle.py
+++ b/tests/test_sendspin_stream_flac_lifecycle.py
@@ -147,8 +147,14 @@ class TestPcmPathNoDecoderCleanup:
         """When no decoder exists, stream/start just resets leftover state."""
         assert stream._flac_decoder is None
 
+        # Set up leftover state to verify it is cleared
+        stream._leftover = np.ones(25, dtype=np.float32)
+        stream._leftover_ts = 12345
+
         msg = MagicMock()
         msg.payload.player = None
         stream._stream_start_handler(msg)
 
         assert stream._flac_decoder is None
+        assert len(stream._leftover) == 0
+        assert stream._leftover_ts == 0


### PR DESCRIPTION
## Fix FLAC decoder lifecycle leak on stream/clear

### Problem
Long-running Sendspin sessions using FLAC eventually die while PCM sessions remain stable. `_stream_clear_handler()` (triggered by seeks, track changes, discontinuities) clears playback buffers and leftover samples but does **not** finish/reset the `pyflac.StreamDecoder`. Unlike stateless PCM decoding, the FLAC decoder accumulates internal state — leaving it alive across stream discontinuities causes stale state buildup, eventual decode failures, and session death.

### Fix
- Extract `_finish_flac_decoder(reason)` helper that safely calls `finish()`, catches/logs exceptions, nulls the decoder, and resets all FLAC bookkeeping fields.
- Call this helper from `_stream_clear_handler()` so seeks and discontinuities get a fresh decoder on the next FLAC chunk.
- Replace duplicated inline cleanup in `_stream_start_handler()` and `close()` with the same helper.
- No changes to PCM path, buffer scheduling, or stream architecture.

### Testing
New `tests/test_sendspin_stream_flac_lifecycle.py` with 9 tests covering:
- Helper no-ops when no decoder exists
- Helper finishes, nulls, and resets all state
- Helper swallows `finish()` exceptions
- `_stream_clear_handler` finishes decoder + clears buffers
- `_stream_start_handler` finishes decoder
- `close()` finishes decoder
- PCM-only sessions (no decoder) unaffected by clear/start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for audio decoder lifecycle, start/clear/close behavior, error handling, and PCM-only sessions.

* **Refactor**
  * Centralized audio-decoder teardown and unified reset paths to reduce duplication and improve reliability.

* **Bug Fixes / Diagnostics**
  * Make stop/close idempotent, add watchdog/interruptible reconnects, and improve stream/codec logging for clearer diagnostics.

* **Behavior**
  * Avoid unnecessary audio reactivation when config changes don’t affect device or pipeline.

* **Documentation**
  * New developer test plan for Sendspin network resilience and fault injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->