### PR TITLE
fix(audio): preserve audio selection and reconnect Sendspin after Music Assistant restarts

### DIFF
--- a/ledfx/api/audio_devices.py
+++ b/ledfx/api/audio_devices.py
@@ -70,10 +70,13 @@ class AudioDevicesEndpoint(RestEndpoint):
         # Update and save config
         new_config = self._ledfx.config.get("audio", {})
         new_config["audio_device"] = int(index)
-        # When user explicitly selects a new device via API, clear the stale
-        # device name so _resolve_device_from_name() uses the index as-is
-        # instead of name-matching back to the old device.
-        new_config["audio_device_name"] = ""
+        # When user explicitly selects a new device via API, replace any stale
+        # stored name with the current name for that selected index. This keeps
+        # the live selection consistent now and preserves boot-time name-based
+        # recovery if indices drift before the next restart.
+        new_config["audio_device_name"] = AudioInputSource.input_devices().get(
+            int(index), ""
+        )
 
         if self._ledfx.audio:
             self._ledfx.audio.update_config(new_config)

--- a/ledfx/api/config.py
+++ b/ledfx/api/config.py
@@ -256,10 +256,10 @@ class ConfigEndpoint(RestEndpoint):
         # the live selection consistent now and preserves boot-time name-based
         # recovery if indices drift before the next restart.
         if "audio_device" in audio_config:
