### PR TITLE
Fix inactive audio device change events

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -511,7 +511,7 @@ class AudioInputSource:
             self._config.get("audio_device") if has_old_config else None
         )
         new_device = new_config.get("audio_device")
-        device_changing = old_device != new_device
+        requested_device_changing = old_device != new_device
 
         # Pipeline-affecting keys require rebuilding internal audio objects
         # (delay_queue, _raw_audio_sample, _phase_vocoder, etc.) even when
@@ -523,7 +523,7 @@ class AudioInputSource:
 
         if AudioInputSource._audio_stream_active:
             if (
-                device_changing
+                requested_device_changing
                 or pipeline_changing
                 or not self._should_always_keep_active()
             ):
@@ -532,6 +532,8 @@ class AudioInputSource:
         self._config = new_config
         # Resolve device by name if available (handles index drift across restarts)
         self._resolve_device_from_name()
+        resolved_device = self._config.get("audio_device")
+        device_changing = has_old_config and old_device != resolved_device
 
         # cache up last active and lets see if it changes
         # Read _last_active with class lock protection
@@ -546,10 +548,10 @@ class AudioInputSource:
 
         # Check if device changed and fire event if needed
         with AudioInputSource._class_lock:
-            if last_active != AudioInputSource._last_active:
+            if device_changing or last_active != AudioInputSource._last_active:
                 self._ledfx.events.fire_event(
                     AudioDeviceChangeEvent(
-                        self.input_devices()[self._config["audio_device"]]
+                        self.input_devices()[resolved_device]
                     )
                 )
 

--- a/tests/test_audio_device_persistence.py
+++ b/tests/test_audio_device_persistence.py
@@ -8,6 +8,7 @@ import logging
 from unittest.mock import MagicMock, patch
 
 from ledfx.effects.audio import AudioInputSource
+from ledfx.events import Event
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -484,6 +485,40 @@ class TestAudioDevicesApi:
 
         assert response["active_device_index"] == 17
         assert response["active_device_name"] == LOOPBACK_NAME
+
+
+# ===========================================================================
+# §7.4.5 — update_config() event emission
+# ===========================================================================
+
+
+class TestUpdateConfigEvents:
+    """Audio device change event regression tests."""
+
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
+    def test_inactive_device_change_fires_event(self, mock_devices):
+        """Changing the configured device emits an event even without subscribers."""
+        old_config = AudioInputSource.AUDIO_CONFIG_SCHEMA.fget()(
+            {"audio_device": 0, "audio_device_name": ""}
+        )
+        ledfx = make_mock_ledfx(dict(old_config))
+        ais = make_ais(config=dict(old_config), ledfx=ledfx)
+        ais._callbacks = []
+
+        AudioInputSource._audio_stream_active = False
+        AudioInputSource._last_active = None
+        try:
+            ais.update_config({"audio_device": 5, "audio_device_name": ""})
+
+            ledfx.events.fire_event.assert_called_once()
+            event = ledfx.events.fire_event.call_args.args[0]
+            assert event.event_type == Event.AUDIO_INPUT_DEVICE_CHANGED
+            assert event.audio_input_device_name == DEVICES_BEFORE[5]
+        finally:
+            AudioInputSource._audio_stream_active = False
+            AudioInputSource._last_active = None
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- Emit `AudioDeviceChangeEvent` when the configured audio input device changes, even if no audio stream is currently active.
- Keep the existing stream rebuild behavior unchanged for active audio streams.
- Add a regression test for inactive audio device changes.

Fixes #1505.

## Testing

- `git diff --check`
- `.venv\Scripts\python.exe -m py_compile ledfx\effects\audio.py tests\test_audio_device_persistence.py`
- Verified the inactive-device-change regression path with mocked `AudioInputSource` state
- Verified unrelated audio config updates do not emit the device-change event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio device change detection to properly trigger event notifications when switching audio input devices, including when the audio stream is currently inactive.

* **Tests**
  * Added regression test for audio device switching behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LedFx/LedFx/pull/1813?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->