### PR TITLE
Fix: Clean up Sendspin eager start and handle pause

### DIFF
--- a/docs/apis/sendspin_servers.md
+++ b/docs/apis/sendspin_servers.md
@@ -317,9 +317,9 @@ All mutating operations (`POST`, `PUT`, `DELETE`) immediately update the in-memo
 
 1. The `config.json` `sendspin_servers` key is written.
 2. `SENDSPIN_SERVERS` (from `ledfx.effects.audio`) is updated in-place.
-3. If the currently active audio source is `SENDSPIN {id}`, changing or removing that server causes the audio system to fall back to the default audio device.
+3. If the currently active audio source is `SENDSPIN: {id}`, changing or removing that server reconciles the active Sendspin stream (restart on URL change, stop on removal).
 
-> **Note:** A server appearing in `SENDSPIN_SERVERS` does **not** mean LedFx is actively streaming from it. The connection is only established when the user selects that server as the active audio input device (via `PUT /api/config` with `audio_device = "SENDSPIN living-room"`).
+> **Note:** A server appearing in `SENDSPIN_SERVERS` does **not** mean LedFx is actively streaming from it. The connection is only established when the user selects that server as the active audio input device (device name format: `SENDSPIN: living-room`).
 
 ---
 

--- a/docs/settings/sendspin.md
+++ b/docs/settings/sendspin.md
@@ -91,7 +91,7 @@ When activated, LedFx will:
 
 ## Always-On Mode
 
-By default, Sendspin audio (like all other audio sources) only starts when an audio-reactive effect is active. If you want the Sendspin connection to stay active regardless of whether any effects are running, enable the **Sendspin Always On** setting.
+Sendspin Always On is enabled by default. With this setting enabled, the Sendspin connection can stay active regardless of whether any effects are running.
 
 This is a global setting found in the sendspin server management dialog (`sendspin_always_on`).
 
@@ -100,6 +100,8 @@ When enabled:
 - The Sendspin audio stream starts immediately when a Sendspin device is selected, even without active effects.
 - The stream remains active if all effects are removed.
 - On boot, if a Sendspin device was previously selected and this setting is `true`, the stream starts automatically.
+
+When disabled, Sendspin follows normal audio lifecycle behavior and may deactivate when no audio-reactive effects are subscribed.
 
 This is useful for integrations where you want LedFx to be ready to visualize audio the moment playback begins, without requiring an effect to be pre-configured.
 

--- a/ledfx/api/config.py
+++ b/ledfx/api/config.py
@@ -249,8 +249,6 @@ class ConfigEndpoint(RestEndpoint):
             config, CORE_CONFIG_SCHEMA, "core"
         )
 
-        # TODO: handle sendspin_always_on it should eager start sendspin or stop sendspin if sendspin is active, and always on changes
-
         # When user explicitly selects a new device via API, replace any stale
         # stored name with the current name for that selected index. This keeps
         # the live selection consistent now and preserves boot-time name-based
@@ -282,6 +280,11 @@ class ConfigEndpoint(RestEndpoint):
             # values (self._config may be the same object as
             # self._ledfx.config["audio"] after _persist_config replaces it).
             self._ledfx.config["audio"].update(audio_config)
+
+            if hasattr(self._ledfx, "reconcile_sendspin_always_on_runtime"):
+                self._ledfx.reconcile_sendspin_always_on_runtime(
+                    "audio_config_updated"
+                )
 
         if hasattr(self._ledfx, "audio") and melbanks_config:
             self._ledfx.audio.melbanks.update_config(

--- a/ledfx/config.py
+++ b/ledfx/config.py
@@ -193,7 +193,7 @@ CORE_CONFIG_SCHEMA = vol.Schema(
         ),
         vol.Optional("instance_id", default=""): str,
         vol.Optional("sendspin_servers", default={}): dict,
-        vol.Optional("sendspin_always_on", default=False): bool,
+        vol.Optional("sendspin_always_on", default=True): bool,
         vol.Optional("now_playing", default={}): dict,
     },
     extra=vol.ALLOW_EXTRA,

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -165,7 +165,7 @@ class LedFxCore:
         Handles the update of the base configuration where there are specific things that need to be done.
 
         Currently handles visualisation configuration (requires new event listeners)