-            audio_config["audio_device_name"] = (
-                AudioInputSource.input_devices().get(
-                    audio_config["audio_device"], ""
-                )
+            audio_config[
+                "audio_device_name"
+            ] = AudioInputSource.input_devices().get(
+                audio_config["audio_device"], ""
             )
 
         self._ledfx.config["melbanks"].update(melbanks_config)

--- a/ledfx/api/config.py
+++ b/ledfx/api/config.py
@@ -251,11 +251,16 @@ class ConfigEndpoint(RestEndpoint):
 
         # TODO: handle sendspin_always_on it should eager start sendspin or stop sendspin if sendspin is active, and always on changes
 
-        # When user explicitly selects a new device via API, clear the stale
-        # device name so _resolve_device_from_name() uses the index as-is
-        # instead of name-matching back to the old device.
+        # When user explicitly selects a new device via API, replace any stale
+        # stored name with the current name for that selected index. This keeps
+        # the live selection consistent now and preserves boot-time name-based
+        # recovery if indices drift before the next restart.
         if "audio_device" in audio_config:
-            audio_config["audio_device_name"] = ""
+            audio_config["audio_device_name"] = (
+                AudioInputSource.input_devices().get(
+                    audio_config["audio_device"], ""
+                )
+            )
 
         self._ledfx.config["melbanks"].update(melbanks_config)
         self._ledfx.config.update(core_config)

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -236,7 +236,9 @@ class LedFxCore:
         if not SENDSPIN_AVAILABLE:
             return
 
-        from ledfx.effects.audio import SENDSPIN_SERVERS
+        from ledfx.effects.audio import AudioInputSource, SENDSPIN_SERVERS
+
+        previous_valid = AudioInputSource.valid_device_indexes()
 
         sendspin_config = self.config.get("sendspin_servers", {})
         SENDSPIN_SERVERS.clear()
@@ -249,13 +251,14 @@ class LedFxCore:
 
         # Log what the audio system sees immediately after loading
         try:
-            from ledfx.effects.audio import AudioInputSource
-
             valid = AudioInputSource.valid_device_indexes()
             _LOGGER.debug(
                 "_load_sendspin_servers: valid_device_indexes after load = %s",
                 valid,
             )
+
+            if valid != previous_valid:
+                self.events.fire_event(AudioDeviceListChangedEvent())
         except Exception as exc:
             _LOGGER.debug(
                 "_load_sendspin_servers: could not query devices: %s", exc

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -236,7 +236,7 @@ class LedFxCore:
         if not SENDSPIN_AVAILABLE:
             return
 
-        from ledfx.effects.audio import AudioInputSource, SENDSPIN_SERVERS
+        from ledfx.effects.audio import SENDSPIN_SERVERS, AudioInputSource
 
         previous_valid = AudioInputSource.valid_device_indexes()
 

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -861,6 +861,9 @@ class SendspinAudioStream:
                 except asyncio.CancelledError:
                     if not self._active:
                         raise
+                    task = asyncio.current_task()
+                    if task is not None:
+                        task.uncancel()
                     # Otherwise, treat as reconnect
                     continue
                 backoff = min(backoff * 2, max_backoff)

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -821,7 +821,13 @@ class SendspinAudioStream:
                     )
                     raise  # Propagate so _run_client sees CancelledError
                 else:
-                    # Watchdog or internal reconnect: just continue loop
+                    # Watchdog or internal reconnect: just continue loop.
+                    # Python 3.12: task.cancel() increments an internal counter
+                    # that re-throws CancelledError into the very next await
+                    # unless we call task.uncancel() to decrement it first.
+                    task = asyncio.current_task()
+                    if task is not None:
+                        task.uncancel()
                     _LOGGER.info(
                         "Reconnect task cancelled by watchdog (attempt=%d, id=%s), restarting connect.",
                         attempt,
@@ -925,11 +931,24 @@ class SendspinAudioStream:
                 player_support=player_support,
             )
 
+            # Per-connection event set by the disconnect callback so the
+            # keep-alive loop below exits immediately when the server drops.
+            _disconnect_event = asyncio.Event()
+
+            def _disconnect_handler():
+                _LOGGER.warning(
+                    "Sendspin server disconnected (id=%s), "
+                    "triggering reconnect",
+                    id(self),
+                )
+                _disconnect_event.set()
+
             # Register event handlers
             self._client.add_audio_chunk_listener(self._audio_chunk_handler)
             self._client.add_stream_start_listener(self._stream_start_handler)
             self._client.add_stream_end_listener(self._stream_end_handler)
             self._client.add_stream_clear_listener(self._stream_clear_handler)
+            self._client.add_disconnect_listener(_disconnect_handler)
             if self._now_playing_provider is not None:
                 self._client.add_metadata_listener(
                     self._now_playing_provider.on_metadata
@@ -948,9 +967,11 @@ class SendspinAudioStream:
                 self._playback_scheduler()
             )
 
-            # Keep connection alive — use stop_event so stop() wakes us
-            # immediately instead of waiting up to 0.1s.
+            # Keep connection alive — exit if stop() signals or the server
+            # disconnects (detected via the disconnect callback above).
             while self._active:
+                if _disconnect_event.is_set():
+                    raise ConnectionError("Sendspin server disconnected")
                 try:
                     await asyncio.wait_for(
                         self._stop_event.wait(), timeout=0.1

--- a/tests/test_audio_device_persistence.py
+++ b/tests/test_audio_device_persistence.py
@@ -7,7 +7,9 @@ Strategy doc: docs/developer/dev_notes/audio-device-persistence-strategy.md
 import logging
 from unittest.mock import MagicMock, patch
 
+from ledfx.core import LedFxCore
 from ledfx.effects.audio import AudioInputSource
+from ledfx.events import AudioDeviceListChangedEvent
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -406,16 +408,17 @@ class TestAudioDevicesApi:
         return_value=tuple(DEVICES_BEFORE.keys()),
     )
     @patch.object(AudioInputSource, "default_device_index", return_value=0)
-    def test_api_put_device_change_clears_stale_name(
+    def test_api_put_device_change_replaces_stale_name(
         self, mock_default, mock_valid, mock_devices, mock_save
     ):
-        """PUT with new audio_device must not name-match back to old device.
+        """PUT with new audio_device must replace any stale persisted name.
 
         Regression test: when config already has audio_device=17 with
         audio_device_name pointing to loopback, and the frontend sends
-        audio_device=5, the merge used to leave the stale name in place.
-        _resolve_device_from_name() would then find the old device by name
-        and override the user's selection back to 17.
+        audio_device=5, the merged config passed to update_config() must carry
+        the newly selected device's current name. That preserves cross-session
+        recovery while still preventing the old persisted name from overriding
+        the user's explicit live selection.
         """
         from ledfx.api.config import ConfigEndpoint
 
@@ -452,11 +455,43 @@ class TestAudioDevicesApi:
         endpoint.update_config({"audio": {"audio_device": 5}})
 
         # The merged config passed to update_config must have the new index
-        # and a cleared name so _resolve_device_from_name() won't override it
+        # and the new device's name, not the stale persisted name.
         assert len(received_configs) == 1
         merged = received_configs[0]
         assert merged["audio_device"] == 5
-        assert merged["audio_device_name"] == ""
+        assert (
+            merged["audio_device_name"]
+            == "Windows WASAPI: Stereo Mix (Realtek High Definition Audio)"
+        )
+
+
+class TestSendspinDeviceListEvent:
+    """Sendspin device-list changes should notify the frontend to requery."""
+
+    @patch("ledfx.sendspin.SENDSPIN_AVAILABLE", True)
+    @patch.object(
+        AudioInputSource,
+        "valid_device_indexes",
+        side_effect=[(0, 1, 2), (0, 1, 2, 99)],
+    )
+    def test_load_sendspin_servers_fires_device_list_changed(
+        self, mock_valid
+    ):
+        core = object.__new__(LedFxCore)
+        core.config = {"sendspin_servers": {"demo": {"url": "ws://demo"}}}
+        core.events = MagicMock()
+
+        from ledfx.effects.audio import SENDSPIN_SERVERS
+
+        original_servers = dict(SENDSPIN_SERVERS)
+        try:
+            core._load_sendspin_servers()
+        finally:
+            SENDSPIN_SERVERS.clear()
+            SENDSPIN_SERVERS.update(original_servers)
+
+        fired_event = core.events.fire_event.call_args[0][0]
+        assert isinstance(fired_event, AudioDeviceListChangedEvent)
 
     @patch.object(
         AudioInputSource, "input_devices", return_value=DEVICES_BEFORE

--- a/tests/test_audio_device_persistence.py
+++ b/tests/test_audio_device_persistence.py
@@ -474,9 +474,7 @@ class TestSendspinDeviceListEvent:
         "valid_device_indexes",
         side_effect=[(0, 1, 2), (0, 1, 2, 99)],
     )
-    def test_load_sendspin_servers_fires_device_list_changed(
-        self, mock_valid
-    ):
+    def test_load_sendspin_servers_fires_device_list_changed(self, mock_valid):
         core = object.__new__(LedFxCore)
         core.config = {"sendspin_servers": {"demo": {"url": "ws://demo"}}}
         core.events = MagicMock()


### PR DESCRIPTION
Fixes two related audio problems:

Partial audio config updates no longer reset the selected input device, so changing settings like delay will not silently switch LedFx back to the default source.

Sendspin now reconnects more reliably when Music Assistant restarts or disconnects, so LedFx can recover without manual intervention.

When Sendspin’s device list changes, LedFx now notifies the frontend so the UI can requery the active devices instead of showing stale state.

Validation:

Added regression coverage for partial config updates preserving the selected device.
Added coverage for Sendspin device-list change notifications and reconnect behavior.
Lots of manual testing on removing / adding audio devices when active or shutdown.
Ensure ledfx connects to Music Assistant after reboot of MA

I believe there are some player group bugs in MA that are resolved by a reboot. When adding new clients to the group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio device switching so selecting a new input keeps the correct current device name instead of clearing it.
  * Updated config handling so explicitly chosen audio devices no longer get overridden by previously saved/stale names.
  * Enhanced Sendspin stream reconnect behavior after disconnects, including more reliable cancellation handling for newer Python versions.
  * Device availability changes are now detected more consistently and emit updates when needed.
* **Tests**
  * Expanded coverage for audio device persistence and Sendspin device list change events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->