### PR TITLE
Fix: gap- device trap corner cases

### DIFF
--- a/ledfx/nowplaying/service.py
+++ b/ledfx/nowplaying/service.py
@@ -91,7 +91,7 @@ NOW_PLAYING_CONFIG_SCHEMA = vol.Schema(
     {
         vol.Optional("gradient", default={}): vol.Schema(
             {
-                vol.Optional("enabled", default=True): bool,
+                vol.Optional("enabled", default=False): bool,
                 vol.Optional("variant", default="led_punchy"): vol.In(
                     GRADIENT_VARIANTS
                 ),

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -246,9 +246,12 @@ class Virtual:
         # Group segments by device for batch adding
         segments_by_device = {}
         for device_id, start_pixel, end_pixel, _invert in segments:
-            # Skip gap devices - they are placeholders for empty space
+            # Skip gap devices - they are configuration placeholders, never
+            # registered in the device registry (so device will be None)
+            if device_id.startswith("gap-"):
+                continue
             device = self._ledfx.devices.get(device_id)
-            if is_gap_device(device):
+            if device is None or is_gap_device(device):
                 continue
             if device_id not in segments_by_device:
                 segments_by_device[device_id] = []
@@ -277,6 +280,11 @@ class Virtual:
 
         # Get device for validation
         device = self._ledfx.devices.get(device_id)
+
+        # gap- IDs are configuration placeholders that are never registered
+        # as real devices, so skip validation entirely
+        if device_id.startswith("gap-"):
+            return segment
 
         if device is None:
             msg = f"Invalid device id: {device_id}"
@@ -1298,7 +1306,8 @@ class Virtual:
         return list(
             self._ledfx.devices.get(device_id)
             for device_id in {segment[0] for segment in self._segments}
-            if not is_gap_device(self._ledfx.devices.get(device_id))
+            if not device_id.startswith("gap-")
+            and self._ledfx.devices.get(device_id) is not None
         )
 
     @cached_property

--- a/tests/test_api_now_playing.py
+++ b/tests/test_api_now_playing.py
@@ -64,7 +64,7 @@ async def test_get_empty_state(endpoint):
     assert data["current_gradient"] is None
     # Phase 7: config section present
     assert "config" in data
-    assert data["config"]["gradient"]["enabled"] is True
+    assert data["config"]["gradient"]["enabled"] is False
     assert data["config"]["gradient"]["variant"] == "led_punchy"
 
 

--- a/tests/test_now_playing_service.py
+++ b/tests/test_now_playing_service.py
@@ -672,7 +672,7 @@ class TestGradientApplicationConfig:
     """Tests for gradient config properties."""
 
     def test_default_gradient_enabled(self, service):
-        assert service.gradient_enabled is True
+        assert service.gradient_enabled is False
 
     def test_set_gradient_enabled(self, service):
         service.gradient_enabled = False
@@ -875,6 +875,8 @@ class TestGradientAutoApplication:
         v1 = _make_mock_virtual("v1", eff)
         ledfx_with_virtuals._virtuals["v1"] = v1
 
+        service_v.gradient_enabled = True
+
         meta = TrackMetadata(source_id="sendspin", title="Song")
         service_v.set_metadata("sendspin", meta)
 
@@ -963,7 +965,7 @@ class TestNowPlayingConfigSchema:
         from ledfx.nowplaying.service import NOW_PLAYING_CONFIG_SCHEMA
 
         result = NOW_PLAYING_CONFIG_SCHEMA({})
-        assert result["gradient"]["enabled"] is True
+        assert result["gradient"]["enabled"] is False
         assert result["gradient"]["variant"] == "led_punchy"
         assert result["gradient"]["virtual_ids"] == []
         assert result["track_text"]["enabled"] is True
@@ -1019,7 +1021,7 @@ class TestServiceConfigFromInit:
 
     def test_default_config_loaded(self, service):
         cfg = service.config
-        assert cfg["gradient"]["enabled"] is True
+        assert cfg["gradient"]["enabled"] is False
         assert cfg["gradient"]["variant"] == "led_punchy"
         assert cfg["gradient"]["virtual_ids"] == []
         assert cfg["track_text"]["enabled"] is True


### PR DESCRIPTION
Leads to crashes on certain operations where code still attempted to access gap- device params when they don't exist.

Needs user testing and if successful a deeper dig.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default now-playing gradient is disabled by default.
  * Virtual device segment handling improved to consistently skip gap placeholders and absent devices.

* **Tests**
  * Unit and API tests updated to reflect the new default gradient behavior and ensure gradient application still works when explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->