-        and sendspin_always_on toggling (requires audio stream deactivation check).
+        and sendspin_always_on runtime updates (via centralized reconcile logic).
 
         Args:
             event (Event): The event that triggered the update - this will always be a BaseConfigUpdateEvent.
@@ -177,14 +177,34 @@ class LedFxCore:
             )
             self.setup_visualisation_events()
 
-        if (
-            "sendspin_always_on" in event.config
-            and not event.config["sendspin_always_on"]
-            and hasattr(self, "audio")
-            and self.audio is not None
-        ):
+        if "sendspin_always_on" in event.config:
+            self.reconcile_sendspin_always_on_runtime(
+                "base_config_update"
+            )
+
+    def reconcile_sendspin_always_on_runtime(self, trigger: str):
+        """Reconcile runtime Sendspin always-on behavior from current config.
+
+        This centralizes policy decisions so API/config/server hooks only need
+        to signal *when* to re-check, not duplicate *what* to do.
+        """
+        if self.config.get("sendspin_always_on", True):
             _LOGGER.debug(
-                "sendspin_always_on toggled off - checking if audio stream should deactivate."
+                "sendspin reconcile (%s): always-on enabled, checking eager start.",
+                trigger,
+            )
+            try:
+                sendspin_eager_start(self)
+            except Exception as exc:
+                _LOGGER.warning(
+                    "sendspin reconcile (%s) failed: %s", trigger, exc
+                )
+            return
+
+        if hasattr(self, "audio") and self.audio is not None:
+            _LOGGER.debug(
+                "sendspin reconcile (%s): always-on disabled, checking deactivate.",
+                trigger,
             )
             self.audio.check_and_deactivate()
 
@@ -265,6 +285,10 @@ class LedFxCore:
             _LOGGER.debug(
                 "_load_sendspin_servers: could not query devices: %s", exc
             )
+
+        # Runtime path: server changes can alter whether the configured
+        # Sendspin source is currently available.
+        self.reconcile_sendspin_always_on_runtime("sendspin_servers_loaded")
 
     def loop_exception_handler(self, loop, context):
         kwargs = {}
@@ -550,13 +574,6 @@ class LedFxCore:
         # virtuals, since virtuals with active effects trigger audio
         # initialization which validates the audio_device index.
         self._load_sendspin_servers()
-
-        # Eagerly start the Sendspin audio stream at boot when configured,
-        # even if no audio-reactive effect is active yet.
-        try:
-            sendspin_eager_start(self)
-        except Exception as e:
-            _LOGGER.warning("Failed to eagerly start Sendspin audio: %s", e)
 
         self.zeroconf = ZeroConfRunner(ledfx=self)
         self.virtuals.create_from_config(

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -178,9 +178,7 @@ class LedFxCore:
             self.setup_visualisation_events()
 
         if "sendspin_always_on" in event.config:
-            self.reconcile_sendspin_always_on_runtime(
-                "base_config_update"
-            )
+            self.reconcile_sendspin_always_on_runtime("base_config_update")
 
     def reconcile_sendspin_always_on_runtime(self, trigger: str):
         """Reconcile runtime Sendspin always-on behavior from current config.

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -992,10 +992,21 @@ class AudioInputSource:
     def _should_always_keep_active(self):
         """Check if the current audio source should stay active regardless of subscribers."""
         sendspin_always_on = self._ledfx.config.get(
-            "sendspin_always_on", False
+            "sendspin_always_on", True
         )
         if not sendspin_always_on:
             return False
+
+        configured_name = (
+            self._config.get("audio_device_name")
+            if hasattr(self, "_config")
+            else ""
+        )
+        if isinstance(configured_name, str) and configured_name.startswith(
+            "SENDSPIN:"
+        ):
+            return True
+
         device_idx = (
             self._config.get("audio_device")
             if hasattr(self, "_config")

--- a/ledfx/effects/audio.py
+++ b/ledfx/effects/audio.py
@@ -991,9 +991,7 @@ class AudioInputSource:
 
     def _should_always_keep_active(self):
         """Check if the current audio source should stay active regardless of subscribers."""
-        sendspin_always_on = self._ledfx.config.get(
-            "sendspin_always_on", True
-        )
+        sendspin_always_on = self._ledfx.config.get("sendspin_always_on", True)
         if not sendspin_always_on:
             return False
 

--- a/ledfx/sendspin/config.py
+++ b/ledfx/sendspin/config.py
@@ -116,7 +116,7 @@ def eager_start(ledfx):
     Sendspin audio stream begins immediately, even when no audio-reactive
     effect is active yet.
     """
-    if not ledfx.config.get("sendspin_always_on", False):
+    if not ledfx.config.get("sendspin_always_on", True):
         return
 
     audio_config = ledfx.config.get("audio", {})
@@ -157,4 +157,13 @@ def eager_start(ledfx):
         device_idx,
         device_name,
     )
