### PR TITLE
Feat: Venues system with color override pad grid

### DIFF
--- a/ledfx/api/venue.py
+++ b/ledfx/api/venue.py
@@ -1,0 +1,111 @@
+import logging
+from json import JSONDecodeError
+
+from aiohttp import web
+
+from ledfx.api import RestEndpoint
+from ledfx.venues import VenueManager
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _ensure_manager(ledfx) -> VenueManager:
+    if not hasattr(ledfx, "venues"):
+        ledfx.venues = VenueManager(ledfx)
+    return ledfx.venues
+
+
+class VenueEndpoint(RestEndpoint):
+    """REST end-point for a single venue: read, update, delete, manage members."""
+
+    ENDPOINT_PATH = "/api/venues/{venue_id}"
+
+    async def get(self, venue_id) -> web.Response:
+        """Get a venue by ID."""
+        mgr = _ensure_manager(self._ledfx)
+        cfg = mgr.get(venue_id)
+        if cfg is None:
+            return await self.invalid_request(f"Venue '{venue_id}' not found")
+        return await self.bare_request_success(
+            {"venue": {"id": venue_id, **cfg}}
+        )
+
+    async def put(self, venue_id, request: web.Request) -> web.Response:
+        """Update venue name, grid dimensions, or manage virtual membership.
+
+        Supported body variants:
+
+        Update name / grid::
+
+            { "name": "...", "color_pads": { "rows": N, "cols": M } }
+
+        Add a virtual::
+
+            { "action": "add_virtual", "virtual_id": "..." }
+
+        Remove a virtual::
+
+            { "action": "remove_virtual", "virtual_id": "..." }
+        """
+        try:
+            data = await request.json()
+        except JSONDecodeError:
+            return await self.json_decode_error()
+
+        mgr = _ensure_manager(self._ledfx)
+
+        action = data.get("action")
+
+        try:
+            if action == "add_virtual":
+                virtual_id = data.get("virtual_id")
+                if not virtual_id:
+                    return await self.invalid_request(
+                        '"virtual_id" required for add_virtual'
+                    )
+                venue = mgr.add_virtual(venue_id, virtual_id)
+                return await self.request_success(
+                    type="success",
+                    message=f"Added virtual '{virtual_id}' to venue '{venue_id}'",
+                    data={"venue": venue},
+                )
+
+            elif action == "remove_virtual":
+                virtual_id = data.get("virtual_id")
+                if not virtual_id:
+                    return await self.invalid_request(
+                        '"virtual_id" required for remove_virtual'
+                    )
+                venue = mgr.remove_virtual(venue_id, virtual_id)
+                return await self.request_success(
+                    type="success",
+                    message=f"Removed virtual '{virtual_id}' from venue '{venue_id}'",
+                    data={"venue": venue},
+                )
+
+            else:
+                # Generic config update (name, color_pads)
+                venue = mgr.update(venue_id, data)
+                return await self.request_success(
+                    type="success",
+                    message=f"Updated venue '{venue_id}'",
+                    data={"venue": venue},
+                )
+
+        except KeyError as e:
+            return await self.invalid_request(str(e))
+        except ValueError as e:
+            return await self.invalid_request(str(e))
+        except Exception as e:
+            _LOGGER.warning("Venue update error: %s", e)
+            return await self.invalid_request(str(e))
+
+    async def delete(self, venue_id) -> web.Response:
+        """Delete a venue."""
+        mgr = _ensure_manager(self._ledfx)
+        ok = mgr.delete(venue_id)
+        if not ok:
+            return await self.invalid_request(f"Venue '{venue_id}' not found")
+        return await self.request_success(
+            type="success", message=f"Deleted venue '{venue_id}'"
+        )

