### PR TITLE
Fix: default gradient to off in now playing service config

### DIFF
--- a/ledfx/nowplaying/service.py
+++ b/ledfx/nowplaying/service.py
@@ -91,7 +91,7 @@ NOW_PLAYING_CONFIG_SCHEMA = vol.Schema(
     {
         vol.Optional("gradient", default={}): vol.Schema(
             {
-                vol.Optional("enabled", default=True): bool,
+                vol.Optional("enabled", default=False): bool,
                 vol.Optional("variant", default="led_punchy"): vol.In(
                     GRADIENT_VARIANTS
                 ),

--- a/tests/test_api_now_playing.py
+++ b/tests/test_api_now_playing.py
@@ -64,7 +64,7 @@ async def test_get_empty_state(endpoint):
     assert data["current_gradient"] is None
     # Phase 7: config section present
     assert "config" in data
-    assert data["config"]["gradient"]["enabled"] is True
+    assert data["config"]["gradient"]["enabled"] is False
     assert data["config"]["gradient"]["variant"] == "led_punchy"
 
 

--- a/tests/test_now_playing_service.py
+++ b/tests/test_now_playing_service.py
@@ -672,7 +672,7 @@ class TestGradientApplicationConfig:
     """Tests for gradient config properties."""
 
     def test_default_gradient_enabled(self, service):
-        assert service.gradient_enabled is True
+        assert service.gradient_enabled is False
 
     def test_set_gradient_enabled(self, service):
         service.gradient_enabled = False
@@ -963,7 +963,7 @@ class TestNowPlayingConfigSchema:
         from ledfx.nowplaying.service import NOW_PLAYING_CONFIG_SCHEMA
 
         result = NOW_PLAYING_CONFIG_SCHEMA({})
-        assert result["gradient"]["enabled"] is True
+        assert result["gradient"]["enabled"] is False
         assert result["gradient"]["variant"] == "led_punchy"
         assert result["gradient"]["virtual_ids"] == []
         assert result["track_text"]["enabled"] is True
@@ -1019,7 +1019,7 @@ class TestServiceConfigFromInit:
 
     def test_default_config_loaded(self, service):
         cfg = service.config
-        assert cfg["gradient"]["enabled"] is True
+        assert cfg["gradient"]["enabled"] is False
         assert cfg["gradient"]["variant"] == "led_punchy"
         assert cfg["gradient"]["virtual_ids"] == []
         assert cfg["track_text"]["enabled"] is True


### PR DESCRIPTION
We don't want to suddenly apply now playing gradient changes to anyone who has not actively turned it on.

May of made sense for testing without a UI, but its a land mine, so defuse it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Changed the default setting for gradient effects in Now Playing to be turned off for new or unspecified configurations, reducing unexpected visual behavior.  
* **Tests**
  * Updated Now Playing API and service tests to reflect the new default behavior for gradient enablement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->