+
+    existing_audio = getattr(ledfx, "audio", None)
+    if existing_audio is not None:
+        # Runtime path: apply current config and allow audio.py to activate
+        # immediately when always-on + Sendspin conditions are met.
+        existing_audio.update_config(audio_config)
+        return
+
+    # Boot-time path: no audio instance exists yet.
     ledfx.audio = AudioAnalysisSource(ledfx, audio_config)

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -26,15 +26,19 @@ try:
     from aiosendspin.client import AudioFormat, SendspinClient
     from aiosendspin.models import AudioCodec, PlayerCommand, Roles
     from aiosendspin.models.core import DeviceInfo
+    from aiosendspin.models.metadata import SessionUpdateMetadata
     from aiosendspin.models.player import (
         ClientHelloPlayerSupport,
         SupportedAudioFormat,
     )
+    from aiosendspin.models.types import UndefinedField
 except ImportError:
     # Python < 3.12 or aiosendspin not available
     SendspinClient = None
     AudioFormat = None
     DeviceInfo = None
+    SessionUpdateMetadata = None
+    UndefinedField = None
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -597,10 +601,7 @@ class SendspinAudioStream:
         Unlike ``_stream_clear_handler`` (seek), we do **not** reset the FLAC
         decoder here because the stream will resume without a new stream_start.
         """
-        try:
-            from aiosendspin.models.metadata import SessionUpdateMetadata
-            from aiosendspin.models.types import UndefinedField
-        except ImportError:
+        if SessionUpdateMetadata is None or UndefinedField is None:
             return
 
         metadata = server_state_payload.metadata

--- a/ledfx/sendspin/stream.py
+++ b/ledfx/sendspin/stream.py
@@ -534,14 +534,33 @@ class SendspinAudioStream:
         self._last_audio_chunk_time = time.monotonic()
 
     def _stream_end_handler(self, stream_end_msg):
-        """Called when the stream ends (track stopped / server idle).
+        """Called when the stream ends (track stopped, paused, or server idle).
 
-        Disarms the watchdog so an idle always-on connection does not
+        Music Assistant ends the Sendspin stream on pause/seek/stop, so
+        flushing the buffer here stops the visualiser immediately rather than
+        letting buffered audio drain for ~2 seconds.  A subsequent
+        ``stream/start`` (on resume or next track) reloads the buffer with
+        fresh audio via ``_stream_start_handler``.
+
+        Also disarms the watchdog so an idle always-on connection does not
         repeatedly reconnect just because no audio is playing.
         """
         _LOGGER.info("Sendspin stream ended (id=%s)", id(self))
         self._expecting_audio = False
         self._last_audio_chunk_time = None