--- a/ledfx/api/venue_override.py
+++ b/ledfx/api/venue_override.py
@@ -1,0 +1,77 @@
+import logging
+from json import JSONDecodeError
+
+from aiohttp import web
+
+from ledfx.api import RestEndpoint
+from ledfx.venues import VenueManager
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _ensure_manager(ledfx) -> VenueManager:
+    if not hasattr(ledfx, "venues"):
+        ledfx.venues = VenueManager(ledfx)
+    return ledfx.venues
+
+
+class VenueOverrideEndpoint(RestEndpoint):
+    """REST end-point for color override pads on a venue.
+
+    POST  — activate override from a specific pad index.
+    DELETE — clear the override (restore running effects).
+    """
+
+    ENDPOINT_PATH = "/api/venues/{venue_id}/override"
+
+    async def post(self, venue_id, request: web.Request) -> web.Response:
+        """Activate a color pad override on all virtuals in the venue.
+
+        Body::
+
+            { "pad_index": int }  # 0-based, row-major
+        """
+        try:
+            data = await request.json()
+        except JSONDecodeError:
+            return await self.json_decode_error()
+
+        pad_index = data.get("pad_index")
+        if pad_index is None:
+            return await self.invalid_request(
+                'Required attribute "pad_index" was not provided'
+            )
+
+        try:
+            pad_index = int(pad_index)
+        except (TypeError, ValueError):
+            return await self.invalid_request('"pad_index" must be an integer')
+
+        mgr = _ensure_manager(self._ledfx)
+        try:
+            mgr.activate_override(venue_id, pad_index)
+        except KeyError as e:
+            return await self.invalid_request(str(e))
+        except IndexError as e:
+            return await self.invalid_request(str(e))
+        except Exception as e:
+            _LOGGER.warning("Override activation error: %s", e)
+            return await self.invalid_request(str(e))
+
+        return await self.request_success(
+            type="success",
+            message=f"Color override activated (pad {pad_index}) on venue '{venue_id}'",
+        )
+
+    async def delete(self, venue_id) -> web.Response:
+        """Clear the color override — running effects immediately resume."""
+        mgr = _ensure_manager(self._ledfx)
+        try:
+            mgr.clear_override(venue_id)
+        except KeyError as e:
+            return await self.invalid_request(str(e))
+
+        return await self.request_success(
+            type="success",
+            message=f"Color override cleared on venue '{venue_id}'",
+        )

--- a/ledfx/api/venues.py
+++ b/ledfx/api/venues.py
@@ -1,0 +1,64 @@
+import logging
+from json import JSONDecodeError
+
+from aiohttp import web
+
+from ledfx.api import RestEndpoint
+from ledfx.venues import VenueManager
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _ensure_manager(ledfx) -> VenueManager:
+    if not hasattr(ledfx, "venues"):
+        ledfx.venues = VenueManager(ledfx)
+    return ledfx.venues
+
+
+class VenuesEndpoint(RestEndpoint):
+    """REST end-point for querying and managing venues (collection)."""
+
+    ENDPOINT_PATH = "/api/venues"
+
+    async def get(self) -> web.Response:
+        """List all venues."""
+        mgr = _ensure_manager(self._ledfx)
+        venues = mgr.list_venues()
+        result = [{"id": vid, **cfg} for vid, cfg in venues.items()]
+        return await self.bare_request_success({"venues": result})
+
+    async def post(self, request: web.Request) -> web.Response:
+        """Create a new venue.
+
+        Body: ``{ "name": str, "rows": int (optional, default 4), "cols": int (optional, default 4) }``
+        """
+        try:
+            data = await request.json()
+        except JSONDecodeError:
+            return await self.json_decode_error()
+
+        name = data.get("name")
+        if not name:
+            return await self.invalid_request(
+                'Required attribute "name" was not provided'
+            )
+
+        rows = int(data.get("rows", 4))
+        cols = int(data.get("cols", 4))
+        if rows < 1 or cols < 1:
+            return await self.invalid_request(
+                '"rows" and "cols" must be positive integers'
+            )
+
+        try:
+            mgr = _ensure_manager(self._ledfx)
+            venue = mgr.create(name=name, rows=rows, cols=cols)
+        except Exception as e:
+            _LOGGER.warning("Failed to create venue: %s", e)
+            return await self.invalid_request(str(e))
+
+        return await self.request_success(
+            type="success",
+            message=f"Created venue '{name}'",
+            data={"venue": venue},
+        )

--- a/ledfx/api/virtual.py
+++ b/ledfx/api/virtual.py
@@ -181,6 +181,10 @@ class VirtualEndpoint(RestEndpoint):
                 if _device["id"] != device_id
             ]
 
+        # cleanup this virtual from any venues
+        if hasattr(self._ledfx, "venues"):
+            self._ledfx.venues.cleanup_virtual(virtual_id)
+
         # cleanup this virtual from any scenes
         ledfx_scenes = self._ledfx.config["scenes"].copy()
         for scene_id, scene_config in ledfx_scenes.items():

--- a/ledfx/config.py
+++ b/ledfx/config.py
@@ -195,6 +195,7 @@ CORE_CONFIG_SCHEMA = vol.Schema(
         vol.Optional("sendspin_servers", default={}): dict,
         vol.Optional("sendspin_always_on", default=False): bool,
         vol.Optional("now_playing", default={}): dict,
+        vol.Optional("venues", default={}): dict,
     },
     extra=vol.ALLOW_EXTRA,
 )

--- a/ledfx/effects/gradient.py
+++ b/ledfx/effects/gradient.py
@@ -36,6 +36,7 @@ class GradientEffect(Effect):
 
     _gradient_curve = None
     _gradient_roll_counter = 0
+    _gradient_override: "Optional[str]" = None  # venue colour override
 
     def _comb(self, N, k):
         N = int(N)
@@ -120,14 +121,33 @@ class GradientEffect(Effect):
         return max(self.pixel_count, 256)
 
     def _assert_gradient(self):
