### PR TITLE
fix(audio): preserve selected device on partial config updates

### DIFF
--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -570,6 +570,15 @@ class AudioInputSource:
 
     def update_config(self, config):
         """Deactivate the audio, update the config, then reactivate"""
+        # Merge the incoming (possibly partial) update over the existing config
+        # before validation. Without this, a partial update such as
+        # {"delay_ms": N} re-validates a bare dict and the schema injects
+        # defaults for every absent key (audio_device -> the default device,
+        # audio_device_name -> ""), silently resetting the active device. The
+        # name-based restore below cannot recover it because the name has
+        # already been cleared.
+        if hasattr(self, "_config") and isinstance(self._config, dict):
+            config = {**self._config, **config}
         new_config = self.AUDIO_CONFIG_SCHEMA.fget()(config)
 
         device_changing = False

--- a/tests/test_audio_device_persistence.py
+++ b/tests/test_audio_device_persistence.py
@@ -811,3 +811,62 @@ class TestRegressionGuards:
         assert (
             ais._config["audio_device_name"] == "SENDSPIN: my-sendspin-server"
         )
+
+
+# ===========================================================================
+# Partial-update merge — update_config() must not reset the device
+# ===========================================================================
+
+
+class TestPartialUpdatePreservesDevice:
+    """A partial audio update (e.g. delay-only) must keep the selected device.
+
+    update_config() re-validates the incoming dict through AUDIO_CONFIG_SCHEMA.
+    When the caller passes only the field they changed (the UI sends
+    ``{"delay_ms": N}``), the schema injects defaults for every absent key:
+    ``audio_device`` falls back to the default device and ``audio_device_name``
+    to ``""``. The name-based restore that runs afterwards can't recover the
+    selection because the name it relied on has already been wiped, so the
+    active device silently switches to the default input.
+
+    update_config() now merges the partial update over the existing config
+    before validation, so untouched keys keep their values.
+    """
+
+    @patch.object(AudioInputSource, "_resolve_device_from_name", autospec=True)
+    @patch.object(
+        AudioInputSource, "_should_always_keep_active", return_value=False
+    )
+    @patch.object(
+        AudioInputSource, "input_devices", return_value=DEVICES_BEFORE
+    )
+    @patch.object(
+        AudioInputSource,
+        "valid_device_indexes",
+        return_value=tuple(DEVICES_BEFORE.keys()),
+    )
+    @patch.object(AudioInputSource, "default_device_index", return_value=0)
+    def test_delay_only_update_keeps_selected_device(
+        self,
+        mock_default,
+        mock_valid,
+        mock_devices,
+        mock_keep_active,
+        mock_resolve,
+    ):
+        """A delay-only update keeps audio_device and audio_device_name."""
+        ais = make_ais(
+            config={
+                "audio_device": 17,
+                "audio_device_name": LOOPBACK_NAME,
+                "delay_ms": 0,
+            },
+            ledfx=make_mock_ledfx(),
+        )
+        ais._callbacks = []
+
+        ais.update_config({"delay_ms": 200})
+
+        assert ais._config["audio_device"] == 17
+        assert ais._config["audio_device_name"] == LOOPBACK_NAME
+        assert ais._config["delay_ms"] == 200


### PR DESCRIPTION
## Problem

Changing the audio **delay** silently switches the audio source back to the default input. If you've selected a non-default device (in my case a Sendspin network source, but the same applies to any selected loopback/USB/etc. input), adjusting the delay in **Settings → Audio** resets it to the default device and the lights go dead until you re-pick the source.

## Root cause

`AudioInputSource.update_config()` re-validates the incoming dict through `AUDIO_CONFIG_SCHEMA` without first merging it over the existing config:

```python
def update_config(self, config):
    new_config = self.AUDIO_CONFIG_SCHEMA.fget()(config)
    ...
```

The frontend sends **only the field that changed** when you move the delay slider — `{"delay_ms": N}` — not the whole audio config. The schema then fills in defaults for every absent key, so `audio_device` falls back to the default device and `audio_device_name` to `""`. The name-based device restore (`_resolve_device_from_name()`) that runs a few lines later can't recover the selection, because the name it relies on has just been cleared.

## Fix

Merge the partial update over the current config **before** schema validation, so keys the caller didn't touch keep their values:

```python
if hasattr(self, "_config") and isinstance(self._config, dict):
    config = {**self._config, **config}
new_config = self.AUDIO_CONFIG_SCHEMA.fget()(config)
```

This is the minimal change — the rest of `update_config()` (the `device_changing` / `pipeline_changing` diff, deactivate/reactivate) is unchanged and still works correctly: a delay-only update now sees the device as unchanged and the delay as a pipeline change, so the pipeline rebuilds without dropping the device.

## Test

Adds `TestPartialUpdatePreservesDevice` to `tests/test_audio_device_persistence.py`, asserting that a delay-only `update_config({"delay_ms": N})` preserves both `audio_device` and `audio_device_name`. I confirmed it fails on `main` (the device resets to index `0`) and passes with this change.

`pre-commit` (isort, flake8, black, ruff, pyupgrade) passes on both changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Partial audio settings updates now preserve previously selected input device information instead of resetting it.
  * Updating only one setting, such as delay, no longer clears device selection in the app.
* **Tests**
  * Added regression coverage to verify that partial configuration updates keep the chosen audio device intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->