+        # Flush buffered audio so visualisation stops immediately.
+        self._leftover = np.array([], dtype=np.float32)
+        self._leftover_ts = 0
+        with self._buffer_lock:
+            buf_len = len(self._chunk_buffer)
+            self._chunk_buffer.clear()
+        if buf_len:
+            _LOGGER.info(
+                "Playback buffer flushed on stream end "
+                "(discarded_chunks=%d, id=%s)",
+                buf_len,
+                id(self),
+            )
 
     def _stream_clear_handler(self, roles):
         """Called on stream/clear (e.g. seek). Flush the playback buffer.
@@ -563,6 +582,51 @@ class SendspinAudioStream:
             roles,
             buf_len,
         )
+
+    def _metadata_pause_handler(self, server_state_payload) -> None:
+        """Belt-and-suspenders flush when metadata reports playback_speed == 0.
+
+        The primary pause flush happens in ``_stream_end_handler`` because
+        Music Assistant ends the Sendspin stream on pause/seek/stop, which
+        fires before this metadata callback arrives.
+
+        This handler catches any implementation where the stream stays open
+        during pause (e.g., future MA versions or non-MA Sendspin servers)
+        but the server sends ``playback_speed = 0`` in the progress field.
+
+        Unlike ``_stream_clear_handler`` (seek), we do **not** reset the FLAC
+        decoder here because the stream will resume without a new stream_start.
+        """
+        try:
+            from aiosendspin.models.metadata import SessionUpdateMetadata
+            from aiosendspin.models.types import UndefinedField
+        except ImportError:
+            return
+
+        metadata = server_state_payload.metadata
+        if metadata is None or not isinstance(metadata, SessionUpdateMetadata):
+            return
+
+        progress = metadata.progress
+        if isinstance(progress, UndefinedField) or progress is None:
+            return
+
+        playback_speed = getattr(progress, "playback_speed", None)
+        if playback_speed != 0:
+            return
+
+        # playback_speed == 0 → paused: flush buffered audio immediately.
+        self._leftover = np.array([], dtype=np.float32)
+        self._leftover_ts = 0
+        with self._buffer_lock:
+            buf_len = len(self._chunk_buffer)
+            self._chunk_buffer.clear()
+        if buf_len:
+            _LOGGER.info(
+                "Playback paused — flushed %d buffered chunks (id=%s)",
+                buf_len,
+                id(self),
+            )
 
     async def _playback_scheduler(self):
         """Release buffered chunks to LedFx at their scheduled play time."""
@@ -952,6 +1016,7 @@ class SendspinAudioStream:
             self._client.add_stream_end_listener(self._stream_end_handler)
             self._client.add_stream_clear_listener(self._stream_clear_handler)
             self._client.add_disconnect_listener(_disconnect_handler)
+            self._client.add_metadata_listener(self._metadata_pause_handler)
             if self._now_playing_provider is not None:
                 self._client.add_metadata_listener(
                     self._now_playing_provider.on_metadata

--- a/tests/test_sendspin_always_on_runtime.py
+++ b/tests/test_sendspin_always_on_runtime.py
@@ -78,7 +78,11 @@ def test_reconcile_sendspin_always_on_runtime_deactivates_when_disabled():
     core.audio.check_and_deactivate.assert_called_once_with()
 
 
-@patch.object(AudioInputSource, "input_devices", return_value={0: "SENDSPIN: living-room"})
+@patch.object(
+    AudioInputSource,
+    "input_devices",
+    return_value={0: "SENDSPIN: living-room"},
+)
 def test_config_update_audio_triggers_core_sendspin_reconcile(_mock_devices):
     ledfx = SimpleNamespace(
         config={

--- a/tests/test_sendspin_always_on_runtime.py
+++ b/tests/test_sendspin_always_on_runtime.py
@@ -1,0 +1,105 @@
+"""Runtime behavior tests for Sendspin always-on startup paths."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from ledfx.api.config import ConfigEndpoint
+from ledfx.config import CORE_CONFIG_SCHEMA
+from ledfx.core import LedFxCore
+from ledfx.effects.audio import AudioInputSource
+from ledfx.sendspin.config import eager_start
+
+
+def test_sendspin_always_on_default_true():
+    config = CORE_CONFIG_SCHEMA({})
+    assert config["sendspin_always_on"] is True
+
+
+def test_audio_should_keep_active_for_sendspin_name_even_if_index_invalid():
+    ais = object.__new__(AudioInputSource)
+    ais._ledfx = SimpleNamespace(config={"sendspin_always_on": True})
+    ais._config = {
+        "audio_device": 999,
+        "audio_device_name": "SENDSPIN: living-room",
+    }
+
+    assert ais._should_always_keep_active() is True
+
+
+def test_handle_base_configuration_update_reconciles_when_enabled():
+    core = object.__new__(LedFxCore)
+    core.audio = None
+    core.config = {"sendspin_always_on": True}
+
+    with patch("ledfx.core.sendspin_eager_start") as mock_eager_start:
+        core.handle_base_configuration_update(
+            SimpleNamespace(config={"sendspin_always_on": True})
+        )
+
+    mock_eager_start.assert_called_once_with(core)
+
+
+def test_eager_start_reuses_existing_audio_instance():
+    ledfx = SimpleNamespace(
+        config={
+            "sendspin_always_on": True,
+            "audio": {
+                "audio_device": 0,
+                "audio_device_name": "SENDSPIN: living-room",
+            },
+        },
+        audio=MagicMock(),
+    )
+
+    with (
+        patch(
+            "ledfx.effects.audio.AudioInputSource.query_devices",
+            return_value=({},),
+        ),
+        patch(
+            "ledfx.effects.audio.AudioInputSource.query_hostapis",
+            return_value=({},),
+        ),
+    ):
+        eager_start(ledfx)
+
+    ledfx.audio.update_config.assert_called_once_with(ledfx.config["audio"])
+
+
+def test_reconcile_sendspin_always_on_runtime_deactivates_when_disabled():
+    core = object.__new__(LedFxCore)
+    core.config = {"sendspin_always_on": False}
+    core.audio = MagicMock()
+
+    with patch("ledfx.core.sendspin_eager_start") as mock_eager_start:
+        core.reconcile_sendspin_always_on_runtime("unit_test")
+
+    mock_eager_start.assert_not_called()
+    core.audio.check_and_deactivate.assert_called_once_with()
+
+
+@patch.object(AudioInputSource, "input_devices", return_value={0: "SENDSPIN: living-room"})
+def test_config_update_audio_triggers_core_sendspin_reconcile(_mock_devices):
+    ledfx = SimpleNamespace(
+        config={
+            "audio": {
+                "audio_device": 0,
+                "audio_device_name": "",
+            },
+            "melbanks": {},
+            "wled_preferences": {},
+            "sendspin_always_on": True,
+        },
+        audio=None,
+        reconcile_sendspin_always_on_runtime=MagicMock(),
+        events=SimpleNamespace(fire_event=MagicMock()),
+    )
+
+    endpoint = object.__new__(ConfigEndpoint)
+    endpoint._ledfx = ledfx
+
+    endpoint.update_config({"audio": {"audio_device": 0}})
+
+    ledfx.reconcile_sendspin_always_on_runtime.assert_called_once_with(
+        "audio_config_updated"
+    )