+        gradient_src = (
+            self._gradient_override
+            if self._gradient_override is not None
+            else self._config["gradient"]
+        )
         if (
             self._gradient_curve is None  # Uninitialized gradient
             or len(self._gradient_curve[0])
             != self.gradient_pixel_count  # Incorrect size
         ):
             self._generate_gradient_curve(
-                self._config["gradient"],
+                gradient_src,
                 self.gradient_pixel_count,
+            )
+
+    def set_gradient_override(self, gradient_str: str):
+        """Inject a temporary gradient override; the effect continues animating."""
+        with self.lock:
+            self._gradient_override = gradient_str
+            self._gradient_curve = None  # force rebuild on next frame
+
+    def clear_gradient_override(self):
+        """Restore the original gradient from config."""
+        with self.lock:
+            self._gradient_override = None
+            self._gradient_curve = (
+                None  # force rebuild from config on next frame
             )
 
     def roll_gradient(self):

--- a/ledfx/venues.py
+++ b/ledfx/venues.py
@@ -1,0 +1,237 @@
+"""Venue manager for LedFx.
+
+A venue is a named collection of virtuals. It provides:
+  - a filtered view: only that venue's virtuals are shown in the UI
+  - a color-override pad grid (NxM): each pad holds a solid color or gradient
+    string; activating a pad overpaints all venue virtuals until cleared.
+
+Venues are persisted in config.json under the "venues" key as a dict keyed
+by venue ID.  Each value has the shape:
+
+    {
+        "name": str,
+        "virtual_ids": [str, ...],          # virtuals belonging to this venue
+        "color_pads": {
+            "rows": int,                    # grid height
+            "cols": int,                    # grid width
+            "pads": [                       # flat list, row-major order
+                {"color": "#rrggbb"},       # solid color pad
+                {"gradient": "linear-gradient(...)"},  # gradient pad
+                ...
+            ]
+        }
+    }
+
+Exclusive membership is enforced: a virtual may belong to at most one venue.
+"""
+
+from __future__ import annotations
+
+import colorsys
+import logging
+from typing import Optional
+
+from ledfx.config import save_config
+from ledfx.utils import generate_id
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _hsl_auto_palette(n: int) -> list[dict]:
+    """Return *n* evenly-spaced hue colors as pad dicts."""
+    pads = []
+    for i in range(n):
+        hue = i / n
+        r, g, b = colorsys.hls_to_rgb(hue, 0.5, 1.0)
+        hex_color = "#{:02x}{:02x}{:02x}".format(
+            int(r * 255), int(g * 255), int(b * 255)
+        )
+        pads.append({"color": hex_color})
+    return pads
+
+
+class VenueManager:
+    """Manages venues in LedFx config."""
+
+    def __init__(self, ledfx):
+        self._ledfx = ledfx
+
+    @property
+    def _venues(self) -> dict:
+        return self._ledfx.config.setdefault("venues", {})
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _find_venue_for_virtual(self, virtual_id: str) -> Optional[str]:
+        """Return the venue ID that owns *virtual_id*, or None."""
+        for vid, cfg in self._venues.items():
+            if virtual_id in cfg.get("virtual_ids", []):
+                return vid
+        return None
+
+    def _save(self):
+        save_config(
+            config=self._ledfx.config,
+            config_dir=self._ledfx.config_dir,
+        )
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    def list_venues(self) -> dict:
+        return dict(self._venues)
+
+    def get(self, venue_id: str) -> Optional[dict]:
+        return self._venues.get(venue_id)
+
+    def create(self, name: str, rows: int = 4, cols: int = 4) -> dict:
+        """Create a new venue with an auto-filled color pad grid."""
+        venue_id = generate_id(name)
+        # Deduplicate ID
+        base_id = venue_id
+        idx = 1
+        while venue_id in self._venues:
+            venue_id = f"{base_id}-{idx}"
+            idx += 1
+
+        n_pads = rows * cols
+        venue_cfg = {
+            "name": name,
+            "virtual_ids": [],
+            "color_pads": {
+                "rows": rows,
+                "cols": cols,
+                "pads": _hsl_auto_palette(n_pads),
+            },
+        }
+        self._venues[venue_id] = venue_cfg
+        self._save()
+        _LOGGER.info("Created venue '%s' (%s)", name, venue_id)
+        return {"id": venue_id, **venue_cfg}
+
+    def update(self, venue_id: str, data: dict) -> dict:
+        """Update name and/or color_pads config for a venue.
+
+        Supported keys in *data*: ``name``, ``color_pads``.
+        To resize the grid pass ``color_pads`` with ``rows``/``cols``; the pads
+        list will be re-initialised to an auto-palette unless ``pads`` is also
+        supplied.
+        """
+        cfg = self._venues.get(venue_id)
+        if cfg is None:
+            raise KeyError(f"Venue '{venue_id}' not found")
+
+        if "name" in data:
+            cfg["name"] = str(data["name"])
+
+        if "color_pads" in data:
+            cp = data["color_pads"]
+            rows = int(cp.get("rows", cfg["color_pads"]["rows"]))
+            cols = int(cp.get("cols", cfg["color_pads"]["cols"]))
+            n_pads = rows * cols
+            if "pads" in cp and len(cp["pads"]) == n_pads:
+                pads = list(cp["pads"])
+            else:
+                pads = _hsl_auto_palette(n_pads)
+            cfg["color_pads"] = {"rows": rows, "cols": cols, "pads": pads}
+
+        self._save()
+        return {"id": venue_id, **cfg}
+
+    def delete(self, venue_id: str) -> bool:
+        """Delete a venue and clear any active overrides on its virtuals."""
+        cfg = self._venues.pop(venue_id, None)
+        if cfg is None:
+            return False
+        # Clear any active color overrides
+        for vid in cfg.get("virtual_ids", []):
+            v = self._ledfx.virtuals.get(vid)
+            if v is not None:
+                v.clear_color_override()
+        self._save()
+        _LOGGER.info("Deleted venue '%s'", venue_id)
+        return True
+
+    # ------------------------------------------------------------------
+    # Virtual membership
+    # ------------------------------------------------------------------
+
+    def add_virtual(self, venue_id: str, virtual_id: str) -> dict:
+        """Add *virtual_id* to *venue_id* (exclusive membership enforced)."""
+        cfg = self._venues.get(venue_id)
+        if cfg is None:
+            raise KeyError(f"Venue '{venue_id}' not found")
+
+        if self._ledfx.virtuals.get(virtual_id) is None:
+            raise ValueError(f"Virtual '{virtual_id}' not found")
+
+        existing = self._find_venue_for_virtual(virtual_id)
+        if existing and existing != venue_id:
+            raise ValueError(
+                f"Virtual '{virtual_id}' already belongs to venue '{existing}'"
+            )
+
+        if virtual_id not in cfg["virtual_ids"]:
+            cfg["virtual_ids"].append(virtual_id)
+            self._save()
+
+        return {"id": venue_id, **cfg}
+
+    def remove_virtual(self, venue_id: str, virtual_id: str) -> dict:
+        """Remove *virtual_id* from *venue_id* and clear its override."""
+        cfg = self._venues.get(venue_id)
+        if cfg is None:
+            raise KeyError(f"Venue '{venue_id}' not found")
+
+        if virtual_id in cfg["virtual_ids"]:
+            cfg["virtual_ids"].remove(virtual_id)
+            v = self._ledfx.virtuals.get(virtual_id)
+            if v is not None:
+                v.clear_color_override()
+            self._save()
+
+        return {"id": venue_id, **cfg}
+
+    def cleanup_virtual(self, virtual_id: str):
+        """Remove *virtual_id* from whichever venue owns it (called on virtual delete)."""
+        owner = self._find_venue_for_virtual(virtual_id)
+        if owner:
+            self.remove_virtual(owner, virtual_id)
+
+    # ------------------------------------------------------------------
+    # Override helpers
+    # ------------------------------------------------------------------
+
+    def activate_override(self, venue_id: str, pad_index: int):
+        """Apply the color/gradient from pad *pad_index* to all venue virtuals."""
+        cfg = self._venues.get(venue_id)
+        if cfg is None:
+            raise KeyError(f"Venue '{venue_id}' not found")
+
+        pads = cfg["color_pads"]["pads"]
+        if pad_index < 0 or pad_index >= len(pads):
+            raise IndexError(
+                f"Pad index {pad_index} out of range (0-{len(pads) - 1})"
+            )
+
+        pad = pads[pad_index]
+        color_or_gradient = pad.get("gradient") or pad.get("color", "#ffffff")
+
+        for vid in cfg["virtual_ids"]:
+            v = self._ledfx.virtuals.get(vid)
+            if v is not None:
+                v.set_color_override(color_or_gradient)
+
+    def clear_override(self, venue_id: str):
+        """Clear the color override from all virtuals in *venue_id*."""
+        cfg = self._venues.get(venue_id)
+        if cfg is None:
+            raise KeyError(f"Venue '{venue_id}' not found")
+
+        for vid in cfg["virtual_ids"]:
+            v = self._ledfx.virtuals.get(vid)
+            if v is not None:
+                v.clear_color_override()

