### PR TITLE
Fix: moved launchpad pro mk3 before pad pro #1824

### DIFF
--- a/ledfx/devices/launchpad.py
+++ b/ledfx/devices/launchpad.py
@@ -25,16 +25,16 @@ launchpads = [
         "class": launchpad.LaunchpadMiniMk3(),
     },
     {
-        "name": "Launchpad Pro",
-        "search": "pad pro",
-        "number": 0,
-        "class": launchpad.LaunchpadPro(),
-    },
-    {
         "name": "Launchpad Pro Mk3",
         "search": "promk3",
         "number": 0,
         "class": launchpad.LaunchpadProMk3(),
+    },
+    {
+        "name": "Launchpad Pro",
+        "search": "pad pro",
+        "number": 0,
+        "class": launchpad.LaunchpadPro(),
     },
     {
         "name": "Launchpad X",
@@ -151,9 +151,7 @@ class LaunchpadDevice(MidiDevice):
                 self._online = True
                 super().activate()
             else:
-                _LOGGER.warning(
-                    "Launchpad variant not supported or not connected"
-                )
+                _LOGGER.warning("Launchpad variant not supported or not connected")
                 self.set_offline()
         else:
             self.set_offline()
@@ -194,9 +192,7 @@ class LaunchpadDevice(MidiDevice):
             if self.lp is None:
                 self.set_class()
             if len(self.lp.segments) == 0:
-                _LOGGER.warning(
-                    "No segments defined in {self.lp.__class__.__name__}"
-                )
+                _LOGGER.warning("No segments defined in {self.lp.__class__.__name__}")
             else:
                 for segment in self.lp.segments:
                     self.sub_v(segment[0], segment[1], segment[2], segment[3])

--- a/ledfx/devices/launchpad.py
+++ b/ledfx/devices/launchpad.py
@@ -151,7 +151,9 @@ class LaunchpadDevice(MidiDevice):
                 self._online = True
                 super().activate()
             else:
-                _LOGGER.warning("Launchpad variant not supported or not connected")
+                _LOGGER.warning(
+                    "Launchpad variant not supported or not connected"
+                )
                 self.set_offline()
         else:
             self.set_offline()
@@ -192,7 +194,9 @@ class LaunchpadDevice(MidiDevice):
             if self.lp is None:
                 self.set_class()
             if len(self.lp.segments) == 0:
-                _LOGGER.warning("No segments defined in {self.lp.__class__.__name__}")
+                _LOGGER.warning(
+                    "No segments defined in {self.lp.__class__.__name__}"
+                )
             else:
                 for segment in self.lp.segments:
                     self.sub_v(segment[0], segment[1], segment[2], segment[3])


### PR DESCRIPTION
Should fix #1824.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed device detection precedence for Launchpad Pro and Launchpad Pro Mk3 variants to ensure correct device identification during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->