### PR DESCRIPTION
Needs manual test...

## Summary
Refactors Sendspin always-on handling to use a single runtime reconcile path, sets always-on default to enabled, and updates docs/tests to match the new behavior. This removes scattered startup logic and fixes cases where Sendspin only registered after a full LedFx restart.

## What Changed
- Set sendspin_always_on default to true.
- Centralized runtime policy in core via a reconcile_sendspin_always_on_runtime method.
- Routed config updates and Sendspin server reloads through the same reconcile path.
- Kept eager_start focused on source eligibility and safe runtime reuse of existing audio instances.
- Hardened keep-active behavior with Sendspin name-based fallback when device indexes drift.
- Updated Sendspin docs to reflect default-enabled always-on and current source naming format.
- Renamed test wording from toggle-centric to reconcile-centric where applicable.

## Why
- Ensures consistent behavior from one policy location instead of multiple scattered call sites.
- Eliminates restart-only startup behavior for Sendspin in common runtime flows.
- Improves maintainability and testability of always-on lifecycle behavior.

## Validation
- uv run pytest tests/test_sendspin_always_on_runtime.py
- uv run pytest tests/test_sendspin_always_on_runtime.py tests/test_api_sendspin_servers.py tests/test_audio_device_persistence.py
- uv run pytest tests/test_now_playing_sendspin.py tests/test_now_playing_musicbrainz.py

All passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sendspin “Always On” is enabled by default.
  * Sendspin runtime behavior now reconciles automatically when audio settings or Sendspin server availability changes.
* **Bug Fixes**
  * Sendspin streams now flush/discard buffered audio when a stream ends or is paused, reducing stale playback/visualization.
* **Documentation**
  * Updated Sendspin docs for revised server-change behavior, device naming format, and always-on semantics.
* **Tests**
  * Added coverage for always-on defaults, runtime reconciliation, and audio instance reuse during eager start.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->