--- a/ledfx/venues.py
+++ b/ledfx/venues.py
@@ -64,7 +64,7 @@ class VenueManager:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _find_venue_for_virtual(self, virtual_id: str) -> Optional[str]:
+    def _find_venue_for_virtual(self, virtual_id: str) -> str | None:
         """Return the venue ID that owns *virtual_id*, or None."""
         for vid, cfg in self._venues.items():
             if virtual_id in cfg.get("virtual_ids", []):
@@ -84,7 +84,7 @@ class VenueManager:
     def list_venues(self) -> dict:
         return dict(self._venues)
 
-    def get(self, venue_id: str) -> Optional[dict]:
+    def get(self, venue_id: str) -> dict | None:
         return self._venues.get(venue_id)
 
     def create(self, name: str, rows: int = 4, cols: int = 4) -> dict:

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -32,6 +32,45 @@ from ledfx.utils import Teleplot, fps_to_sleep_interval, is_gap_device
 _LOGGER = logging.getLogger(__name__)
 
 
+def _apply_gradient_override(
+    frame: np.ndarray, lut: np.ndarray, lut_size: int
+) -> np.ndarray:
+    """Recolour *frame* using a gradient LUT indexed by per-pixel hue.
+
+    The effect's per-pixel **brightness** (HSV value = max RGB channel) is
+    preserved so beats, scrolls, and animations continue to show motion.
+    The *hue* of each pixel is used to select which gradient colour to use,
+    so a scrolling rainbow remaps cleanly to the override gradient palette.
+
+    Args:
+        frame:    N×3 float array (0–255), the assembled effect output.
+        lut:      L×3 float array (0–255), pre-sampled gradient at L positions.
+        lut_size: number of LUT entries (L).
+
+    Returns:
+        N×3 float array with gradient colours scaled by the effect's brightness.
+    """
+    f = frame / 255.0  # (N, 3) in [0, 1]
+    r, g, b = f[:, 0], f[:, 1], f[:, 2]
+    maxc = np.maximum(np.maximum(r, g), b)  # HSV value (brightness)
+    minc = np.minimum(np.minimum(r, g), b)
+    diff = maxc - minc
+
+    hue = np.zeros(len(frame), dtype=float)
+    chromatic = diff > 1e-6
+    mr = chromatic & (r == maxc)
+    mg = chromatic & (g == maxc) & ~mr
+    mb = chromatic & (b == maxc) & ~mr & ~mg
+    hue[mr] = ((g[mr] - b[mr]) / diff[mr]) % 6
+    hue[mg] = (b[mg] - r[mg]) / diff[mg] + 2
+    hue[mb] = (r[mb] - g[mb]) / diff[mb] + 4
+    hue /= 6.0  # normalise to [0, 1]
+
+    indices = np.clip((hue * (lut_size - 1)).astype(int), 0, lut_size - 1)
+    # Scale gradient colour by the effect's per-pixel brightness
+    return lut[indices] * maxc[:, np.newaxis]
+
+
 class Virtual:
     CONFIG_SCHEMA = vol.Schema(
         {
@@ -209,6 +248,13 @@ class Virtual:
         # Maps virtual indices to device indices per device
         self._device_remap: dict = {}
 
+        # Color override: when set, overpaints assembled_frame before flush.
+        # Effects keep running in the background; override is instant on/off.
+        self._color_override: Optional[str] = None
+        self._color_override_frame: Optional[np.ndarray] = None
+        # For gradient overrides: 1024-entry LUT sampled by per-pixel hue.
+        self._color_override_lut: Optional[np.ndarray] = None
+
         self._debug_flush_total = 0.0
         self._debug_last_report = time.perf_counter()
         self._debug_flush_frames = 0
@@ -383,6 +429,9 @@ class Virtual:
                 if self.pixel_count != _pixel_count:
                     # chenging segments is a deep edit, just flush any transition
                     self._reactivate_effect()
+                    # Rebuild override frame if pixel count changed
+                    if self._color_override is not None:
+                        self._apply_color_override_to_effect()
 
                 mode = self._config["transition_mode"]
                 self.frame_transitions = self.transitions[mode]
@@ -652,6 +701,9 @@ class Virtual:
                 )
                 return
             self._active_effect.activate(self)
+            # Re-apply any active colour override to the new effect
+            if self._color_override is not None:
+                self._apply_color_override_to_effect()
             self._ledfx.events.fire_event(
                 EffectSetEvent(
                     self._active_effect.name,
@@ -779,6 +831,113 @@ class Virtual:
         self.flush(self.assembled_frame)
         self._fire_update_event()
 
+    _GRADIENT_LUT_SIZE = 1024
+
+    def _build_override_frame(self):
+        """Build override data from the stored color/gradient string.
+
+        Returns:
+            (spatial_frame, gradient_lut) where:
+            - spatial_frame: N×3 float array, gradient sampled at pixel positions.
+              Used for solid colors, and as the static "preview" for gradients.
+            - gradient_lut: 1024×3 float array sampled uniformly 0→1, or None for
+              solid colors. Used at render time: per-pixel hue → LUT index → color.
+        """
+        if self._color_override is None or self.pixel_count == 0:
+            return None, None
+
+        from ledfx.color import RGB, Gradient, parse_gradient
+
+        try:
+            parsed = parse_gradient(self._color_override)
+        except Exception:
+            _LOGGER.warning(
+                "Virtual %s: invalid color override '%s', using white",
+                self.id,
+                self._color_override,
+            )
+            parsed = RGB(255, 255, 255)
+
+        n = self.pixel_count
+
+        if isinstance(parsed, RGB):
+            spatial = np.tile(
+                [parsed.red, parsed.green, parsed.blue], (n, 1)
+            ).astype(float)
+            return spatial, None  # solid colour: no LUT needed
+
+        # Gradient: build spatial frame (for static pad preview) + LUT
+        def _sample_hex(gradient, pos):
+            hex_c = gradient.sample(pos)
+            return (
+                int(hex_c[1:3], 16),
+                int(hex_c[3:5], 16),
+                int(hex_c[5:7], 16),
+            )
+
+        spatial = np.empty((n, 3), dtype=float)
+        for i in range(n):
+            r, g, b = _sample_hex(parsed, i / max(n - 1, 1))
+            spatial[i] = [r, g, b]
+
+        lut_size = self._GRADIENT_LUT_SIZE
+        lut = np.empty((lut_size, 3), dtype=float)
+        for i in range(lut_size):
+            r, g, b = _sample_hex(parsed, i / (lut_size - 1))
+            lut[i] = [r, g, b]
+
+        return spatial, lut
+
+    def _apply_color_override_to_effect(self):
+        """Internal: route override to the effect or to post-processing.
+
+        Called (inside self.lock) whenever the override is activated or the
+        pixel count changes while an override is active.
+        """
+        from ledfx.effects.gradient import GradientEffect
+
+        if self._color_override is None:
+            return
+
+        if isinstance(self._active_effect, GradientEffect):
+            # The effect handles colour natively — inject the override gradient
+            # so animations (roll, modulation, etc.) continue unaffected.
+            self._active_effect.set_gradient_override(self._color_override)
+            # No post-processing needed
+            self._color_override_frame = None
+            self._color_override_lut = None
+        else:
+            # Fallback: post-process the assembled frame for effects that don't
+            # expose a gradient config (e.g. Energy, custom solid-colour effects).
+            self._color_override_frame, self._color_override_lut = (
+                self._build_override_frame()
+            )
+
+    def set_color_override(self, color_or_gradient: str):
+        """Activate a persistent colour override on this virtual.
+
+        For GradientEffect-based effects the override is injected directly into
+        the effect's gradient curve, so all animations continue in the new
+        colours (identical to changing the effect's colour via the UI).
+
+        For other effects the assembled frame is post-processed each cycle
+        using a luminance-preserving tint.
+        """
+        with self.lock:
+            self._color_override = color_or_gradient
+            self._apply_color_override_to_effect()
+
+    def clear_color_override(self):
+        """Remove the colour override; the running effect is immediately visible again."""
+        from ledfx.effects.gradient import GradientEffect
+
+        with self.lock:
+            self._color_override = None
+            self._color_override_frame = None
+            self._color_override_lut = None
+            if isinstance(self._active_effect, GradientEffect):
+                self._active_effect.clear_gradient_override()
+
     def _fire_update_event(self, frame=None):
         if frame is None:
             frame = self.assembled_frame
@@ -844,6 +1003,27 @@ class Virtual:
                     # )
                     self.assembled_frame = self.assemble_frame()
                     if self.assembled_frame is not None and not self._paused:
+                        # Apply color override as a gel/tint keeping the effect's animation.
+                        if self._color_override_lut is not None:
+                            # Gradient override: map each pixel's hue to the gradient LUT,
+                            # preserving the effect's per-pixel brightness (animation).
+                            self.assembled_frame = _apply_gradient_override(
+                                self.assembled_frame,
+                                self._color_override_lut,
+                                self._GRADIENT_LUT_SIZE,
+                            )
+                        elif self._color_override_frame is not None:
+                            # Solid colour override: tint by per-pixel luminance so the
+                            # effect's brightness pattern (beats, pulses) is preserved.
+                            luminance = (
+                                np.max(
+                                    self.assembled_frame, axis=1, keepdims=True
+                                )
+                                / 255.0
+                            )
+                            self.assembled_frame = (
+                                self._color_override_frame * luminance
+                            )
                         if not self._config["preview_only"]:
                             # self._ledfx.thread_executor.submit(self.flush)
                             # await self._ledfx.loop.run_in_executor(

--- a/tests/test_venues.py
+++ b/tests/test_venues.py
@@ -1,0 +1,200 @@
+"""Tests for the Venues system: CRUD, exclusive virtual membership, and
+color/gradient override activation."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ledfx.venues import VenueManager, _hsl_auto_palette
+
+
+def _make_ledfx():
+    """Build a minimal ledfx stand-in with an in-memory config and a
+    virtuals registry mock."""
+    ledfx = MagicMock()
+    ledfx.config = {}
+    ledfx.virtuals = MagicMock()
+    ledfx._virtuals_by_id = {}
+    ledfx.virtuals.get.side_effect = lambda vid: ledfx._virtuals_by_id.get(vid)
+    return ledfx
+
+
+@pytest.fixture(autouse=True)
+def _no_disk_writes():
+    """VenueManager persists to config.json on every mutation; these are
+    pure logic tests so stub out the disk write."""
+    with patch("ledfx.venues.save_config"):
+        yield
+
+
+def _add_virtual(ledfx, virtual_id):
+    v = MagicMock()
+    ledfx._virtuals_by_id[virtual_id] = v
+    return v
+
+
+@pytest.fixture
+def ledfx():
+    return _make_ledfx()
+
+
+@pytest.fixture
+def mgr(ledfx):
+    return VenueManager(ledfx)
+
+
+def test_hsl_auto_palette_length_and_shape():
+    pads = _hsl_auto_palette(6)
+    assert len(pads) == 6
+    for pad in pads:
+        assert "color" in pad
+        assert pad["color"].startswith("#")
+        assert len(pad["color"]) == 7
+
+
+def test_create_venue_defaults(mgr):
+    venue = mgr.create(name="Living Room")
+    assert venue["name"] == "Living Room"
+    assert venue["virtual_ids"] == []
+    assert venue["color_pads"]["rows"] == 4
+    assert venue["color_pads"]["cols"] == 4
+    assert len(venue["color_pads"]["pads"]) == 16
+
+
+def test_create_venue_dedupes_id(mgr):
+    v1 = mgr.create(name="Patio")
+    v2 = mgr.create(name="Patio")
+    assert v1["id"] != v2["id"]
+
+
+def test_list_and_get_venue(mgr):
+    created = mgr.create(name="Deck", rows=2, cols=2)
+    venue_id = created["id"]
+
+    listed = mgr.list_venues()
+    assert venue_id in listed
+
+    fetched = mgr.get(venue_id)
+    assert fetched["name"] == "Deck"
+    assert mgr.get("does-not-exist") is None
+
+
+def test_update_venue_name_and_grid(mgr):
+    created = mgr.create(name="Garage", rows=2, cols=2)
+    venue_id = created["id"]
+
+    updated = mgr.update(venue_id, {"name": "Garage 2"})
+    assert updated["name"] == "Garage 2"
+
+    resized = mgr.update(venue_id, {"color_pads": {"rows": 3, "cols": 3}})
+    assert resized["color_pads"]["rows"] == 3
+    assert resized["color_pads"]["cols"] == 3
+    assert len(resized["color_pads"]["pads"]) == 9
+
+
+def test_update_missing_venue_raises(mgr):
+    with pytest.raises(KeyError):
+        mgr.update("nope", {"name": "x"})
+
+
+def test_add_virtual_success(mgr, ledfx):
+    venue = mgr.create(name="Studio")
+    _add_virtual(ledfx, "v1")
+
+    updated = mgr.add_virtual(venue["id"], "v1")
+    assert "v1" in updated["virtual_ids"]
+
+
+def test_add_virtual_missing_virtual_raises(mgr):
+    venue = mgr.create(name="Studio2")
+    with pytest.raises(ValueError):
+        mgr.add_virtual(venue["id"], "ghost")
+
+
+def test_add_virtual_exclusive_membership(mgr, ledfx):
+    venue_a = mgr.create(name="A")
+    venue_b = mgr.create(name="B")
+    _add_virtual(ledfx, "v1")
+
+    mgr.add_virtual(venue_a["id"], "v1")
+    with pytest.raises(ValueError):
+        mgr.add_virtual(venue_b["id"], "v1")
+
+
+def test_remove_virtual_clears_override(mgr, ledfx):
+    venue = mgr.create(name="C")
+    v1 = _add_virtual(ledfx, "v1")
+    mgr.add_virtual(venue["id"], "v1")
+
+    mgr.remove_virtual(venue["id"], "v1")
+    v1.clear_color_override.assert_called_once()
+    assert "v1" not in mgr.get(venue["id"])["virtual_ids"]
+
+
+def test_cleanup_virtual_removes_from_owning_venue(mgr, ledfx):
+    venue = mgr.create(name="D")
+    v1 = _add_virtual(ledfx, "v1")
+    mgr.add_virtual(venue["id"], "v1")
+
+    mgr.cleanup_virtual("v1")
+    assert "v1" not in mgr.get(venue["id"])["virtual_ids"]
+    v1.clear_color_override.assert_called_once()
+
+
+def test_delete_venue_clears_overrides_and_removes(mgr, ledfx):
+    venue = mgr.create(name="E")
+    v1 = _add_virtual(ledfx, "v1")
+    mgr.add_virtual(venue["id"], "v1")
+
+    assert mgr.delete(venue["id"]) is True
+    v1.clear_color_override.assert_called_once()
+    assert mgr.get(venue["id"]) is None
+    assert mgr.delete(venue["id"]) is False
+
+
+def test_activate_override_solid_color(mgr, ledfx):
+    venue = mgr.create(name="F", rows=1, cols=1)
+    v1 = _add_virtual(ledfx, "v1")
+    mgr.add_virtual(venue["id"], "v1")
+
+    pad_color = mgr.get(venue["id"])["color_pads"]["pads"][0]["color"]
+    mgr.activate_override(venue["id"], 0)
+    v1.set_color_override.assert_called_once_with(pad_color)
+
+
+def test_activate_override_gradient_pad(mgr, ledfx):
+    venue = mgr.create(name="G", rows=1, cols=1)
+    v1 = _add_virtual(ledfx, "v1")
+    mgr.add_virtual(venue["id"], "v1")
+
+    gradient = "linear-gradient(90deg, #ff0000, #0000ff)"
+    mgr._venues[venue["id"]]["color_pads"]["pads"][0] = {"gradient": gradient}
+
+    mgr.activate_override(venue["id"], 0)
+    v1.set_color_override.assert_called_once_with(gradient)
+
+
+def test_activate_override_invalid_pad_index_raises(mgr, ledfx):
+    venue = mgr.create(name="H", rows=1, cols=1)
+    _add_virtual(ledfx, "v1")
+    mgr.add_virtual(venue["id"], "v1")
+
+    with pytest.raises(IndexError):
+        mgr.activate_override(venue["id"], 99)
+
+
+def test_clear_override_calls_clear_on_all_virtuals(mgr, ledfx):
+    venue = mgr.create(name="I")
+    v1 = _add_virtual(ledfx, "v1")
+    v2 = _add_virtual(ledfx, "v2")
+    mgr.add_virtual(venue["id"], "v1")
+    mgr.add_virtual(venue["id"], "v2")
+
+    mgr.clear_override(venue["id"])
+    v1.clear_color_override.assert_called_once()
+    v2.clear_color_override.assert_called_once()
+
+
+def test_clear_override_missing_venue_raises(mgr):
+    with pytest.raises(KeyError):
+        mgr.clear_override("nope")


### PR DESCRIPTION
## Summary
Adds a **Venues** system: a named collection of virtuals with a color/gradient override "pad grid". Activating a pad tints all virtuals in the venue with that color or gradient while preserving the running effect's animation; clearing the override instantly restores the effect.

## What's included
- `ledfx/venues.py` - `VenueManager`: CRUD, exclusive virtual membership (a virtual belongs to at most one venue), auto-generated HSV pad palette, activate/clear override helpers.
- `ledfx/virtuals.py` - color override mechanism:
  - Solid-color overrides tint the assembled frame via per-pixel luminance (gel/tint, not a full replace) so brightness/animation patterns are preserved.
  - For `GradientEffect`-based effects, the override is injected directly into the effect's gradient curve (mirrors what the UI does when changing an effect's color), so palette changes without freezing animation.
  - Re-applies an active override automatically when a new effect is set on the virtual.
- `ledfx/effects/gradient.py` - `set_gradient_override()` / `clear_gradient_override()` to swap the gradient curve source without touching roll/modulation/beat-response logic.
- `ledfx/api/venues.py`, `ledfx/api/venue.py`, `ledfx/api/venue_override.py` - REST endpoints: list/create venues, get/update/delete a venue + manage virtual membership, activate/clear a pad override.
- `ledfx/api/virtual.py` - wires `VenueManager.cleanup_virtual()` into virtual deletion so removing a virtual cleans up its venue membership.
- `ledfx/config.py` - adds `venues` key to `CORE_CONFIG_SCHEMA`.

## Testing
- Added `tests/test_venues.py` (17 tests): venue CRUD, ID de-duplication, grid resize, exclusive virtual membership enforcement, override clearing on virtual/venue removal, solid-color and gradient pad activation, error paths (missing venue, invalid pad index).
- Full suite: `uv run pytest` result: 996 passed, 13 skipped, 0 regressions.
- `uv run black --check` / `uv run flake8` clean.

## Related
Companion frontend PR: YeonV/LedFx-Frontend-v2#133 (Venues page, pad grid UI, live preview) — tested with a new Playwright spec, full suite green (one pre-existing flaky spec confirmed unrelated).

Split out of a larger mixed branch to keep this PR focused on the Venues feature only. A separate follow-up PR (#1839, draft) adds DMX Input integration, which builds on this override mechanism.
