### PR TITLE
Fix: Sendspin always on, force default for melbanks

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -644,7 +644,9 @@ class AudioInputSource:
         # Setup a pre-emphasis filter to balance the input volume of lows to highs
         self.pre_emphasis = aubio.digital_filter(3)
         # depending on the coeffs type, we need to use different pre_emphasis values to make em work better. allegedly.
-        selected_coeff = self._ledfx.config["melbanks"]["coeffs_type"]
+        selected_coeff = self._ledfx.config.get("melbanks", {}).get(
+            "coeffs_type", "matt_mel"
+        )
         if selected_coeff == "matt_mel":
             _LOGGER.debug("Using matt_mel settings for pre-emphasis.")
             self.pre_emphasis.set_biquad(


### PR DESCRIPTION

### Cause

`AudioInputSource.__init__` accesses `self._ledfx.config["melbanks"]["coeffs_type"]` directly. On a fresh or minimal config, `melbanks` defaults to `{}` (set in `config.py`). The `Melbanks` class normally populates this dict via its `CONFIG_SCHEMA` validation, but during eager Sendspin startup, `AudioInputSource` is constructed *before* any `Melbanks` instance has applied schema defaults.

### Fix

Use `.get()` with the schema default value (`"matt_mel"`) instead of direct key indexing:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio input stability by implementing graceful handling for missing or incomplete configuration settings, preventing potential crashes during audio feature initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LedFx/LedFx/pull/1808?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->