### PR TITLE
Feat(dmx_input): pause/mute controls (global, venue, device)

### DIFF
--- a/docs/howto/soundswitch_dmx.md
+++ b/docs/howto/soundswitch_dmx.md
@@ -1,0 +1,125 @@
+# How to: Control LedFx from SoundSwitch (DMX Input)
+
+The **DMX Input** integration lets an external DMX source drive LedFx in
+real time. It was built for [SoundSwitch](https://www.soundswitch.com/), but
+works with any controller that can emit
+[Art-Net](https://art-net.org.uk/) (QLC+, lighting consoles, DMX-over-Art-Net
+software, etc.).
+
+The key idea: you do **not** need any extra hardware or a separate bridge.
+SoundSwitch can output Art-Net over the network **at the same time** as it
+drives your real fixtures through its USB-DMX interface. LedFx simply listens
+to that Art-Net stream on `127.0.0.1` and maps DMX channels to LedFx actions.
+
+## What you can do with it
+
+Each *mapping* connects one or more DMX channels to a LedFx target. There are
+three mapping types:
+
+1. **Trigger** &mdash; a button / static-look channel toggles a **venue color
+   pad override**. When the channel goes high the pad's color or gradient is
+   applied to every virtual in the venue; when it goes low the override is
+   released. Edge detection uses hysteresis (separate on/off thresholds) so a
+   noisy channel does not flicker.
+2. **Color** &mdash; live **R/G/B passthrough**. The target's effect keeps
+   animating, but its colors are recolored to the incoming DMX color in real
+   time (the same mechanism as a venue color override).
+3. **Fixture / wash** &mdash; treat a virtual like a dumb DMX wash. A
+   **mode-toggle** channel switches the virtual between "run the LedFx effect"
+   and "act as a solid wash" driven by a **dimmer** channel and **R/G/B**
+   channels. Toggle it back off and the current effect is revealed again.
+
+## Step 1 &mdash; Enable Art-Net output in SoundSwitch
+
+In SoundSwitch, add an **Art-Net** output **in addition to** your existing
+USB-DMX interface, and mirror the universe(s) you want LedFx to see:
+
+- **Destination IP:** `127.0.0.1` (loopback &mdash; LedFx runs on the same PC).
+  If LedFx runs on another machine, use that machine's IP instead.
+- **Universe:** match the universe(s) your fixtures / buttons use. Note
+  whether SoundSwitch numbers universes from 0 or 1 &mdash; LedFx mappings use
+  the raw Art-Net Port-Address (0-based) by default.
+- Keep your USB-DMX interface enabled so your real fixtures are unaffected.
+
+> SoundSwitch's "signal" is just DMX. By mirroring it over Art-Net you get a
+> clean, documented copy of exactly what your faders and buttons are sending.
+
+## Step 2 &mdash; Add the DMX Input integration in LedFx
+
+1. Go to **Settings &rarr; Integrations** and add a **DMX Input** integration.
+2. Configuration options:
+   - **bind_address** (default `127.0.0.1`) &mdash; the local address LedFx
+     listens on. Use `0.0.0.0` to accept Art-Net from other machines.
+   - **port** (default `6454`) &mdash; the standard Art-Net UDP port. If
+     LedFx's own Art-Net *output* or another Art-Net node already uses this
+     port, you will see a bind error in the log; free the port or change it.
+   - **update_fps** (default `60`) &mdash; how often incoming DMX is applied.
+   - **stale_timeout** (default `2.0` s) &mdash; if the Art-Net stream stops,
+     LedFx releases any overrides/washes it owns after this many seconds.
+   - **hold_last_look** (default off) &mdash; keep the last look instead of
+     releasing it when the stream stops.
+3. Toggle the integration **on**. The log should show
+   `DMX Input listening for Art-Net on 127.0.0.1:6454`.
+
+## Step 3 &mdash; Find the right channel (DMX learn)
+
+Not sure which channel a SoundSwitch button uses? Watch the **live DMX**
+values while you press it:
+
+- The integration exposes the latest DMX values per universe via its REST
+  endpoint, so you can see which channel jumps when you press a button or push
+  a fader. Use that channel number in your mapping.
+
+## Step 4 &mdash; Create mappings
+
+Add a mapping for each control you want to bridge.
+
+**Trigger (button &rarr; venue pad override)**
+
+| Field          | Example         |
+| -------------- | --------------- |
+| type           | `trigger`       |
+| universe       | `0`             |
+| channel        | `1`             |
+| venue          | your venue      |
+| pad            | pad index       |
+| on / off       | `128` / `96`    |
+
+**Color (live recolor)**
+
+| Field          | Example             |
+| -------------- | ------------------- |
+| type           | `color`             |
+| universe       | `0`                 |
+| channels       | R, G, B (e.g. 1-3)  |
+| target         | a venue or virtual  |
+
+**Fixture / wash**
+
+| Field          | Example                       |
+| -------------- | ----------------------------- |
+| type           | `fixture`                     |
+| universe       | `1`                           |
+| channels       | mode, dimmer, R, G, B         |
+| target virtual | the LED run to use as a wash  |
+| on / off       | `128` / `96` (mode toggle)    |
+
+When the **mode** channel is high the virtual outputs a solid `RGB x dimmer`
+wash; when it is low the virtual's normal LedFx effect plays again.
+
+## Tips
+
+- LedFx only changes the **color** of the running effect for trigger/color
+  mappings &mdash; the animation keeps playing. Fixture mode is the only mode
+  that replaces the effect with a solid wash.
+- LedFx releases only the overrides/washes **it** owns, so you can still
+  control effects normally from the LedFx UI alongside DMX control.
+- If a channel is already high when LedFx starts, it will **not** auto-fire;
+  LedFx waits for a fresh low&rarr;high edge.
+
+## Optional: wireless / USB DMX input
+
+The same mapping engine is transport-agnostic. A future option is to capture
+physical or wireless DMX with a USB DMX-input interface and feed it to the
+same mappings &mdash; useful if you would rather add LedFx as another
+"fixture" in SoundSwitch and steer it with a DMX wash channel.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,7 @@
    /howto/complex_segments
    /howto/reorder
    /howto/alpha
+   /howto/soundswitch_dmx
 
 .. toctree::
    :maxdepth: 2

--- a/ledfx/api/integration_dmx_input.py
+++ b/ledfx/api/integration_dmx_input.py
@@ -1,0 +1,131 @@
+import logging
+from json import JSONDecodeError
+
+from aiohttp import web
+
+from ledfx.api import RestEndpoint
+from ledfx.config import save_config
+from ledfx.venues import VenueManager
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DMXInputEndpoint(RestEndpoint):
+    """REST end-point for managing a DMX Input integration's channel mappings.
+
+    GET    — list mappings plus live DMX, venues and virtuals (for the editor).
+    POST   — add a new mapping or update an existing one (by ``index``).
+    DELETE — remove a mapping by ``index``.
+    """
+
+    ENDPOINT_PATH = "/api/integrations/dmx_input/{integration_id}"
+
+    def _get_integration(self, integration_id):
+        integration = self._ledfx.integrations.get(integration_id)
+        if (integration is None) or (integration.type != "dmx_input"):
+            return None
+        return integration
+
+    def _persist(self, integration):
+        for _integration in self._ledfx.config["integrations"]:
+            if _integration["id"] == integration.id:
+                _integration["data"] = integration.data
+                break
+        save_config(
+            config=self._ledfx.config,
+            config_dir=self._ledfx.config_dir,
+        )
+
+    async def get(self, integration_id) -> web.Response:
+        integration = self._get_integration(integration_id)
+        if integration is None:
+            return await self.invalid_request(
+                f"Integration {integration_id} was not found or is not type dmx_input"
+            )
+
+        venues = {}
+        if not hasattr(self._ledfx, "venues"):
+            self._ledfx.venues = VenueManager(self._ledfx)
+        venues = self._ledfx.venues.list_venues()
+
+        virtuals = {v.id: v.name for v in self._ledfx.virtuals.values()}
+
+        response = {
+            "mappings": integration.get_mappings(),
+            "live_dmx": integration.get_live_dmx(),
+            "venues": venues,
+            "virtuals": virtuals,
+        }
+        return await self.bare_request_success(response)
+
+    async def post(self, integration_id, request: web.Request) -> web.Response:
+        integration = self._get_integration(integration_id)
+        if integration is None:
+            return await self.invalid_request(
+                f"Integration {integration_id} was not found or is not type dmx_input"
+            )
+
+        try:
+            data = await request.json()
+        except JSONDecodeError:
+            return await self.json_decode_error()
+
+        mapping = data.get("mapping")
+        if mapping is None or not isinstance(mapping, dict):
+            return await self.invalid_request(
+                'Required attribute "mapping" (object) was not provided'
+            )
+
+        index = data.get("index")
+        mappings = integration.get_mappings()
+        if index is None:
+            integration.add_mapping(mapping)
+        else:
+            try:
+                index = int(index)
+            except (TypeError, ValueError):
+                return await self.invalid_request('"index" must be an integer')
+            if index < 0 or index >= len(mappings):
+                return await self.invalid_request(
+                    f"Mapping index {index} out of range"
+                )
+            mappings[index] = mapping
+
+        self._persist(integration)
+        return await self.request_success(
+            type="success", message="DMX mapping saved"
+        )
+
+    async def delete(
+        self, integration_id, request: web.Request
+    ) -> web.Response:
+        integration = self._get_integration(integration_id)
+        if integration is None:
+            return await self.invalid_request(
+                f"Integration {integration_id} was not found or is not type dmx_input"
+            )
+
+        try:
+            data = await request.json()
+        except JSONDecodeError:
+            return await self.json_decode_error()
+
+        index = data.get("index")
+        if index is None:
+            return await self.invalid_request(
+                'Required attribute "index" was not provided'
+            )
+        try:
+            index = int(index)
+        except (TypeError, ValueError):
+            return await self.invalid_request('"index" must be an integer')
+        if index < 0 or index >= len(integration.get_mappings()):
+            return await self.invalid_request(
+                f"Mapping index {index} out of range"
+            )
+
+        integration.delete_mapping(index)
+        self._persist(integration)
+        return await self.request_success(
+            type="success", message="DMX mapping deleted"
+        )

--- a/ledfx/api/integration_dmx_input_pause.py
+++ b/ledfx/api/integration_dmx_input_pause.py
@@ -1,0 +1,53 @@
+import logging
+from json import JSONDecodeError
+
+from aiohttp import web
+
+from ledfx.api import RestEndpoint
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DMXInputPauseEndpoint(RestEndpoint):
+    """REST end-point for globally pausing (muting) a DMX Input integration.
+
+    While paused, the Art-Net UDP listener keeps running and still replies
+    to ArtPoll (so SoundSwitch stays "connected"), but no mapping is
+    applied to any virtual/venue. The flag persists across restarts.
+
+    PUT — set the paused state. Body: ``{"paused": true|false}``.
+    """
+
+    ENDPOINT_PATH = "/api/integrations/dmx_input/{integration_id}/pause"
+
+    def _get_integration(self, integration_id):
+        integration = self._ledfx.integrations.get(integration_id)
+        if (integration is None) or (integration.type != "dmx_input"):
+            return None
+        return integration
+
+    async def put(self, integration_id, request: web.Request) -> web.Response:
+        integration = self._get_integration(integration_id)
+        if integration is None:
+            return await self.invalid_request(
+                f"Integration {integration_id} was not found or is not type dmx_input"
+            )
+
+        try:
+            data = await request.json()
+        except JSONDecodeError:
+            return await self.json_decode_error()
+
+        paused = data.get("paused")
+        if paused is None:
+            return await self.invalid_request(
+                'Required attribute "paused" was not provided'
+            )
+
+        integration.set_paused(bool(paused))
+
+        return await self.request_success(
+            type="success",
+            message=f"DMX Input {'paused' if integration.paused else 'resumed'}",
+            data={"paused": integration.paused},
+        )

--- a/ledfx/api/venue.py
+++ b/ledfx/api/venue.py
@@ -4,6 +4,7 @@ from json import JSONDecodeError
 from aiohttp import web
 
 from ledfx.api import RestEndpoint
+from ledfx.integrations.dmx_input import compute_dmx_mapped
 from ledfx.venues import VenueManager
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,8 +27,15 @@ class VenueEndpoint(RestEndpoint):
         cfg = mgr.get(venue_id)
         if cfg is None:
             return await self.invalid_request(f"Venue '{venue_id}' not found")
+        _, dmx_mapped_venue_ids = compute_dmx_mapped(self._ledfx)
         return await self.bare_request_success(
-            {"venue": {"id": venue_id, **cfg}}
+            {
+                "venue": {
+                    "id": venue_id,
+                    **cfg,
+                    "dmx_mapped": venue_id in dmx_mapped_venue_ids,
+                }
+            }
         )
 
     async def put(self, venue_id, request: web.Request) -> web.Response:

--- a/ledfx/api/venue.py
+++ b/ledfx/api/venue.py
@@ -1,0 +1,111 @@
+import logging
+from json import JSONDecodeError
+
+from aiohttp import web
+
+from ledfx.api import RestEndpoint
+from ledfx.venues import VenueManager
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _ensure_manager(ledfx) -> VenueManager:
+    if not hasattr(ledfx, "venues"):
+        ledfx.venues = VenueManager(ledfx)
+    return ledfx.venues
+
+
+class VenueEndpoint(RestEndpoint):
+    """REST end-point for a single venue: read, update, delete, manage members."""
+
+    ENDPOINT_PATH = "/api/venues/{venue_id}"
+
+    async def get(self, venue_id) -> web.Response:
+        """Get a venue by ID."""
+        mgr = _ensure_manager(self._ledfx)
+        cfg = mgr.get(venue_id)
+        if cfg is None:
+            return await self.invalid_request(f"Venue '{venue_id}' not found")
+        return await self.bare_request_success(
+            {"venue": {"id": venue_id, **cfg}}
+        )
+
+    async def put(self, venue_id, request: web.Request) -> web.Response:
+        """Update venue name, grid dimensions, or manage virtual membership.
+
+        Supported body variants:
+
+        Update name / grid::
+
+            { "name": "...", "color_pads": { "rows": N, "cols": M } }
+
+        Add a virtual::
+
+            { "action": "add_virtual", "virtual_id": "..." }
+
+        Remove a virtual::
+
+            { "action": "remove_virtual", "virtual_id": "..." }
+        """
+        try:
+            data = await request.json()
+        except JSONDecodeError:
+            return await self.json_decode_error()
+
+        mgr = _ensure_manager(self._ledfx)
+
+        action = data.get("action")
+
+        try:
+            if action == "add_virtual":
+                virtual_id = data.get("virtual_id")
+                if not virtual_id:
+                    return await self.invalid_request(
+                        '"virtual_id" required for add_virtual'
+                    )
+                venue = mgr.add_virtual(venue_id, virtual_id)
+                return await self.request_success(
+                    type="success",
+                    message=f"Added virtual '{virtual_id}' to venue '{venue_id}'",
+                    data={"venue": venue},
+                )
+
+            elif action == "remove_virtual":
+                virtual_id = data.get("virtual_id")
+                if not virtual_id:
+                    return await self.invalid_request(
+                        '"virtual_id" required for remove_virtual'
+                    )
+                venue = mgr.remove_virtual(venue_id, virtual_id)
+                return await self.request_success(
+                    type="success",
+                    message=f"Removed virtual '{virtual_id}' from venue '{venue_id}'",
+                    data={"venue": venue},
+                )
+
+            else:
+                # Generic config update (name, color_pads)
+                venue = mgr.update(venue_id, data)
+                return await self.request_success(
+                    type="success",
+                    message=f"Updated venue '{venue_id}'",
+                    data={"venue": venue},
+                )
+
+        except KeyError as e:
+            return await self.invalid_request(str(e))
+        except ValueError as e:
+            return await self.invalid_request(str(e))
+        except Exception as e:
+            _LOGGER.warning("Venue update error: %s", e)
+            return await self.invalid_request(str(e))
+
+    async def delete(self, venue_id) -> web.Response:
+        """Delete a venue."""
+        mgr = _ensure_manager(self._ledfx)
+        ok = mgr.delete(venue_id)
+        if not ok:
+            return await self.invalid_request(f"Venue '{venue_id}' not found")
+        return await self.request_success(
+            type="success", message=f"Deleted venue '{venue_id}'"
+        )

--- a/ledfx/api/venue_override.py
+++ b/ledfx/api/venue_override.py
@@ -1,0 +1,77 @@
+import logging
+from json import JSONDecodeError
+
+from aiohttp import web
+
+from ledfx.api import RestEndpoint
+from ledfx.venues import VenueManager
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _ensure_manager(ledfx) -> VenueManager:
+    if not hasattr(ledfx, "venues"):
+        ledfx.venues = VenueManager(ledfx)
+    return ledfx.venues
+
+
+class VenueOverrideEndpoint(RestEndpoint):
+    """REST end-point for color override pads on a venue.
+
+    POST  — activate override from a specific pad index.
+    DELETE — clear the override (restore running effects).
+    """
+
+    ENDPOINT_PATH = "/api/venues/{venue_id}/override"
+
+    async def post(self, venue_id, request: web.Request) -> web.Response:
+        """Activate a color pad override on all virtuals in the venue.
+
+        Body::
+
+            { "pad_index": int }  # 0-based, row-major
+        """
+        try:
+            data = await request.json()
+        except JSONDecodeError:
+            return await self.json_decode_error()
+
+        pad_index = data.get("pad_index")
+        if pad_index is None:
+            return await self.invalid_request(
+                'Required attribute "pad_index" was not provided'
+            )
+
+        try:
+            pad_index = int(pad_index)
+        except (TypeError, ValueError):
+            return await self.invalid_request('"pad_index" must be an integer')
+
+        mgr = _ensure_manager(self._ledfx)
+        try:
+            mgr.activate_override(venue_id, pad_index)
+        except KeyError as e:
+            return await self.invalid_request(str(e))
+        except IndexError as e:
+            return await self.invalid_request(str(e))
+        except Exception as e:
+            _LOGGER.warning("Override activation error: %s", e)
+            return await self.invalid_request(str(e))
+
+        return await self.request_success(
+            type="success",
+            message=f"Color override activated (pad {pad_index}) on venue '{venue_id}'",
+        )
+
+    async def delete(self, venue_id) -> web.Response:
+        """Clear the color override — running effects immediately resume."""
+        mgr = _ensure_manager(self._ledfx)
+        try:
+            mgr.clear_override(venue_id)
+        except KeyError as e:
+            return await self.invalid_request(str(e))
+
+        return await self.request_success(
+            type="success",
+            message=f"Color override cleared on venue '{venue_id}'",
+        )

--- a/ledfx/api/venue_pause.py
+++ b/ledfx/api/venue_pause.py
@@ -1,0 +1,51 @@
+import logging
+from json import JSONDecodeError
+
+from aiohttp import web
+
+from ledfx.api import RestEndpoint
+from ledfx.venues import VenueManager
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _ensure_manager(ledfx) -> VenueManager:
+    if not hasattr(ledfx, "venues"):
+        ledfx.venues = VenueManager(ledfx)
+    return ledfx.venues
+
+
+class VenuePauseEndpoint(RestEndpoint):
+    """REST end-point for muting DMX Input takeover on a venue.
+
+    Pausing also clears any active color-pad override on the venue,
+    since both represent "this venue's manual takeover" to the operator.
+
+    PUT — set the paused state. Body: ``{"paused": true|false}``.
+    """
+
+    ENDPOINT_PATH = "/api/venues/{venue_id}/pause"
+
+    async def put(self, venue_id, request: web.Request) -> web.Response:
+        try:
+            data = await request.json()
+        except JSONDecodeError:
+            return await self.json_decode_error()
+
+        paused = data.get("paused")
+        if paused is None:
+            return await self.invalid_request(
+                'Required attribute "paused" was not provided'
+            )
+
+        mgr = _ensure_manager(self._ledfx)
+        try:
+            venue = mgr.set_paused(venue_id, bool(paused))
+        except KeyError as e:
+            return await self.invalid_request(str(e))
+
+        return await self.request_success(
+            type="success",
+            message=f"Venue '{venue_id}' {'paused' if venue['paused'] else 'resumed'}",
+            data={"venue": venue},
+        )

--- a/ledfx/api/venues.py
+++ b/ledfx/api/venues.py
@@ -4,6 +4,7 @@ from json import JSONDecodeError
 from aiohttp import web
 
 from ledfx.api import RestEndpoint
+from ledfx.integrations.dmx_input import compute_dmx_mapped
 from ledfx.venues import VenueManager
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,7 +25,11 @@ class VenuesEndpoint(RestEndpoint):
         """List all venues."""
         mgr = _ensure_manager(self._ledfx)
         venues = mgr.list_venues()
-        result = [{"id": vid, **cfg} for vid, cfg in venues.items()]
+        _, dmx_mapped_venue_ids = compute_dmx_mapped(self._ledfx)
+        result = [
+            {"id": vid, **cfg, "dmx_mapped": vid in dmx_mapped_venue_ids}
+            for vid, cfg in venues.items()
+        ]
         return await self.bare_request_success({"venues": result})
 
     async def post(self, request: web.Request) -> web.Response:

--- a/ledfx/api/venues.py
+++ b/ledfx/api/venues.py
@@ -1,0 +1,64 @@
+import logging
+from json import JSONDecodeError
+
+from aiohttp import web
+
+from ledfx.api import RestEndpoint
+from ledfx.venues import VenueManager
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _ensure_manager(ledfx) -> VenueManager:
+    if not hasattr(ledfx, "venues"):
+        ledfx.venues = VenueManager(ledfx)
+    return ledfx.venues
+
+
+class VenuesEndpoint(RestEndpoint):
+    """REST end-point for querying and managing venues (collection)."""
+
+    ENDPOINT_PATH = "/api/venues"
+
+    async def get(self) -> web.Response:
+        """List all venues."""
+        mgr = _ensure_manager(self._ledfx)
+        venues = mgr.list_venues()
+        result = [{"id": vid, **cfg} for vid, cfg in venues.items()]
+        return await self.bare_request_success({"venues": result})
+
+    async def post(self, request: web.Request) -> web.Response:
+        """Create a new venue.
+
+        Body: ``{ "name": str, "rows": int (optional, default 4), "cols": int (optional, default 4) }``
+        """
+        try:
+            data = await request.json()
+        except JSONDecodeError:
+            return await self.json_decode_error()
+
+        name = data.get("name")
+        if not name:
+            return await self.invalid_request(
+                'Required attribute "name" was not provided'
+            )
+
+        rows = int(data.get("rows", 4))
+        cols = int(data.get("cols", 4))
+        if rows < 1 or cols < 1:
+            return await self.invalid_request(
+                '"rows" and "cols" must be positive integers'
+            )
+
+        try:
+            mgr = _ensure_manager(self._ledfx)
+            venue = mgr.create(name=name, rows=rows, cols=cols)
+        except Exception as e:
+            _LOGGER.warning("Failed to create venue: %s", e)
+            return await self.invalid_request(str(e))
+
+        return await self.request_success(
+            type="success",
+            message=f"Created venue '{name}'",
+            data={"venue": venue},
+        )

--- a/ledfx/api/virtual.py
+++ b/ledfx/api/virtual.py
@@ -7,11 +7,14 @@ from aiohttp import web
 from ledfx.api import RestEndpoint
 from ledfx.config import save_config
 from ledfx.effects import DummyEffect
+from ledfx.integrations.dmx_input import compute_dmx_mapped
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def make_virtual_response(virtual):
+def make_virtual_response(virtual, dmx_mapped_ids=None):
+    if dmx_mapped_ids is None:
+        dmx_mapped_ids, _ = compute_dmx_mapped(virtual._ledfx)
     virtual_response = {
         "config": virtual.config,
         "id": virtual.id,
@@ -22,6 +25,8 @@ def make_virtual_response(virtual):
         "active": virtual.active,
         "streaming": virtual.streaming,
         "last_effect": virtual.virtual_cfg.get("last_effect", None),
+        "dmx_mapped": virtual.id in dmx_mapped_ids,
+        "dmx_paused": virtual.is_dmx_paused(),
         "effect": {},
     }
     # Protect from DummyEffect

--- a/ledfx/api/virtual.py
+++ b/ledfx/api/virtual.py
@@ -181,6 +181,10 @@ class VirtualEndpoint(RestEndpoint):
                 if _device["id"] != device_id
             ]
 
+        # cleanup this virtual from any venues
+        if hasattr(self._ledfx, "venues"):
+            self._ledfx.venues.cleanup_virtual(virtual_id)
+
         # cleanup this virtual from any scenes
         ledfx_scenes = self._ledfx.config["scenes"].copy()
         for scene_id, scene_config in ledfx_scenes.items():

--- a/ledfx/api/virtual_dmx_pause.py
+++ b/ledfx/api/virtual_dmx_pause.py
@@ -1,0 +1,58 @@
+import logging
+from json import JSONDecodeError
+
+from aiohttp import web
+
+from ledfx.api import RestEndpoint
+from ledfx.config import save_config
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VirtualDMXPauseEndpoint(RestEndpoint):
+    """REST end-point for muting DMX Input takeover on a single virtual.
+
+    Pausing blocks every mapping type (fixture wash, color tint, and
+    venue-trigger override) from applying to this virtual, and immediately
+    releases any currently owned wash/color override. Persists across
+    restarts alongside the virtual's other config.
+
+    PUT — set the paused state. Body: ``{"paused": true|false}``.
+    """
+
+    ENDPOINT_PATH = "/api/virtuals/{virtual_id}/dmx_pause"
+
+    async def put(self, virtual_id, request: web.Request) -> web.Response:
+        virtual = self._ledfx.virtuals.get(virtual_id)
+        if virtual is None:
+            return await self.invalid_request(
+                f"Virtual with ID {virtual_id} not found"
+            )
+
+        try:
+            data = await request.json()
+        except JSONDecodeError:
+            return await self.json_decode_error()
+
+        paused = data.get("paused")
+        if paused is None:
+            return await self.invalid_request(
+                'Required attribute "paused" was not provided'
+            )
+
+        virtual.set_dmx_paused(bool(paused))
+        virtual.virtual_cfg["dmx_paused"] = virtual.is_dmx_paused()
+
+        save_config(
+            config=self._ledfx.config,
+            config_dir=self._ledfx.config_dir,
+        )
+
+        return await self.request_success(
+            type="success",
+            message=(
+                f"Virtual '{virtual.name}' "
+                f"{'DMX-paused' if virtual.is_dmx_paused() else 'DMX-resumed'}"
+            ),
+            data={"paused": virtual.is_dmx_paused()},
+        )

--- a/ledfx/api/virtuals.py
+++ b/ledfx/api/virtuals.py
@@ -6,6 +6,7 @@ from aiohttp import web
 from ledfx.api import RestEndpoint
 from ledfx.api.virtual import make_virtual_response
 from ledfx.config import save_config
+from ledfx.integrations.dmx_input import compute_dmx_mapped
 from ledfx.utils import generate_id
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,8 +26,11 @@ class VirtualsEndpoint(RestEndpoint):
         """
         response = {"status": "success", "virtuals": {}}
         response["paused"] = self._ledfx.virtuals._paused
+        dmx_mapped_ids, _ = compute_dmx_mapped(self._ledfx)
         for virtual in self._ledfx.virtuals.values():
-            response["virtuals"][virtual.id] = make_virtual_response(virtual)
+            response["virtuals"][virtual.id] = make_virtual_response(
+                virtual, dmx_mapped_ids
+            )
 
         return web.json_response(data=response, status=200)
 

--- a/ledfx/config.py
+++ b/ledfx/config.py
@@ -195,6 +195,7 @@ CORE_CONFIG_SCHEMA = vol.Schema(
         vol.Optional("sendspin_servers", default={}): dict,
         vol.Optional("sendspin_always_on", default=False): bool,
         vol.Optional("now_playing", default={}): dict,
+        vol.Optional("venues", default={}): dict,
     },
     extra=vol.ALLOW_EXTRA,
 )

--- a/ledfx/effects/gradient.py
+++ b/ledfx/effects/gradient.py
@@ -36,6 +36,7 @@ class GradientEffect(Effect):
 
     _gradient_curve = None
     _gradient_roll_counter = 0
+    _gradient_override: "Optional[str]" = None  # venue colour override
 
     def _comb(self, N, k):
         N = int(N)
@@ -120,14 +121,33 @@ class GradientEffect(Effect):
         return max(self.pixel_count, 256)
 
     def _assert_gradient(self):
+        gradient_src = (
+            self._gradient_override
+            if self._gradient_override is not None
+            else self._config["gradient"]
+        )
         if (
             self._gradient_curve is None  # Uninitialized gradient
             or len(self._gradient_curve[0])
             != self.gradient_pixel_count  # Incorrect size
         ):
             self._generate_gradient_curve(
-                self._config["gradient"],
+                gradient_src,
                 self.gradient_pixel_count,
+            )
+
+    def set_gradient_override(self, gradient_str: str):
+        """Inject a temporary gradient override; the effect continues animating."""
+        with self.lock:
+            self._gradient_override = gradient_str
+            self._gradient_curve = None  # force rebuild on next frame
+
+    def clear_gradient_override(self):
+        """Restore the original gradient from config."""
+        with self.lock:
+            self._gradient_override = None
+            self._gradient_curve = (
+                None  # force rebuild from config on next frame
             )
 
     def roll_gradient(self):

--- a/ledfx/integrations/dmx_input.py
+++ b/ledfx/integrations/dmx_input.py
@@ -22,6 +22,8 @@ integration pattern) as a list of dicts. See ``MAPPING_SCHEMA`` for the shape.
 
 import asyncio
 import logging
+import socket
+import struct
 import time
 
 import voluptuous as vol
@@ -33,7 +35,91 @@ _LOGGER = logging.getLogger(__name__)
 
 ARTNET_ID = b"Art-Net\x00"
 OPCODE_ARTDMX = 0x5000
+OPCODE_ARTPOLL = 0x2000
 ARTNET_MIN_PROTO = 14
+ARTNET_PORT = 6454
+
+
+def _best_local_ip(bind_address: str) -> str:
+    """Return the best routable local IP to advertise in ArtPollReply.
+
+    When bound to 0.0.0.0 we probe the routing table via a throw-away UDP
+    socket so we report the IP that remote hosts can actually reach us on.
+    """
+    if bind_address and bind_address != "0.0.0.0":
+        return bind_address
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80))
+        ip = s.getsockname()[0]
+        s.close()
+        return ip
+    except Exception:
+        return "0.0.0.0"
+
+
+def _build_artpollreply(local_ip: str, port: int = ARTNET_PORT) -> bytes:
+    """Build a 239-byte ArtPollReply advertising one DMX output port.
+
+    SoundSwitch (and other Art-Net controllers) broadcast ArtPoll to discover
+    nodes.  Without this reply LedFx is invisible to them and they report
+    "no device found".
+
+    We advertise a single output port on universe 0 (StNode style).  Once
+    SoundSwitch selects this node it sends ArtDMX to our IP regardless of
+    which universe/channel is active, so no multi-universe advertising is
+    needed.
+    """
+    pkt = bytearray(239)
+    pkt[0:8] = ARTNET_ID
+    # OpCode 0x2100 – stored little-endian
+    pkt[8] = 0x00
+    pkt[9] = 0x21
+    # IP address (network byte order / big-endian)
+    try:
+        pkt[10:14] = socket.inet_aton(local_ip)
+    except OSError:
+        pkt[10:14] = bytes(4)
+    # Port – little-endian
+    struct.pack_into("<H", pkt, 14, port)
+    # VersInfo – firmware version big-endian; just use 1
+    struct.pack_into(">H", pkt, 16, 1)
+    # NetSwitch / SubSwitch – universe 0
+    pkt[18] = 0
+    pkt[19] = 0
+    # OemHi / Oem – 0x00 0xFF = unknown/experimental
+    pkt[20] = 0x00
+    pkt[21] = 0xFF
+    # ShortName (18 bytes, null-padded)
+    short = b"LedFx DMX Input"
+    pkt[26 : 26 + len(short)] = short
+    # LongName (64 bytes, null-padded)
+    long_n = b"LedFx Art-Net DMX Input Bridge"
+    pkt[44 : 44 + len(long_n)] = long_n
+    # NodeReport (64 bytes)
+    report = b"#0001 [0000] LedFx DMX Input active"
+    pkt[108 : 108 + len(report)] = report
+    # NumPorts – 1
+    pkt[172] = 0
+    pkt[173] = 1
+    # PortTypes[0] – 0x80 = output port (receives DMX from network → LedFx)
+    pkt[174] = 0x80
+    # GoodOutput[0] – 0x80 = data being transmitted
+    pkt[182] = 0x80
+    # SwOut[0] – universe 0
+    pkt[190] = 0
+    # Style – 0x00 = StNode
+    pkt[200] = 0x00
+    # BindIp – same as our IP
+    try:
+        pkt[207:211] = socket.inet_aton(local_ip)
+    except OSError:
+        pkt[207:211] = bytes(4)
+    # BindIndex – 1
+    pkt[211] = 1
+    # Status2 – 0x08 = DHCP capable (harmless flag)
+    pkt[212] = 0x08
+    return bytes(pkt)
 
 
 def parse_artdmx(data: bytes):
@@ -65,17 +151,32 @@ def parse_artdmx(data: bytes):
 class _ArtNetProtocol(asyncio.DatagramProtocol):
     """Minimal UDP protocol that forwards parsed ArtDMX frames upstream.
 
-    The callback is deliberately tiny: it only stores the latest DMX state so
-    the asyncio loop is never blocked on per-frame work.
+    Also responds to ArtPoll broadcasts so Art-Net controllers (e.g.
+    SoundSwitch) can discover LedFx via the standard node-discovery flow
+    instead of requiring a manually entered IP address.
     """
 
-    def __init__(self, on_dmx):
+    def __init__(self, on_dmx, local_ip: str, port: int = ARTNET_PORT):
         self._on_dmx = on_dmx
+        self._reply = _build_artpollreply(local_ip, port)
+        self._transport = None
+
+    def connection_made(self, transport):
+        self._transport = transport
 
     def datagram_received(self, data, addr):
-        parsed = parse_artdmx(data)
-        if parsed is not None:
-            self._on_dmx(parsed[0], parsed[1])
+        if len(data) < 10 or data[:8] != ARTNET_ID:
+            return
+        opcode = data[8] | (data[9] << 8)
+        if opcode == OPCODE_ARTPOLL:
+            # Reply directly to the controller that asked
+            if self._transport is not None:
+                self._transport.sendto(self._reply, (addr[0], ARTNET_PORT))
+                _LOGGER.debug("DMX Input: ArtPoll from %s → replied", addr[0])
+        elif opcode == OPCODE_ARTDMX:
+            parsed = parse_artdmx(data)
+            if parsed is not None:
+                self._on_dmx(parsed[0], parsed[1])
 
     def error_received(self, exc):
         _LOGGER.debug("Art-Net socket error: %s", exc)
@@ -199,12 +300,13 @@ class DMXInput(Integration):
     async def connect(self):
         bind = self._config["bind_address"]
         port = self._config["port"]
+        local_ip = _best_local_ip(bind)
         try:
             (
                 self._transport,
                 self._protocol,
             ) = await self._ledfx.loop.create_datagram_endpoint(
-                lambda: _ArtNetProtocol(self._on_dmx),
+                lambda: _ArtNetProtocol(self._on_dmx, local_ip, port),
                 local_addr=(bind, port),
                 allow_broadcast=True,
             )
@@ -221,7 +323,8 @@ class DMXInput(Integration):
 
         self._update_task = self._ledfx.loop.create_task(self._update_loop())
         await super().connect(
-            f"DMX Input listening for Art-Net on {bind}:{port}"
+            f"DMX Input listening for Art-Net on {local_ip}:{port} "
+            f"(bind {bind}) — ArtPoll discovery enabled"
         )
 
     async def disconnect(self):

--- a/ledfx/integrations/dmx_input.py
+++ b/ledfx/integrations/dmx_input.py
@@ -1,0 +1,528 @@
+"""DMX Input bridge integration.
+
+Listens for incoming Art-Net DMX (e.g. from SoundSwitch outputting Art-Net to
+127.0.0.1 in parallel with its USB-DMX output) and maps DMX channels onto LedFx
+actions:
+
+  * **trigger**  — a button / static-look channel toggles a venue color-override
+    pad (edge-detected with hysteresis).
+  * **color**    — an RGB fixture recolors a target virtual live, while the
+    effect keeps animating.
+  * **fixture**  — a mode-toggle + dimmer + RGB turn a virtual into a dumb DMX
+    wash fixture (solid color × brightness), so an LED run can be programmed in
+    SoundSwitch alongside real wash fixtures. Toggling off reveals the effect.
+
+The incoming Art-Net "signal" is just DMX; no reverse engineering of SoundSwitch
+internals is required. SoundSwitch is configured to mirror its USB universe to
+Art-Net on the loopback interface.
+
+Mappings are persisted in the integration ``data`` blob (mirroring the QLC+
+integration pattern) as a list of dicts. See ``MAPPING_SCHEMA`` for the shape.
+"""
+
+import asyncio
+import logging
+import time
+
+import voluptuous as vol
+
+from ledfx.integrations import Integration
+from ledfx.venues import VenueManager
+
+_LOGGER = logging.getLogger(__name__)
+
+ARTNET_ID = b"Art-Net\x00"
+OPCODE_ARTDMX = 0x5000
+ARTNET_MIN_PROTO = 14
+
+
+def parse_artdmx(data: bytes):
+    """Strictly parse an ArtDMX packet.
+
+    Returns ``(universe, dmx_bytes)`` or ``None`` if the packet is not a valid
+    ArtDMX frame. The DMX length field is honored (not assumed to be 512).
+    """
+    if len(data) < 18:
+        return None
+    if data[:8] != ARTNET_ID:
+        return None
+    # OpCode is little-endian; ArtDMX == 0x5000
+    opcode = data[8] | (data[9] << 8)
+    if opcode != OPCODE_ARTDMX:
+        return None
+    # Protocol version is big-endian at bytes 10-11
+    proto = (data[10] << 8) | data[11]
+    if proto < ARTNET_MIN_PROTO:
+        return None
+    # Port-Address (universe) is little-endian, 15 bits, at bytes 14-15
+    universe = (data[14] | (data[15] << 8)) & 0x7FFF
+    # Length is big-endian at bytes 16-17
+    length = (data[16] << 8) | data[17]
+    dmx = data[18 : 18 + length]
+    return universe, bytes(dmx)
+
+
+class _ArtNetProtocol(asyncio.DatagramProtocol):
+    """Minimal UDP protocol that forwards parsed ArtDMX frames upstream.
+
+    The callback is deliberately tiny: it only stores the latest DMX state so
+    the asyncio loop is never blocked on per-frame work.
+    """
+
+    def __init__(self, on_dmx):
+        self._on_dmx = on_dmx
+
+    def datagram_received(self, data, addr):
+        parsed = parse_artdmx(data)
+        if parsed is not None:
+            self._on_dmx(parsed[0], parsed[1])
+
+    def error_received(self, exc):
+        _LOGGER.debug("Art-Net socket error: %s", exc)
+
+
+def _channel(dmx: bytes, ch: int) -> int:
+    """Return the value of 1-based DMX channel *ch* (0 if out of range)."""
+    idx = ch - 1
+    if 0 <= idx < len(dmx):
+        return dmx[idx]
+    return 0
+
+
+class DMXInput(Integration):
+    """Bridge incoming Art-Net DMX onto LedFx venue overrides and virtuals."""
+
+    beta = False
+
+    NAME = "DMX Input"
+    DESCRIPTION = (
+        "Control LedFx from a DMX source (e.g. SoundSwitch via Art-Net): "
+        "venue color overrides, live color passthrough, and DMX wash fixtures."
+    )
+
+    CONFIG_SCHEMA = vol.Schema(
+        {
+            vol.Required(
+                "name",
+                description="Name of this integration instance",
+                default="DMX Input",
+            ): str,
+            vol.Required(
+                "description",
+                description="Description of this integration",
+                default="Art-Net DMX input bridge",
+            ): str,
+            vol.Required(
+                "bind_address",
+                description="Local address to listen on (use 127.0.0.1 for a "
+                "SoundSwitch Art-Net output unicast to loopback)",
+                default="127.0.0.1",
+            ): str,
+            vol.Required(
+                "port",
+                description="Art-Net UDP port",
+                default=6454,
+            ): vol.All(vol.Coerce(int), vol.Range(min=1, max=65535)),
+            vol.Optional(
+                "update_fps",
+                description="How often incoming DMX is applied to LedFx",
+                default=60,
+            ): vol.All(vol.Coerce(int), vol.Range(min=1, max=120)),
+            vol.Optional(
+                "stale_timeout",
+                description="Seconds without DMX before owned overrides are "
+                "released (0 disables)",
+                default=2.0,
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=60.0)),
+            vol.Optional(
+                "hold_last_look",
+                description="Keep the last look when the DMX stream stops "
+                "instead of releasing it",
+                default=False,
+            ): bool,
+        }
+    )
+
+    def __init__(self, ledfx, config, active, data):
+        super().__init__(ledfx, config, active, data)
+
+        self._ledfx = ledfx
+        self._config = config
+        # data is the list of channel mappings
+        self._data = data if isinstance(data, list) else []
+
+        self._transport = None
+        self._protocol = None
+        self._update_task = None
+
+        # Latest DMX state per universe and when it last arrived
+        self._latest_dmx: dict[int, bytes] = {}
+        self._last_packet_time: dict[int, float] = {}
+        self._seen_universe: set[int] = set()
+
+        # Per-mapping runtime state, keyed by mapping index
+        self._mapping_state: dict[int, dict] = {}
+
+        # Ownership: which mapping index currently owns each venue override
+        self._venue_override_owner: dict[str, int] = {}
+        # Virtuals we currently hold in wash / color-passthrough mode
+        self._owned_washes: set[str] = set()
+        self._owned_color: set[str] = set()
+
+    # ------------------------------------------------------------------
+    # Mapping management (persisted in self._data)
+    # ------------------------------------------------------------------
+
+    def get_mappings(self):
+        return self._data
+
+    def add_mapping(self, mapping: dict):
+        self._data.append(mapping)
+
+    def delete_mapping(self, index: int):
+        if 0 <= index < len(self._data):
+            del self._data[index]
+            self._mapping_state.pop(index, None)
+
+    def get_live_dmx(self) -> dict:
+        """Return the latest DMX values per universe (for monitor / learn UI)."""
+        return {
+            str(universe): list(dmx)
+            for universe, dmx in self._latest_dmx.items()
+        }
+
+    # ------------------------------------------------------------------
+    # Connection lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self):
+        bind = self._config["bind_address"]
+        port = self._config["port"]
+        try:
+            (
+                self._transport,
+                self._protocol,
+            ) = await self._ledfx.loop.create_datagram_endpoint(
+                lambda: _ArtNetProtocol(self._on_dmx),
+                local_addr=(bind, port),
+                allow_broadcast=True,
+            )
+        except OSError as e:
+            _LOGGER.error(
+                "DMX Input: failed to bind Art-Net listener on %s:%s (%s). "
+                "Is another Art-Net node or LedFx Art-Net output using the port?",
+                bind,
+                port,
+                e,
+            )
+            await super().disconnect()
+            return
+
+        self._update_task = self._ledfx.loop.create_task(self._update_loop())
+        await super().connect(
+            f"DMX Input listening for Art-Net on {bind}:{port}"
+        )
+
+    async def disconnect(self):
+        if self._update_task is not None:
+            self._update_task.cancel()
+            self._update_task = None
+        if self._transport is not None:
+            self._transport.close()
+            self._transport = None
+            self._protocol = None
+        # Release everything this integration owns
+        self._release_all()
+        await super().disconnect("DMX Input stopped")
+
+    def on_shutdown(self):
+        self._release_all()
+
+    # ------------------------------------------------------------------
+    # Art-Net intake (runs on the loop thread, kept tiny)
+    # ------------------------------------------------------------------
+
+    def _on_dmx(self, universe: int, dmx: bytes):
+        self._latest_dmx[universe] = dmx
+        self._last_packet_time[universe] = time.monotonic()
+
+    # ------------------------------------------------------------------
+    # Coalesced processing loop
+    # ------------------------------------------------------------------
+
+    async def _update_loop(self):
+        try:
+            while True:
+                interval = 1.0 / max(1, self._config.get("update_fps", 60))
+                await asyncio.sleep(interval)
+                try:
+                    self._process()
+                except Exception as e:  # never let the loop die
+                    _LOGGER.warning("DMX Input processing error: %s", e)
+        except asyncio.CancelledError:
+            pass
+
+    def _process(self):
+        now = time.monotonic()
+        stale_timeout = self._config.get("stale_timeout", 2.0)
+        hold = self._config.get("hold_last_look", False)
+
+        for idx, mapping in enumerate(self._data):
+            if not mapping.get("active", True):
+                continue
+
+            universe = int(mapping.get("universe", 0))
+            dmx = self._latest_dmx.get(universe)
+            if dmx is None:
+                continue
+
+            # On the first packet for a universe, prime baselines so a channel
+            # that is already high at startup does not spuriously fire.
+            if universe not in self._seen_universe:
+                self._seen_universe.add(universe)
+                self._prime_mapping(idx, mapping, dmx)
+                continue
+
+            # Stale-stream handling: release owned looks if the source stopped.
+            if (
+                stale_timeout > 0
+                and not hold
+                and (now - self._last_packet_time.get(universe, 0))
+                > stale_timeout
+            ):
+                self._release_mapping(idx, mapping)
+                continue
+
+            mtype = mapping.get("type")
+            if mtype == "trigger":
+                self._process_trigger(idx, mapping, dmx)
+            elif mtype == "color":
+                self._process_color(idx, mapping, dmx)
+            elif mtype == "fixture":
+                self._process_fixture(idx, mapping, dmx)
+
+    # ------------------------------------------------------------------
+    # Per-type handlers
+    # ------------------------------------------------------------------
+
+    def _prime_mapping(self, idx, mapping, dmx):
+        """Record an initial 'off' baseline so startup does not auto-fire."""
+        self._mapping_state.setdefault(
+            idx, {"triggered": False, "last_color": None, "wash_on": False}
+        )
+
+    def _process_trigger(self, idx, mapping, dmx):
+        state = self._mapping_state.setdefault(idx, {"triggered": False})
+        ch = int(mapping.get("channels", [1])[0])
+        value = _channel(dmx, ch)
+        on_t = int(mapping.get("on_threshold", 128))
+        off_t = int(mapping.get("off_threshold", 96))
+        venue_id = mapping.get("venue_id")
+        pad_index = mapping.get("pad_index")
+        if venue_id is None or pad_index is None:
+            return
+
+        mgr = self._venues()
+        if state["triggered"]:
+            if value <= off_t:
+                state["triggered"] = False
+                # Only clear if we still own this venue's override
+                if self._venue_override_owner.get(venue_id) == idx:
+                    try:
+                        mgr.clear_override(venue_id)
+                    except Exception as e:
+                        _LOGGER.warning("DMX Input clear_override: %s", e)
+                    self._venue_override_owner.pop(venue_id, None)
+        else:
+            if value >= on_t:
+                state["triggered"] = True
+                try:
+                    mgr.activate_override(venue_id, int(pad_index))
+                    self._venue_override_owner[venue_id] = idx
+                    _LOGGER.info(
+                        "DMX Input: trigger '%s' activated override pad %s on venue '%s'",
+                        mapping.get("name", idx),
+                        pad_index,
+                        venue_id,
+                    )
+                except Exception as e:
+                    _LOGGER.warning("DMX Input activate_override: %s", e)
+
+    def _process_color(self, idx, mapping, dmx):
+        state = self._mapping_state.setdefault(idx, {"last_color": None})
+        chans = mapping.get("channels", [1, 2, 3])
+        r = _channel(dmx, int(chans[0]))
+        g = _channel(dmx, int(chans[1]))
+        b = _channel(dmx, int(chans[2]))
+        rgb = (r, g, b)
+        if rgb == state["last_color"]:
+            return
+        state["last_color"] = rgb
+        hex_color = "#{:02x}{:02x}{:02x}".format(r, g, b)
+        for v in self._targets(mapping):
+            try:
+                v.set_color_override(hex_color)
+                self._owned_color.add(v.id)
+            except Exception as e:
+                _LOGGER.warning("DMX Input set_color_override: %s", e)
+
+    def _process_fixture(self, idx, mapping, dmx):
+        state = self._mapping_state.setdefault(idx, {"wash_on": False})
+        chans = mapping.get("channels", {})
+        # channels may be a dict {mode,dimmer,r,g,b} or a 5-list in that order
+        if isinstance(chans, dict):
+            mode_ch = int(chans.get("mode", 1))
+            dim_ch = int(chans.get("dimmer", 2))
+            r_ch = int(chans.get("r", 3))
+            g_ch = int(chans.get("g", 4))
+            b_ch = int(chans.get("b", 5))
+        else:
+            mode_ch, dim_ch, r_ch, g_ch, b_ch = (
+                list(chans) + [1, 2, 3, 4, 5]
+            )[:5]
+        on_t = int(mapping.get("on_threshold", 128))
+        off_t = int(mapping.get("off_threshold", 96))
+        mode_val = _channel(dmx, mode_ch)
+
+        targets = list(self._targets(mapping))
+        if state["wash_on"]:
+            if mode_val <= off_t:
+                state["wash_on"] = False
+                for v in targets:
+                    try:
+                        v.clear_dmx_wash()
+                    except Exception as e:
+                        _LOGGER.warning("DMX Input clear_dmx_wash: %s", e)
+                    self._owned_washes.discard(v.id)
+                _LOGGER.info(
+                    "DMX Input: fixture '%s' wash OFF on %d virtual(s)",
+                    mapping.get("name", idx),
+                    len(targets),
+                )
+            else:
+                dimmer = _channel(dmx, dim_ch) / 255.0
+                rgb = (
+                    _channel(dmx, r_ch),
+                    _channel(dmx, g_ch),
+                    _channel(dmx, b_ch),
+                )
+                for v in targets:
+                    try:
+                        v.set_dmx_wash(rgb, dimmer)
+                    except Exception as e:
+                        _LOGGER.warning("DMX Input set_dmx_wash: %s", e)
+        else:
+            if mode_val >= on_t:
+                state["wash_on"] = True
+                dimmer = _channel(dmx, dim_ch) / 255.0
+                rgb = (
+                    _channel(dmx, r_ch),
+                    _channel(dmx, g_ch),
+                    _channel(dmx, b_ch),
+                )
+                for v in targets:
+                    try:
+                        v.set_dmx_wash(rgb, dimmer)
+                        self._owned_washes.add(v.id)
+                    except Exception as e:
+                        _LOGGER.warning("DMX Input set_dmx_wash: %s", e)
+                _LOGGER.info(
+                    "DMX Input: fixture '%s' wash ON rgb=%s dimmer=%.2f on "
+                    "%d virtual(s)",
+                    mapping.get("name", idx),
+                    rgb,
+                    dimmer,
+                    len(targets),
+                )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _venues(self) -> VenueManager:
+        if not hasattr(self._ledfx, "venues"):
+            self._ledfx.venues = VenueManager(self._ledfx)
+        return self._ledfx.venues
+
+    def _targets(self, mapping):
+        """Yield target virtuals for a color/fixture mapping.
+
+        A mapping targets either a single ``virtual_id`` or every virtual in a
+        ``venue_id``.
+        """
+        vid = mapping.get("virtual_id")
+        if vid:
+            v = self._ledfx.virtuals.get(vid)
+            if v is not None:
+                yield v
+            return
+        venue_id = mapping.get("venue_id")
+        if venue_id:
+            cfg = self._venues().get(venue_id)
+            if not cfg:
+                return
+            for v_id in cfg.get("virtual_ids", []):
+                v = self._ledfx.virtuals.get(v_id)
+                if v is not None:
+                    yield v
+
+    def _release_mapping(self, idx, mapping):
+        """Release whatever a single mapping currently owns."""
+        state = self._mapping_state.get(idx)
+        if not state:
+            return
+        mtype = mapping.get("type")
+        if mtype == "trigger" and state.get("triggered"):
+            state["triggered"] = False
+            venue_id = mapping.get("venue_id")
+            if venue_id and self._venue_override_owner.get(venue_id) == idx:
+                try:
+                    self._venues().clear_override(venue_id)
+                except Exception:
+                    pass
+                self._venue_override_owner.pop(venue_id, None)
+        elif mtype == "color" and state.get("last_color") is not None:
+            state["last_color"] = None
+            for v in self._targets(mapping):
+                try:
+                    v.clear_color_override()
+                except Exception:
+                    pass
+                self._owned_color.discard(v.id)
+        elif mtype == "fixture" and state.get("wash_on"):
+            state["wash_on"] = False
+            for v in self._targets(mapping):
+                try:
+                    v.clear_dmx_wash()
+                except Exception:
+                    pass
+                self._owned_washes.discard(v.id)
+
+    def _release_all(self):
+        """Release every override / takeover this integration owns."""
+        for venue_id in list(self._venue_override_owner.keys()):
+            try:
+                self._venues().clear_override(venue_id)
+            except Exception:
+                pass
+        self._venue_override_owner.clear()
+
+        for vid in list(self._owned_color):
+            v = self._ledfx.virtuals.get(vid)
+            if v is not None:
+                try:
+                    v.clear_color_override()
+                except Exception:
+                    pass
+        self._owned_color.clear()
+
+        for vid in list(self._owned_washes):
+            v = self._ledfx.virtuals.get(vid)
+            if v is not None:
+                try:
+                    v.clear_dmx_wash()
+                except Exception:
+                    pass
+        self._owned_washes.clear()
+
+        self._mapping_state.clear()

--- a/ledfx/integrations/dmx_input.py
+++ b/ledfx/integrations/dmx_input.py
@@ -114,9 +114,10 @@ class DMXInput(Integration):
             ): str,
             vol.Required(
                 "bind_address",
-                description="Local address to listen on (use 127.0.0.1 for a "
-                "SoundSwitch Art-Net output unicast to loopback)",
-                default="127.0.0.1",
+                description="Local address to listen on. Use 0.0.0.0 to accept Art-Net "
+                "from any machine on the network (e.g. SoundSwitch on a separate PC). "
+                "Use 127.0.0.1 to accept only from the same machine.",
+                default="0.0.0.0",
             ): str,
             vol.Required(
                 "port",

--- a/ledfx/integrations/dmx_input.py
+++ b/ledfx/integrations/dmx_input.py
@@ -8,9 +8,13 @@ actions:
     pad (edge-detected with hysteresis).
   * **color**    — an RGB fixture recolors a target virtual live, while the
     effect keeps animating.
-  * **fixture**  — a mode-toggle + dimmer + RGB turn a virtual into a dumb DMX
-    wash fixture (solid color × brightness), so an LED run can be programmed in
-    SoundSwitch alongside real wash fixtures. Toggling off reveals the effect.
+  * **fixture**  — a dimmer + RGB turn a virtual into a dumb DMX wash fixture
+    (solid color × brightness), so an LED run can be programmed in
+    SoundSwitch alongside real wash fixtures. The wash is engaged
+    unconditionally as soon as its universe is receiving data, and tracks
+    live dimmer/RGB continuously (dimmer 0 = solid black, no threshold gate);
+    it is only released back to the running effect when the DMX stream
+    itself goes stale or the mapping is deactivated.
 
 The incoming Art-Net "signal" is just DMX; no reverse engineering of SoundSwitch
 internals is required. SoundSwitch is configured to mirror its USB universe to
@@ -22,6 +26,7 @@ integration pattern) as a list of dicts. See ``MAPPING_SCHEMA`` for the shape.
 
 import asyncio
 import logging
+import os
 import socket
 import struct
 import time
@@ -36,8 +41,17 @@ _LOGGER = logging.getLogger(__name__)
 ARTNET_ID = b"Art-Net\x00"
 OPCODE_ARTDMX = 0x5000
 OPCODE_ARTPOLL = 0x2000
+OPCODE_ARTPOLLREPLY = 0x2100  # other nodes announcing themselves; just noise
 ARTNET_MIN_PROTO = 14
 ARTNET_PORT = 6454
+
+# TEMP DEBUG ONLY — set LEDFX_DMX_TRACE=1 to log every UDP datagram this
+# listener receives (source, opcode, raw bytes) plus per-universe DMX values
+# at ~2Hz, for tracing a SoundSwitch → LedFx Art-Net handshake. Not meant to
+# be committed/merged; strip before opening/updating the PR.
+_TRACE = os.environ.get("LEDFX_DMX_TRACE") == "1"
+_trace_last_log: dict[int, float] = {}
+_trace_last_nomatch_log: dict[int, float] = {}
 
 
 def _best_local_ip(bind_address: str) -> str:
@@ -166,17 +180,54 @@ class _ArtNetProtocol(asyncio.DatagramProtocol):
 
     def datagram_received(self, data, addr):
         if len(data) < 10 or data[:8] != ARTNET_ID:
+            if _TRACE:
+                _LOGGER.info(
+                    "DMX Input TRACE: non-Art-Net UDP from %s (%d bytes): %s",
+                    addr[0],
+                    len(data),
+                    data[:16].hex(),
+                )
             return
         opcode = data[8] | (data[9] << 8)
+        if _TRACE and opcode not in (
+            OPCODE_ARTPOLL,
+            OPCODE_ARTDMX,
+            OPCODE_ARTPOLLREPLY,
+        ):
+            _LOGGER.info(
+                "DMX Input TRACE: unhandled Art-Net opcode 0x%04x from %s",
+                opcode,
+                addr[0],
+            )
         if opcode == OPCODE_ARTPOLL:
             # Reply directly to the controller that asked
             if self._transport is not None:
                 self._transport.sendto(self._reply, (addr[0], ARTNET_PORT))
-                _LOGGER.debug("DMX Input: ArtPoll from %s → replied", addr[0])
+                _LOGGER.info("DMX Input: ArtPoll from %s → replied", addr[0])
         elif opcode == OPCODE_ARTDMX:
             parsed = parse_artdmx(data)
-            if parsed is not None:
-                self._on_dmx(parsed[0], parsed[1])
+            if parsed is None:
+                if _TRACE:
+                    _LOGGER.info(
+                        "DMX Input TRACE: malformed ArtDMX from %s (%d bytes)",
+                        addr[0],
+                        len(data),
+                    )
+                return
+            universe, dmx = parsed
+            if _TRACE:
+                now = time.monotonic()
+                if now - _trace_last_log.get(universe, 0) > 0.5:
+                    _trace_last_log[universe] = now
+                    _LOGGER.info(
+                        "DMX Input TRACE: ArtDMX from %s universe=%d len=%d "
+                        "first10=%s",
+                        addr[0],
+                        universe,
+                        len(dmx),
+                        list(dmx[:10]),
+                    )
+            self._on_dmx(universe, dmx)
 
     def error_received(self, exc):
         _LOGGER.debug("Art-Net socket error: %s", exc)
@@ -378,6 +429,18 @@ class DMXInput(Integration):
             universe = int(mapping.get("universe", 0))
             dmx = self._latest_dmx.get(universe)
             if dmx is None:
+                if _TRACE and self._latest_dmx:
+                    if now - _trace_last_nomatch_log.get(idx, 0) > 2.0:
+                        _trace_last_nomatch_log[idx] = now
+                        _LOGGER.info(
+                            "DMX Input TRACE: mapping '%s' wants universe %d "
+                            "but only received universe(s) %s so far — check "
+                            "SoundSwitch's universe setting matches the "
+                            "mapping.",
+                            mapping.get("name", idx),
+                            universe,
+                            sorted(self._latest_dmx.keys()),
+                        )
                 continue
 
             # On the first packet for a universe, prime baselines so a channel
@@ -388,12 +451,8 @@ class DMXInput(Integration):
                 continue
 
             # Stale-stream handling: release owned looks if the source stopped.
-            if (
-                stale_timeout > 0
-                and not hold
-                and (now - self._last_packet_time.get(universe, 0))
-                > stale_timeout
-            ):
+            age = now - self._last_packet_time.get(universe, 0)
+            if stale_timeout > 0 and not hold and age > stale_timeout:
                 self._release_mapping(idx, mapping)
                 continue
 
@@ -471,73 +530,54 @@ class DMXInput(Integration):
                 _LOGGER.warning("DMX Input set_color_override: %s", e)
 
     def _process_fixture(self, idx, mapping, dmx):
+        """Drive a virtual as a continuous DMX wash fixture.
+
+        As soon as this mapping's universe is receiving data, the target
+        virtual(s) are engaged as a wash fixture and driven continuously by
+        the live dimmer/RGB values on every packet — a dimmer of 0 naturally
+        renders solid black (rgb * 0). There is no on/off threshold gate:
+        the wash is engaged unconditionally while the DMX stream is live, and
+        only released back to the running effect via the stale-stream
+        timeout (SoundSwitch stops sending entirely) or the mapping being
+        deactivated/removed, handled by ``_release_mapping``. This avoids a
+        bright "flash" of the underlying effect whenever the operator dims a
+        fixture down to (near) zero.
+        """
         state = self._mapping_state.setdefault(idx, {"wash_on": False})
         chans = mapping.get("channels", {})
-        # channels may be a dict {mode,dimmer,r,g,b} or a 5-list in that order
+        # channels may be a dict {dimmer,r,g,b} or a 4-list in that order
+        # (a legacy "mode" key, if still present in old saved mappings, is
+        # ignored — the fixture wash is no longer gated by a threshold).
         if isinstance(chans, dict):
-            mode_ch = int(chans.get("mode", 1))
-            dim_ch = int(chans.get("dimmer", 2))
-            r_ch = int(chans.get("r", 3))
-            g_ch = int(chans.get("g", 4))
-            b_ch = int(chans.get("b", 5))
+            dim_ch = int(chans.get("dimmer", 1))
+            r_ch = int(chans.get("r", 2))
+            g_ch = int(chans.get("g", 3))
+            b_ch = int(chans.get("b", 4))
         else:
-            mode_ch, dim_ch, r_ch, g_ch, b_ch = (
-                list(chans) + [1, 2, 3, 4, 5]
-            )[:5]
-        on_t = int(mapping.get("on_threshold", 128))
-        off_t = int(mapping.get("off_threshold", 96))
-        mode_val = _channel(dmx, mode_ch)
+            dim_ch, r_ch, g_ch, b_ch = (list(chans) + [1, 2, 3, 4])[:4]
 
         targets = list(self._targets(mapping))
-        if state["wash_on"]:
-            if mode_val <= off_t:
-                state["wash_on"] = False
-                for v in targets:
-                    try:
-                        v.clear_dmx_wash()
-                    except Exception as e:
-                        _LOGGER.warning("DMX Input clear_dmx_wash: %s", e)
-                    self._owned_washes.discard(v.id)
-                _LOGGER.info(
-                    "DMX Input: fixture '%s' wash OFF on %d virtual(s)",
-                    mapping.get("name", idx),
-                    len(targets),
-                )
-            else:
-                dimmer = _channel(dmx, dim_ch) / 255.0
-                rgb = (
-                    _channel(dmx, r_ch),
-                    _channel(dmx, g_ch),
-                    _channel(dmx, b_ch),
-                )
-                for v in targets:
-                    try:
-                        v.set_dmx_wash(rgb, dimmer)
-                    except Exception as e:
-                        _LOGGER.warning("DMX Input set_dmx_wash: %s", e)
-        else:
-            if mode_val >= on_t:
-                state["wash_on"] = True
-                dimmer = _channel(dmx, dim_ch) / 255.0
-                rgb = (
-                    _channel(dmx, r_ch),
-                    _channel(dmx, g_ch),
-                    _channel(dmx, b_ch),
-                )
-                for v in targets:
-                    try:
-                        v.set_dmx_wash(rgb, dimmer)
-                        self._owned_washes.add(v.id)
-                    except Exception as e:
-                        _LOGGER.warning("DMX Input set_dmx_wash: %s", e)
-                _LOGGER.info(
-                    "DMX Input: fixture '%s' wash ON rgb=%s dimmer=%.2f on "
-                    "%d virtual(s)",
-                    mapping.get("name", idx),
-                    rgb,
-                    dimmer,
-                    len(targets),
-                )
+        dimmer = _channel(dmx, dim_ch) / 255.0
+        rgb = (
+            _channel(dmx, r_ch),
+            _channel(dmx, g_ch),
+            _channel(dmx, b_ch),
+        )
+
+        if not state["wash_on"]:
+            state["wash_on"] = True
+            _LOGGER.info(
+                "DMX Input: fixture '%s' wash ENGAGED on %d virtual(s)",
+                mapping.get("name", idx),
+                len(targets),
+            )
+
+        for v in targets:
+            try:
+                v.set_dmx_wash(rgb, dimmer)
+                self._owned_washes.add(v.id)
+            except Exception as e:
+                _LOGGER.warning("DMX Input set_dmx_wash: %s", e)
 
     # ------------------------------------------------------------------
     # Helpers
@@ -595,6 +635,10 @@ class DMXInput(Integration):
                 self._owned_color.discard(v.id)
         elif mtype == "fixture" and state.get("wash_on"):
             state["wash_on"] = False
+            _LOGGER.info(
+                "DMX Input: fixture '%s' wash RELEASED (stale/deactivated)",
+                mapping.get("name", idx),
+            )
             for v in self._targets(mapping):
                 try:
                     v.clear_dmx_wash()

--- a/ledfx/integrations/dmx_input.py
+++ b/ledfx/integrations/dmx_input.py
@@ -475,7 +475,14 @@ class DMXInput(Integration):
         )
 
     def _process_trigger(self, idx, mapping, dmx):
-        state = self._mapping_state.setdefault(idx, {"triggered": False})
+        # Use setdefault on the specific key, not just the container: if this
+        # index previously held state for a *different* mapping type (e.g.
+        # the mapping's type was edited in place from "color"/"fixture" to
+        # "trigger" without restarting), the dict already exists but lacks
+        # this handler's key — a plain setdefault(idx, {...}) would silently
+        # leave it missing and this handler would KeyError forever.
+        state = self._mapping_state.setdefault(idx, {})
+        state.setdefault("triggered", False)
         ch = int(mapping.get("channels", [1])[0])
         value = _channel(dmx, ch)
         on_t = int(mapping.get("on_threshold", 128))
@@ -512,7 +519,11 @@ class DMXInput(Integration):
                     _LOGGER.warning("DMX Input activate_override: %s", e)
 
     def _process_color(self, idx, mapping, dmx):
-        state = self._mapping_state.setdefault(idx, {"last_color": None})
+        # See _process_trigger for why we setdefault the key, not just the
+        # container dict — guards against a mapping's type having been
+        # changed in place at runtime.
+        state = self._mapping_state.setdefault(idx, {})
+        state.setdefault("last_color", None)
         chans = mapping.get("channels", [1, 2, 3])
         r = _channel(dmx, int(chans[0]))
         g = _channel(dmx, int(chans[1]))
@@ -543,7 +554,11 @@ class DMXInput(Integration):
         bright "flash" of the underlying effect whenever the operator dims a
         fixture down to (near) zero.
         """
-        state = self._mapping_state.setdefault(idx, {"wash_on": False})
+        state = self._mapping_state.setdefault(idx, {})
+        # See _process_trigger for why we setdefault the key, not just the
+        # container dict — guards against a mapping's type having been
+        # changed in place at runtime.
+        state.setdefault("wash_on", False)
         chans = mapping.get("channels", {})
         # channels may be a dict {dimmer,r,g,b} or a 4-list in that order
         # (a legacy "mode" key, if still present in old saved mappings, is

--- a/ledfx/integrations/dmx_input.py
+++ b/ledfx/integrations/dmx_input.py
@@ -27,6 +27,7 @@ integration pattern) as a list of dicts. See ``MAPPING_SCHEMA`` for the shape.
 import asyncio
 import logging
 import os
+import random
 import socket
 import struct
 import time
@@ -578,12 +579,25 @@ class DMXInput(Integration):
         deactivated/removed, handled by ``_release_mapping``. This avoids a
         bright "flash" of the underlying effect whenever the operator dims a
         fixture down to (near) zero.
+
+        Optional ``strobe_probability`` (0.0-1.0, default 1.0): real DMX
+        fixtures each strobe on their own independent onboard oscillator, so
+        multiple real fixtures visibly drift out of sync with each other even
+        when fed identical DMX — whereas LedFx mirrors the incoming dimmer
+        frame-perfectly, looking artificially "locked". Setting this below
+        1.0 draws one Bernoulli trial per detected strobe *pulse* (edge-
+        detected: dimmer rising from 0), forcing that pulse to render black
+        instead of firing with probability ``1 - strobe_probability``. The
+        default of 1.0 renders every pulse (today's exact behaviour, no
+        regression for anyone who leaves the setting untouched).
         """
         state = self._mapping_state.setdefault(idx, {})
         # See _process_trigger for why we setdefault the key, not just the
         # container dict — guards against a mapping's type having been
         # changed in place at runtime.
         state.setdefault("wash_on", False)
+        state.setdefault("strobe_pulse_on", False)
+        state.setdefault("strobe_pulse_render", True)
         chans = mapping.get("channels", {})
         # channels may be a dict {dimmer,r,g,b} or a 4-list in that order
         # (a legacy "mode" key, if still present in old saved mappings, is
@@ -603,6 +617,22 @@ class DMXInput(Integration):
             _channel(dmx, g_ch),
             _channel(dmx, b_ch),
         )
+
+        strobe_probability = float(mapping.get("strobe_probability", 1.0))
+        strobe_probability = max(0.0, min(1.0, strobe_probability))
+        if strobe_probability < 1.0:
+            pulse_on = dimmer > 0.0
+            if pulse_on and not state["strobe_pulse_on"]:
+                # Rising edge of a new strobe pulse — roll once and hold the
+                # decision until the pulse's falling edge, so a single
+                # intended flash isn't chopped into flicker by re-rolling
+                # every frame.
+                state["strobe_pulse_render"] = (
+                    random.random() < strobe_probability
+                )
+            state["strobe_pulse_on"] = pulse_on
+            if pulse_on and not state["strobe_pulse_render"]:
+                dimmer = 0.0
 
         if not state["wash_on"]:
             state["wash_on"] = True

--- a/ledfx/integrations/dmx_input.py
+++ b/ledfx/integrations/dmx_input.py
@@ -457,6 +457,28 @@ class DMXInput(Integration):
                 continue
 
             mtype = mapping.get("type")
+
+            # If this mapping's type was edited in place at runtime (same
+            # index, e.g. "fixture" -> "color" via the UI), release whatever
+            # the *previous* type owned (wash takeover, color override,
+            # triggered venue pad) before dispatching to the new type's
+            # handler. Without this, e.g. a virtual's DMX wash takeover
+            # (which wins render priority over a color override) would stay
+            # engaged forever with its last stale value, since nothing else
+            # ever calls clear_dmx_wash() for it once the mapping stops
+            # being processed as "fixture" — the LED appears permanently
+            # frozen on the last wash frame even though a new color override
+            # is being applied underneath it.
+            prev_state = self._mapping_state.get(idx)
+            prev_type = prev_state.get("_active_type") if prev_state else None
+            if prev_type is not None and prev_type != mtype:
+                self._release_mapping(idx, mapping, mtype=prev_type)
+            # Record unconditionally (creating the state dict on the very
+            # first cycle if needed) so a type change is detected even if
+            # this is the mapping's first-ever processed cycle immediately
+            # followed by a type edit before the next cycle.
+            self._mapping_state.setdefault(idx, {})["_active_type"] = mtype
+
             if mtype == "trigger":
                 self._process_trigger(idx, mapping, dmx)
             elif mtype == "color":
@@ -470,9 +492,12 @@ class DMXInput(Integration):
 
     def _prime_mapping(self, idx, mapping, dmx):
         """Record an initial 'off' baseline so startup does not auto-fire."""
-        self._mapping_state.setdefault(
+        state = self._mapping_state.setdefault(
             idx, {"triggered": False, "last_color": None, "wash_on": False}
         )
+        # Seed the active type so the first real _process() cycle after
+        # priming has a baseline to detect an in-place type change against.
+        state.setdefault("_active_type", mapping.get("type"))
 
     def _process_trigger(self, idx, mapping, dmx):
         # Use setdefault on the specific key, not just the container: if this
@@ -625,12 +650,21 @@ class DMXInput(Integration):
                 if v is not None:
                     yield v
 
-    def _release_mapping(self, idx, mapping):
-        """Release whatever a single mapping currently owns."""
+    def _release_mapping(self, idx, mapping, mtype=None):
+        """Release whatever a single mapping currently owns.
+
+        Args:
+            mtype: release ownership for this type instead of the mapping's
+                current ``type``. Used when a mapping's type was edited in
+                place at runtime — we must release what the *previous* type
+                owned (e.g. a fixture wash takeover), not what the new type
+                would own, since the new type hasn't engaged anything yet.
+        """
         state = self._mapping_state.get(idx)
         if not state:
             return
-        mtype = mapping.get("type")
+        if mtype is None:
+            mtype = mapping.get("type")
         if mtype == "trigger" and state.get("triggered"):
             state["triggered"] = False
             venue_id = mapping.get("venue_id")

--- a/ledfx/integrations/dmx_input.py
+++ b/ledfx/integrations/dmx_input.py
@@ -462,7 +462,7 @@ class DMXInput(Integration):
         if rgb == state["last_color"]:
             return
         state["last_color"] = rgb
-        hex_color = "#{:02x}{:02x}{:02x}".format(r, g, b)
+        hex_color = f"#{r:02x}{g:02x}{b:02x}"
         for v in self._targets(mapping):
             try:
                 v.set_color_override(hex_color)

--- a/ledfx/integrations/dmx_input.py
+++ b/ledfx/integrations/dmx_input.py
@@ -561,6 +561,28 @@ class DMXInput(Integration):
                 continue
 
             mtype = mapping.get("type")
+
+            # If this mapping's type was edited in place at runtime (same
+            # index, e.g. "fixture" -> "color" via the UI), release whatever
+            # the *previous* type owned (wash takeover, color override,
+            # triggered venue pad) before dispatching to the new type's
+            # handler. Without this, e.g. a virtual's DMX wash takeover
+            # (which wins render priority over a color override) would stay
+            # engaged forever with its last stale value, since nothing else
+            # ever calls clear_dmx_wash() for it once the mapping stops
+            # being processed as "fixture" — the LED appears permanently
+            # frozen on the last wash frame even though a new color override
+            # is being applied underneath it.
+            prev_state = self._mapping_state.get(idx)
+            prev_type = prev_state.get("_active_type") if prev_state else None
+            if prev_type is not None and prev_type != mtype:
+                self._release_mapping(idx, mapping, mtype=prev_type)
+            # Record unconditionally (creating the state dict on the very
+            # first cycle if needed) so a type change is detected even if
+            # this is the mapping's first-ever processed cycle immediately
+            # followed by a type edit before the next cycle.
+            self._mapping_state.setdefault(idx, {})["_active_type"] = mtype
+
             if mtype == "trigger":
                 self._process_trigger(idx, mapping, dmx)
             elif mtype == "color":
@@ -574,9 +596,12 @@ class DMXInput(Integration):
 
     def _prime_mapping(self, idx, mapping, dmx):
         """Record an initial 'off' baseline so startup does not auto-fire."""
-        self._mapping_state.setdefault(
+        state = self._mapping_state.setdefault(
             idx, {"triggered": False, "last_color": None, "wash_on": False}
         )
+        # Seed the active type so the first real _process() cycle after
+        # priming has a baseline to detect an in-place type change against.
+        state.setdefault("_active_type", mapping.get("type"))
 
     def _process_trigger(self, idx, mapping, dmx):
         # Use setdefault on the specific key, not just the container: if this
@@ -773,12 +798,21 @@ class DMXInput(Integration):
         except Exception as e:
             _LOGGER.warning("DMX Input clear_override: %s", e)
 
-    def _release_mapping(self, idx, mapping):
-        """Release whatever a single mapping currently owns."""
+    def _release_mapping(self, idx, mapping, mtype=None):
+        """Release whatever a single mapping currently owns.
+
+        Args:
+            mtype: release ownership for this type instead of the mapping's
+                current ``type``. Used when a mapping's type was edited in
+                place at runtime — we must release what the *previous* type
+                owned (e.g. a fixture wash takeover), not what the new type
+                would own, since the new type hasn't engaged anything yet.
+        """
         state = self._mapping_state.get(idx)
         if not state:
             return
-        mtype = mapping.get("type")
+        if mtype is None:
+            mtype = mapping.get("type")
         if mtype == "trigger" and state.get("triggered"):
             state["triggered"] = False
             venue_id = mapping.get("venue_id")

--- a/ledfx/integrations/dmx_input.py
+++ b/ledfx/integrations/dmx_input.py
@@ -579,7 +579,14 @@ class DMXInput(Integration):
         )
 
     def _process_trigger(self, idx, mapping, dmx):
-        state = self._mapping_state.setdefault(idx, {"triggered": False})
+        # Use setdefault on the specific key, not just the container: if this
+        # index previously held state for a *different* mapping type (e.g.
+        # the mapping's type was edited in place from "color"/"fixture" to
+        # "trigger" without restarting), the dict already exists but lacks
+        # this handler's key — a plain setdefault(idx, {...}) would silently
+        # leave it missing and this handler would KeyError forever.
+        state = self._mapping_state.setdefault(idx, {})
+        state.setdefault("triggered", False)
         ch = int(mapping.get("channels", [1])[0])
         value = _channel(dmx, ch)
         on_t = int(mapping.get("on_threshold", 128))
@@ -619,7 +626,11 @@ class DMXInput(Integration):
                     _LOGGER.warning("DMX Input activate_override: %s", e)
 
     def _process_color(self, idx, mapping, dmx):
-        state = self._mapping_state.setdefault(idx, {"last_color": None})
+        # See _process_trigger for why we setdefault the key, not just the
+        # container dict — guards against a mapping's type having been
+        # changed in place at runtime.
+        state = self._mapping_state.setdefault(idx, {})
+        state.setdefault("last_color", None)
         chans = mapping.get("channels", [1, 2, 3])
         r = _channel(dmx, int(chans[0]))
         g = _channel(dmx, int(chans[1]))
@@ -650,7 +661,11 @@ class DMXInput(Integration):
         bright "flash" of the underlying effect whenever the operator dims a
         fixture down to (near) zero.
         """
-        state = self._mapping_state.setdefault(idx, {"wash_on": False})
+        state = self._mapping_state.setdefault(idx, {})
+        # See _process_trigger for why we setdefault the key, not just the
+        # container dict — guards against a mapping's type having been
+        # changed in place at runtime.
+        state.setdefault("wash_on", False)
         chans = mapping.get("channels", {})
         # channels may be a dict {dimmer,r,g,b} or a 4-list in that order
         # (a legacy "mode" key, if still present in old saved mappings, is

--- a/ledfx/integrations/dmx_input.py
+++ b/ledfx/integrations/dmx_input.py
@@ -33,6 +33,7 @@ import time
 
 import voluptuous as vol
 
+from ledfx.config import save_config
 from ledfx.integrations import Integration
 from ledfx.venues import VenueManager
 
@@ -241,6 +242,54 @@ def _channel(dmx: bytes, ch: int) -> int:
     return 0
 
 
+def compute_dmx_mapped(ledfx):
+    """Cross-reference every ``dmx_input`` integration's mappings to find
+    which virtuals and venues are currently targeted by DMX Input.
+
+    Used by the virtuals/venues REST endpoints to compute a ``dmx_mapped``
+    flag per item, so the frontend can only render pause controls where DMX
+    actually applies.
+
+    Returns:
+        (mapped_virtual_ids, mapped_venue_ids): a tuple of sets. A venue is
+        included if any mapping targets it directly by ``venue_id``, or if
+        it owns a virtual targeted directly by ``virtual_id``. A virtual is
+        included if any mapping targets it directly, or targets a venue it
+        belongs to.
+    """
+    mapped_virtual_ids = set()
+    mapped_venue_ids = set()
+
+    integrations = getattr(ledfx, "integrations", None)
+    if integrations is not None:
+        for integration in integrations.values():
+            if getattr(integration, "type", None) != "dmx_input":
+                continue
+            get_mappings = getattr(integration, "get_mappings", None)
+            if get_mappings is None:
+                continue
+            for mapping in get_mappings():
+                vid = mapping.get("virtual_id")
+                if vid:
+                    mapped_virtual_ids.add(vid)
+                venue_id = mapping.get("venue_id")
+                if venue_id:
+                    mapped_venue_ids.add(venue_id)
+
+    # Expand venue-targeted mappings to their member virtuals, and mark a
+    # venue as mapped if it owns a directly-targeted virtual.
+    venues = getattr(ledfx, "venues", None)
+    if venues is not None:
+        for venue_id, cfg in venues.list_venues().items():
+            virtual_ids = cfg.get("virtual_ids", [])
+            if venue_id in mapped_venue_ids:
+                mapped_virtual_ids.update(virtual_ids)
+            elif mapped_virtual_ids.intersection(virtual_ids):
+                mapped_venue_ids.add(venue_id)
+
+    return mapped_virtual_ids, mapped_venue_ids
+
+
 class DMXInput(Integration):
     """Bridge incoming Art-Net DMX onto LedFx venue overrides and virtuals."""
 
@@ -301,8 +350,17 @@ class DMXInput(Integration):
 
         self._ledfx = ledfx
         self._config = config
-        # data is the list of channel mappings
-        self._data = data if isinstance(data, list) else []
+        # `data` is the integration's persisted state. Historically this was
+        # just the list of channel mappings; it is now a dict of
+        # ``{"mappings": [...], "paused": bool}`` so the global pause flag
+        # can survive restarts alongside the mappings. Old-format (bare
+        # list) configs are transparently migrated on load.
+        if isinstance(data, dict):
+            self._data = data.get("mappings", [])
+            self._paused = bool(data.get("paused", False))
+        else:
+            self._data = data if isinstance(data, list) else []
+            self._paused = False
 
         self._transport = None
         self._protocol = None
@@ -326,6 +384,11 @@ class DMXInput(Integration):
     # Mapping management (persisted in self._data)
     # ------------------------------------------------------------------
 
+    @property
+    def data(self):
+        """Persisted state: mapping list plus the global pause flag."""
+        return {"mappings": self._data, "paused": self._paused}
+
     def get_mappings(self):
         return self._data
 
@@ -343,6 +406,40 @@ class DMXInput(Integration):
             str(universe): list(dmx)
             for universe, dmx in self._latest_dmx.items()
         }
+
+    @property
+    def paused(self) -> bool:
+        return self._paused
+
+    def set_paused(self, paused: bool):
+        """Globally mute (or unmute) this integration's DMX takeover.
+
+        The Art-Net UDP listener keeps running and still replies to
+        ArtPoll (so SoundSwitch stays "connected") — pausing only stops
+        mapping dispatch. Pausing releases every mapping's currently owned
+        wash/color override/venue-trigger immediately, so all target
+        virtuals revert right away instead of waiting for the next
+        stale-stream timeout. Unpausing needs no special action: the next
+        DMX tick re-engages mappings naturally.
+        """
+        self._paused = bool(paused)
+        if self._paused:
+            self._release_all()
+        self._persist()
+
+    def _persist(self):
+        """Save this integration's persisted state (mirrors the API's
+        ``_persist`` helper in ``ledfx.api.integration_dmx_input``), so
+        toggling pause is instant and durable without triggering a
+        reconnect (unlike a ``CONFIG_SCHEMA`` change)."""
+        for integration in self._ledfx.config.get("integrations", []):
+            if integration["id"] == self.id:
+                integration["data"] = self.data
+                break
+        save_config(
+            config=self._ledfx.config,
+            config_dir=self._ledfx.config_dir,
+        )
 
     # ------------------------------------------------------------------
     # Connection lifecycle
@@ -418,6 +515,13 @@ class DMXInput(Integration):
             pass
 
     def _process(self):
+        # Global pause: the UDP listener and update loop keep running (so
+        # ArtPoll replies and DMX intake are unaffected and SoundSwitch
+        # stays "connected"), but no mapping is dispatched — nothing is
+        # applied to any virtual/venue while paused.
+        if self._paused:
+            return
+
         now = time.monotonic()
         stale_timeout = self._config.get("stale_timeout", 2.0)
         hold = self._config.get("hold_last_look", False)
@@ -485,22 +589,25 @@ class DMXInput(Integration):
         if venue_id is None or pad_index is None:
             return
 
-        mgr = self._venues()
+        if self._venues().is_paused(venue_id):
+            # Venue paused: stop tracking edges and drop ownership until
+            # unpaused (the venue's own pause already cleared its override).
+            state["triggered"] = False
+            self._venue_override_owner.pop(venue_id, None)
+            return
+
         if state["triggered"]:
             if value <= off_t:
                 state["triggered"] = False
                 # Only clear if we still own this venue's override
                 if self._venue_override_owner.get(venue_id) == idx:
-                    try:
-                        mgr.clear_override(venue_id)
-                    except Exception as e:
-                        _LOGGER.warning("DMX Input clear_override: %s", e)
+                    self._clear_venue_pad(venue_id)
                     self._venue_override_owner.pop(venue_id, None)
         else:
             if value >= on_t:
                 state["triggered"] = True
                 try:
-                    mgr.activate_override(venue_id, int(pad_index))
+                    self._activate_venue_pad(venue_id, int(pad_index))
                     self._venue_override_owner[venue_id] = idx
                     _LOGGER.info(
                         "DMX Input: trigger '%s' activated override pad %s on venue '%s'",
@@ -592,23 +699,64 @@ class DMXInput(Integration):
         """Yield target virtuals for a color/fixture mapping.
 
         A mapping targets either a single ``virtual_id`` or every virtual in a
-        ``venue_id``.
+        ``venue_id``. Applies global -> venue -> device pause precedence:
+        a globally paused integration yields nothing at all, a paused venue
+        yields nothing for venue-targeted mappings, and an individually
+        paused virtual is skipped regardless of how it was targeted. Actual
+        release of any override this virtual currently owns happens the
+        instant the relevant pause flag is set (see ``set_paused`` here,
+        ``VenueManager.set_paused``, and ``Virtual.set_dmx_paused``) — this
+        is only responsible for not re-engaging a paused target.
         """
+        if self._paused:
+            return
+
         vid = mapping.get("virtual_id")
         if vid:
             v = self._ledfx.virtuals.get(vid)
-            if v is not None:
+            if v is not None and not v.is_dmx_paused():
                 yield v
             return
         venue_id = mapping.get("venue_id")
         if venue_id:
+            if self._venues().is_paused(venue_id):
+                return
             cfg = self._venues().get(venue_id)
             if not cfg:
                 return
             for v_id in cfg.get("virtual_ids", []):
                 v = self._ledfx.virtuals.get(v_id)
-                if v is not None:
+                if v is not None and not v.is_dmx_paused():
                     yield v
+
+    def _activate_venue_pad(self, venue_id, pad_index):
+        """Apply a venue color pad, honoring per-device DMX pause.
+
+        Mirrors ``VenueManager.activate_override`` but routes virtual
+        selection through ``_targets`` so a device-paused virtual in the
+        venue is skipped even though the trigger targets the whole venue.
+        """
+        cfg = self._venues().get(venue_id)
+        if not cfg:
+            raise KeyError(f"Venue '{venue_id}' not found")
+
+        pads = cfg["color_pads"]["pads"]
+        if pad_index < 0 or pad_index >= len(pads):
+            raise IndexError(
+                f"Pad index {pad_index} out of range (0-{len(pads) - 1})"
+            )
+
+        pad = pads[pad_index]
+        color_or_gradient = pad.get("gradient") or pad.get("color", "#ffffff")
+
+        for v in self._targets({"venue_id": venue_id}):
+            v.set_color_override(color_or_gradient)
+
+    def _clear_venue_pad(self, venue_id):
+        try:
+            self._venues().clear_override(venue_id)
+        except Exception as e:
+            _LOGGER.warning("DMX Input clear_override: %s", e)
 
     def _release_mapping(self, idx, mapping):
         """Release whatever a single mapping currently owns."""
@@ -620,10 +768,7 @@ class DMXInput(Integration):
             state["triggered"] = False
             venue_id = mapping.get("venue_id")
             if venue_id and self._venue_override_owner.get(venue_id) == idx:
-                try:
-                    self._venues().clear_override(venue_id)
-                except Exception:
-                    pass
+                self._clear_venue_pad(venue_id)
                 self._venue_override_owner.pop(venue_id, None)
         elif mtype == "color" and state.get("last_color") is not None:
             state["last_color"] = None

--- a/ledfx/venues.py
+++ b/ledfx/venues.py
@@ -1,0 +1,237 @@
+"""Venue manager for LedFx.
+
+A venue is a named collection of virtuals. It provides:
+  - a filtered view: only that venue's virtuals are shown in the UI
+  - a color-override pad grid (NxM): each pad holds a solid color or gradient
+    string; activating a pad overpaints all venue virtuals until cleared.
+
+Venues are persisted in config.json under the "venues" key as a dict keyed
+by venue ID.  Each value has the shape:
+
+    {
+        "name": str,
+        "virtual_ids": [str, ...],          # virtuals belonging to this venue
+        "color_pads": {
+            "rows": int,                    # grid height
+            "cols": int,                    # grid width
+            "pads": [                       # flat list, row-major order
+                {"color": "#rrggbb"},       # solid color pad
+                {"gradient": "linear-gradient(...)"},  # gradient pad
+                ...
+            ]
+        }
+    }
+
+Exclusive membership is enforced: a virtual may belong to at most one venue.
+"""
+
+from __future__ import annotations
+
+import colorsys
+import logging
+from typing import Optional
+
+from ledfx.config import save_config
+from ledfx.utils import generate_id
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _hsl_auto_palette(n: int) -> list[dict]:
+    """Return *n* evenly-spaced hue colors as pad dicts."""
+    pads = []
+    for i in range(n):
+        hue = i / n
+        r, g, b = colorsys.hls_to_rgb(hue, 0.5, 1.0)
+        hex_color = "#{:02x}{:02x}{:02x}".format(
+            int(r * 255), int(g * 255), int(b * 255)
+        )
+        pads.append({"color": hex_color})
+    return pads
+
+
+class VenueManager:
+    """Manages venues in LedFx config."""
+
+    def __init__(self, ledfx):
+        self._ledfx = ledfx
+
+    @property
+    def _venues(self) -> dict:
+        return self._ledfx.config.setdefault("venues", {})
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _find_venue_for_virtual(self, virtual_id: str) -> Optional[str]:
+        """Return the venue ID that owns *virtual_id*, or None."""
+        for vid, cfg in self._venues.items():
+            if virtual_id in cfg.get("virtual_ids", []):
+                return vid
+        return None
+
+    def _save(self):
+        save_config(
+            config=self._ledfx.config,
+            config_dir=self._ledfx.config_dir,
+        )
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    def list_venues(self) -> dict:
+        return dict(self._venues)
+
+    def get(self, venue_id: str) -> Optional[dict]:
+        return self._venues.get(venue_id)
+
+    def create(self, name: str, rows: int = 4, cols: int = 4) -> dict:
+        """Create a new venue with an auto-filled color pad grid."""
+        venue_id = generate_id(name)
+        # Deduplicate ID
+        base_id = venue_id
+        idx = 1
+        while venue_id in self._venues:
+            venue_id = f"{base_id}-{idx}"
+            idx += 1
+
+        n_pads = rows * cols
+        venue_cfg = {
+            "name": name,
+            "virtual_ids": [],
+            "color_pads": {
+                "rows": rows,
+                "cols": cols,
+                "pads": _hsl_auto_palette(n_pads),
+            },
+        }
+        self._venues[venue_id] = venue_cfg
+        self._save()
+        _LOGGER.info("Created venue '%s' (%s)", name, venue_id)
+        return {"id": venue_id, **venue_cfg}
+
+    def update(self, venue_id: str, data: dict) -> dict:
+        """Update name and/or color_pads config for a venue.
+
+        Supported keys in *data*: ``name``, ``color_pads``.
+        To resize the grid pass ``color_pads`` with ``rows``/``cols``; the pads
+        list will be re-initialised to an auto-palette unless ``pads`` is also
+        supplied.
+        """
+        cfg = self._venues.get(venue_id)
+        if cfg is None:
+            raise KeyError(f"Venue '{venue_id}' not found")
+
+        if "name" in data:
+            cfg["name"] = str(data["name"])
+
+        if "color_pads" in data:
+            cp = data["color_pads"]
+            rows = int(cp.get("rows", cfg["color_pads"]["rows"]))
+            cols = int(cp.get("cols", cfg["color_pads"]["cols"]))
+            n_pads = rows * cols
+            if "pads" in cp and len(cp["pads"]) == n_pads:
+                pads = list(cp["pads"])
+            else:
+                pads = _hsl_auto_palette(n_pads)
+            cfg["color_pads"] = {"rows": rows, "cols": cols, "pads": pads}
+
+        self._save()
+        return {"id": venue_id, **cfg}
+
+    def delete(self, venue_id: str) -> bool:
+        """Delete a venue and clear any active overrides on its virtuals."""
+        cfg = self._venues.pop(venue_id, None)
+        if cfg is None:
+            return False
+        # Clear any active color overrides
+        for vid in cfg.get("virtual_ids", []):
+            v = self._ledfx.virtuals.get(vid)
+            if v is not None:
+                v.clear_color_override()
+        self._save()
+        _LOGGER.info("Deleted venue '%s'", venue_id)
+        return True
+
+    # ------------------------------------------------------------------
+    # Virtual membership
+    # ------------------------------------------------------------------
+
+    def add_virtual(self, venue_id: str, virtual_id: str) -> dict:
+        """Add *virtual_id* to *venue_id* (exclusive membership enforced)."""
+        cfg = self._venues.get(venue_id)
+        if cfg is None:
+            raise KeyError(f"Venue '{venue_id}' not found")
+
+        if self._ledfx.virtuals.get(virtual_id) is None:
+            raise ValueError(f"Virtual '{virtual_id}' not found")
+
+        existing = self._find_venue_for_virtual(virtual_id)
+        if existing and existing != venue_id:
+            raise ValueError(
+                f"Virtual '{virtual_id}' already belongs to venue '{existing}'"
+            )
+
+        if virtual_id not in cfg["virtual_ids"]:
+            cfg["virtual_ids"].append(virtual_id)
+            self._save()
+
+        return {"id": venue_id, **cfg}
+
+    def remove_virtual(self, venue_id: str, virtual_id: str) -> dict:
+        """Remove *virtual_id* from *venue_id* and clear its override."""
+        cfg = self._venues.get(venue_id)
+        if cfg is None:
+            raise KeyError(f"Venue '{venue_id}' not found")
+
+        if virtual_id in cfg["virtual_ids"]:
+            cfg["virtual_ids"].remove(virtual_id)
+            v = self._ledfx.virtuals.get(virtual_id)
+            if v is not None:
+                v.clear_color_override()
+            self._save()
+
+        return {"id": venue_id, **cfg}
+
+    def cleanup_virtual(self, virtual_id: str):
+        """Remove *virtual_id* from whichever venue owns it (called on virtual delete)."""
+        owner = self._find_venue_for_virtual(virtual_id)
+        if owner:
+            self.remove_virtual(owner, virtual_id)
+
+    # ------------------------------------------------------------------
+    # Override helpers
+    # ------------------------------------------------------------------
+
+    def activate_override(self, venue_id: str, pad_index: int):
+        """Apply the color/gradient from pad *pad_index* to all venue virtuals."""
+        cfg = self._venues.get(venue_id)
+        if cfg is None:
+            raise KeyError(f"Venue '{venue_id}' not found")
+
+        pads = cfg["color_pads"]["pads"]
+        if pad_index < 0 or pad_index >= len(pads):
+            raise IndexError(
+                f"Pad index {pad_index} out of range (0-{len(pads) - 1})"
+            )
+
+        pad = pads[pad_index]
+        color_or_gradient = pad.get("gradient") or pad.get("color", "#ffffff")
+
+        for vid in cfg["virtual_ids"]:
+            v = self._ledfx.virtuals.get(vid)
+            if v is not None:
+                v.set_color_override(color_or_gradient)
+
+    def clear_override(self, venue_id: str):
+        """Clear the color override from all virtuals in *venue_id*."""
+        cfg = self._venues.get(venue_id)
+        if cfg is None:
+            raise KeyError(f"Venue '{venue_id}' not found")
+
+        for vid in cfg["virtual_ids"]:
+            v = self._ledfx.virtuals.get(vid)
+            if v is not None:
+                v.clear_color_override()

--- a/ledfx/venues.py
+++ b/ledfx/venues.py
@@ -11,6 +11,7 @@ by venue ID.  Each value has the shape:
     {
         "name": str,
         "virtual_ids": [str, ...],          # virtuals belonging to this venue
+        "paused": bool,                     # mute DMX Input takeover for this venue
         "color_pads": {
             "rows": int,                    # grid height
             "cols": int,                    # grid width
@@ -101,6 +102,7 @@ class VenueManager:
         venue_cfg = {
             "name": name,
             "virtual_ids": [],
+            "paused": False,
             "color_pads": {
                 "rows": rows,
                 "cols": cols,
@@ -235,3 +237,30 @@ class VenueManager:
             v = self._ledfx.virtuals.get(vid)
             if v is not None:
                 v.clear_color_override()
+
+    # ------------------------------------------------------------------
+    # DMX pause
+    # ------------------------------------------------------------------
+
+    def set_paused(self, venue_id: str, paused: bool) -> dict:
+        """Mute (or unmute) DMX Input takeover for all virtuals in a venue.
+
+        Pausing also clears any active color-pad override on the venue,
+        since both represent "this venue's manual takeover" from the
+        operator's perspective.
+        """
+        cfg = self._venues.get(venue_id)
+        if cfg is None:
+            raise KeyError(f"Venue '{venue_id}' not found")
+
+        cfg["paused"] = bool(paused)
+        if cfg["paused"]:
+            self.clear_override(venue_id)
+        self._save()
+        return {"id": venue_id, **cfg}
+
+    def is_paused(self, venue_id: str) -> bool:
+        cfg = self._venues.get(venue_id)
+        if cfg is None:
+            return False
+        return bool(cfg.get("paused", False))

--- a/ledfx/venues.py
+++ b/ledfx/venues.py
@@ -64,7 +64,7 @@ class VenueManager:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _find_venue_for_virtual(self, virtual_id: str) -> Optional[str]:
+    def _find_venue_for_virtual(self, virtual_id: str) -> str | None:
         """Return the venue ID that owns *virtual_id*, or None."""
         for vid, cfg in self._venues.items():
             if virtual_id in cfg.get("virtual_ids", []):
@@ -84,7 +84,7 @@ class VenueManager:
     def list_venues(self) -> dict:
         return dict(self._venues)
 
-    def get(self, venue_id: str) -> Optional[dict]:
+    def get(self, venue_id: str) -> dict | None:
         return self._venues.get(venue_id)
 
     def create(self, name: str, rows: int = 4, cols: int = 4) -> dict:

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -264,6 +264,12 @@ class Virtual:
         self._wash_rgb: Optional[np.ndarray] = None  # float array, 3, 0-255
         self._wash_dimmer: float = 1.0
 
+        # DMX pause (device-level mute): when True, the DMX input integration
+        # must not apply any mapping (wash, color, or venue-trigger override)
+        # to this virtual. Persisted so it survives restarts, mirroring the
+        # "active" key stored in virtual_cfg.
+        self._dmx_paused: bool = False
+
         self._debug_flush_total = 0.0
         self._debug_last_report = time.perf_counter()
         self._debug_flush_frames = 0
@@ -977,6 +983,23 @@ class Virtual:
     @property
     def wash_active(self) -> bool:
         return self._wash_active
+
+    def set_dmx_paused(self, paused: bool):
+        """Mute (or unmute) DMX Input takeover for this virtual.
+
+        While paused, the DMX Input integration must not apply any mapping
+        (fixture wash, color tint, or venue-trigger override) to this
+        virtual. Pausing releases any currently owned wash/color override
+        immediately so the running effect is visible again right away,
+        instead of waiting for the next stale-stream timeout.
+        """
+        self._dmx_paused = bool(paused)
+        if self._dmx_paused:
+            self.clear_dmx_wash()
+            self.clear_color_override()
+
+    def is_dmx_paused(self) -> bool:
+        return self._dmx_paused
 
     def _fire_update_event(self, frame=None):
         if frame is None:
@@ -1869,6 +1892,10 @@ class Virtuals:
             # via the active key if it exists. Let the setter deal with it
             if "active" in virtual_cfg and not virtual_cfg["active"]:
                 new_virtual.active = False
+
+            # Restore persisted DMX Input device-level pause flag.
+            if virtual_cfg.get("dmx_paused"):
+                new_virtual.set_dmx_paused(True)
 
             # global pause is handled differently to virtual pause
             if pause_all:

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -255,6 +255,15 @@ class Virtual:
         # For gradient overrides: 1024-entry LUT sampled by per-pixel hue.
         self._color_override_lut: Optional[np.ndarray] = None
 
+        # DMX wash takeover (fixture mode): when active, the assembled frame is
+        # fully replaced by a solid colour (rgb * dimmer) before flush, so the
+        # virtual behaves like a dumb DMX wash fixture. The running effect is
+        # suppressed (not removed) and is revealed again the moment the takeover
+        # is cleared. Driven externally (e.g. the DMX input integration).
+        self._wash_active: bool = False
+        self._wash_rgb: Optional[np.ndarray] = None  # float array, 3, 0-255
+        self._wash_dimmer: float = 1.0
+
         self._debug_flush_total = 0.0
         self._debug_last_report = time.perf_counter()
         self._debug_flush_frames = 0
@@ -567,7 +576,6 @@ class Virtual:
 
         if self.fallback_active:
             if self.fallback_effect_type is not None:
-
                 effect = self._ledfx.effects.create(
                     ledfx=self._ledfx,
                     type=self.fallback_effect_type,
@@ -909,9 +917,10 @@ class Virtual:
         else:
             # Fallback: post-process the assembled frame for effects that don't
             # expose a gradient config (e.g. Energy, custom solid-colour effects).
-            self._color_override_frame, self._color_override_lut = (
-                self._build_override_frame()
-            )
+            (
+                self._color_override_frame,
+                self._color_override_lut,
+            ) = self._build_override_frame()
 
     def set_color_override(self, color_or_gradient: str):
         """Activate a persistent colour override on this virtual.
@@ -937,6 +946,37 @@ class Virtual:
             self._color_override_lut = None
             if isinstance(self._active_effect, GradientEffect):
                 self._active_effect.clear_gradient_override()
+
+    def set_dmx_wash(self, rgb, dimmer: float = 1.0):
+        """Take the virtual over as a solid DMX wash fixture.
+
+        While active, the render thread replaces the assembled frame with a
+        solid ``rgb * dimmer`` colour, suppressing (but not removing) the
+        running effect. Intended for external DMX control (e.g. SoundSwitch via
+        the DMX input integration), so an LED run can be programmed alongside
+        real wash fixtures.
+
+        Args:
+            rgb: iterable of 3 values in the 0-255 range (R, G, B).
+            dimmer: master brightness multiplier in the 0.0-1.0 range.
+        """
+        rgb_arr = np.clip(np.asarray(rgb, dtype=float), 0, 255)
+        dimmer = float(np.clip(dimmer, 0.0, 1.0))
+        with self.lock:
+            self._wash_rgb = rgb_arr
+            self._wash_dimmer = dimmer
+            self._wash_active = True
+
+    def clear_dmx_wash(self):
+        """Release the DMX wash takeover; the running effect is visible again."""
+        with self.lock:
+            self._wash_active = False
+            self._wash_rgb = None
+            self._wash_dimmer = 1.0
+
+    @property
+    def wash_active(self) -> bool:
+        return self._wash_active
 
     def _fire_update_event(self, frame=None):
         if frame is None:
@@ -1003,8 +1043,16 @@ class Virtual:
                     # )
                     self.assembled_frame = self.assemble_frame()
                     if self.assembled_frame is not None and not self._paused:
+                        # DMX wash takeover (fixture mode) wins over everything:
+                        # replace the frame with a solid colour × dimmer.
+                        if self._wash_active and self._wash_rgb is not None:
+                            self.assembled_frame = (
+                                np.ones_like(self.assembled_frame)
+                                * self._wash_rgb
+                                * self._wash_dimmer
+                            )
                         # Apply color override as a gel/tint keeping the effect's animation.
-                        if self._color_override_lut is not None:
+                        elif self._color_override_lut is not None:
                             # Gradient override: map each pixel's hue to the gradient LUT,
                             # preserving the effect's per-pixel brightness (animation).
                             self.assembled_frame = _apply_gradient_override(

--- a/ledfx/virtuals.py
+++ b/ledfx/virtuals.py
@@ -32,6 +32,45 @@ from ledfx.utils import Teleplot, fps_to_sleep_interval, is_gap_device
 _LOGGER = logging.getLogger(__name__)
 
 
+def _apply_gradient_override(
+    frame: np.ndarray, lut: np.ndarray, lut_size: int
+) -> np.ndarray:
+    """Recolour *frame* using a gradient LUT indexed by per-pixel hue.
+
+    The effect's per-pixel **brightness** (HSV value = max RGB channel) is
+    preserved so beats, scrolls, and animations continue to show motion.
+    The *hue* of each pixel is used to select which gradient colour to use,
+    so a scrolling rainbow remaps cleanly to the override gradient palette.
+
+    Args:
+        frame:    N×3 float array (0–255), the assembled effect output.
+        lut:      L×3 float array (0–255), pre-sampled gradient at L positions.
+        lut_size: number of LUT entries (L).
+
+    Returns:
+        N×3 float array with gradient colours scaled by the effect's brightness.
+    """
+    f = frame / 255.0  # (N, 3) in [0, 1]
+    r, g, b = f[:, 0], f[:, 1], f[:, 2]
+    maxc = np.maximum(np.maximum(r, g), b)  # HSV value (brightness)
+    minc = np.minimum(np.minimum(r, g), b)
+    diff = maxc - minc
+
+    hue = np.zeros(len(frame), dtype=float)
+    chromatic = diff > 1e-6
+    mr = chromatic & (r == maxc)
+    mg = chromatic & (g == maxc) & ~mr
+    mb = chromatic & (b == maxc) & ~mr & ~mg
+    hue[mr] = ((g[mr] - b[mr]) / diff[mr]) % 6
+    hue[mg] = (b[mg] - r[mg]) / diff[mg] + 2
+    hue[mb] = (r[mb] - g[mb]) / diff[mb] + 4
+    hue /= 6.0  # normalise to [0, 1]
+
+    indices = np.clip((hue * (lut_size - 1)).astype(int), 0, lut_size - 1)
+    # Scale gradient colour by the effect's per-pixel brightness
+    return lut[indices] * maxc[:, np.newaxis]
+
+
 class Virtual:
     CONFIG_SCHEMA = vol.Schema(
         {
@@ -209,6 +248,13 @@ class Virtual:
         # Maps virtual indices to device indices per device
         self._device_remap: dict = {}
 
+        # Color override: when set, overpaints assembled_frame before flush.
+        # Effects keep running in the background; override is instant on/off.
+        self._color_override: Optional[str] = None
+        self._color_override_frame: Optional[np.ndarray] = None
+        # For gradient overrides: 1024-entry LUT sampled by per-pixel hue.
+        self._color_override_lut: Optional[np.ndarray] = None
+
         self._debug_flush_total = 0.0
         self._debug_last_report = time.perf_counter()
         self._debug_flush_frames = 0
@@ -383,6 +429,9 @@ class Virtual:
                 if self.pixel_count != _pixel_count:
                     # chenging segments is a deep edit, just flush any transition
                     self._reactivate_effect()
+                    # Rebuild override frame if pixel count changed
+                    if self._color_override is not None:
+                        self._apply_color_override_to_effect()
 
                 mode = self._config["transition_mode"]
                 self.frame_transitions = self.transitions[mode]
@@ -652,6 +701,9 @@ class Virtual:
                 )
                 return
             self._active_effect.activate(self)
+            # Re-apply any active colour override to the new effect
+            if self._color_override is not None:
+                self._apply_color_override_to_effect()
             self._ledfx.events.fire_event(
                 EffectSetEvent(
                     self._active_effect.name,
@@ -779,6 +831,113 @@ class Virtual:
         self.flush(self.assembled_frame)
         self._fire_update_event()
 
+    _GRADIENT_LUT_SIZE = 1024
+
+    def _build_override_frame(self):
+        """Build override data from the stored color/gradient string.
+
+        Returns:
+            (spatial_frame, gradient_lut) where:
+            - spatial_frame: N×3 float array, gradient sampled at pixel positions.
+              Used for solid colors, and as the static "preview" for gradients.
+            - gradient_lut: 1024×3 float array sampled uniformly 0→1, or None for
+              solid colors. Used at render time: per-pixel hue → LUT index → color.
+        """
+        if self._color_override is None or self.pixel_count == 0:
+            return None, None
+
+        from ledfx.color import RGB, Gradient, parse_gradient
+
+        try:
+            parsed = parse_gradient(self._color_override)
+        except Exception:
+            _LOGGER.warning(
+                "Virtual %s: invalid color override '%s', using white",
+                self.id,
+                self._color_override,
+            )
+            parsed = RGB(255, 255, 255)
+
+        n = self.pixel_count
+
+        if isinstance(parsed, RGB):
+            spatial = np.tile(
+                [parsed.red, parsed.green, parsed.blue], (n, 1)
+            ).astype(float)
+            return spatial, None  # solid colour: no LUT needed
+
+        # Gradient: build spatial frame (for static pad preview) + LUT
+        def _sample_hex(gradient, pos):
+            hex_c = gradient.sample(pos)
+            return (
+                int(hex_c[1:3], 16),
+                int(hex_c[3:5], 16),
+                int(hex_c[5:7], 16),
+            )
+
+        spatial = np.empty((n, 3), dtype=float)
+        for i in range(n):
+            r, g, b = _sample_hex(parsed, i / max(n - 1, 1))
+            spatial[i] = [r, g, b]
+
+        lut_size = self._GRADIENT_LUT_SIZE
+        lut = np.empty((lut_size, 3), dtype=float)
+        for i in range(lut_size):
+            r, g, b = _sample_hex(parsed, i / (lut_size - 1))
+            lut[i] = [r, g, b]
+
+        return spatial, lut
+
+    def _apply_color_override_to_effect(self):
+        """Internal: route override to the effect or to post-processing.
+
+        Called (inside self.lock) whenever the override is activated or the
+        pixel count changes while an override is active.
+        """
+        from ledfx.effects.gradient import GradientEffect
+
+        if self._color_override is None:
+            return
+
+        if isinstance(self._active_effect, GradientEffect):
+            # The effect handles colour natively — inject the override gradient
+            # so animations (roll, modulation, etc.) continue unaffected.
+            self._active_effect.set_gradient_override(self._color_override)
+            # No post-processing needed
+            self._color_override_frame = None
+            self._color_override_lut = None
+        else:
+            # Fallback: post-process the assembled frame for effects that don't
+            # expose a gradient config (e.g. Energy, custom solid-colour effects).
+            self._color_override_frame, self._color_override_lut = (
+                self._build_override_frame()
+            )
+
+    def set_color_override(self, color_or_gradient: str):
+        """Activate a persistent colour override on this virtual.
+
+        For GradientEffect-based effects the override is injected directly into
+        the effect's gradient curve, so all animations continue in the new
+        colours (identical to changing the effect's colour via the UI).
+
+        For other effects the assembled frame is post-processed each cycle
+        using a luminance-preserving tint.
+        """
+        with self.lock:
+            self._color_override = color_or_gradient
+            self._apply_color_override_to_effect()
+
+    def clear_color_override(self):
+        """Remove the colour override; the running effect is immediately visible again."""
+        from ledfx.effects.gradient import GradientEffect
+
+        with self.lock:
+            self._color_override = None
+            self._color_override_frame = None
+            self._color_override_lut = None
+            if isinstance(self._active_effect, GradientEffect):
+                self._active_effect.clear_gradient_override()
+
     def _fire_update_event(self, frame=None):
         if frame is None:
             frame = self.assembled_frame
@@ -844,6 +1003,27 @@ class Virtual:
                     # )
                     self.assembled_frame = self.assemble_frame()
                     if self.assembled_frame is not None and not self._paused:
+                        # Apply color override as a gel/tint keeping the effect's animation.
+                        if self._color_override_lut is not None:
+                            # Gradient override: map each pixel's hue to the gradient LUT,
+                            # preserving the effect's per-pixel brightness (animation).
+                            self.assembled_frame = _apply_gradient_override(
+                                self.assembled_frame,
+                                self._color_override_lut,
+                                self._GRADIENT_LUT_SIZE,
+                            )
+                        elif self._color_override_frame is not None:
+                            # Solid colour override: tint by per-pixel luminance so the
+                            # effect's brightness pattern (beats, pulses) is preserved.
+                            luminance = (
+                                np.max(
+                                    self.assembled_frame, axis=1, keepdims=True
+                                )
+                                / 255.0
+                            )
+                            self.assembled_frame = (
+                                self._color_override_frame * luminance
+                            )
                         if not self._config["preview_only"]:
                             # self._ledfx.thread_executor.submit(self.flush)
                             # await self._ledfx.loop.run_in_executor(

--- a/tests/test_definitions/virtual_config.py
+++ b/tests/test_definitions/virtual_config.py
@@ -319,6 +319,8 @@ virtual_config_tests = {
                         "active": False,
                         "streaming": False,
                         "last_effect": None,
+                        "dmx_mapped": False,
+                        "dmx_paused": False,
                         "effect": {},
                     },
                     "first-virt": {
@@ -346,6 +348,8 @@ virtual_config_tests = {
                         "active": False,
                         "streaming": False,
                         "last_effect": None,
+                        "dmx_mapped": False,
+                        "dmx_paused": False,
                         "effect": {},
                     },
                 }

--- a/tests/test_dmx_input.py
+++ b/tests/test_dmx_input.py
@@ -1,0 +1,68 @@
+"""Tests for the DMX Input (Art-Net) integration parser and mapping logic."""
+
+import struct
+
+from ledfx.integrations.dmx_input import _channel, parse_artdmx
+
+
+def _build_artdmx(universe: int, dmx: bytes, sequence: int = 1) -> bytes:
+    """Build a spec-compliant ArtDMX packet for testing."""
+    length = len(dmx)
+    header = b"Art-Net\x00"
+    header += struct.pack("<H", 0x5000)  # OpCode little-endian
+    header += struct.pack(">H", 14)  # ProtVer big-endian
+    header += bytes([sequence, 0])  # Sequence, Physical
+    header += struct.pack("<H", universe & 0x7FFF)  # Port-Address LE
+    header += struct.pack(">H", length)  # Length big-endian
+    return header + dmx
+
+
+def test_parse_valid_artdmx():
+    dmx = bytes([0, 200, 50] + [0] * 9)
+    pkt = _build_artdmx(7, dmx)
+    result = parse_artdmx(pkt)
+    assert result is not None
+    universe, data = result
+    assert universe == 7
+    assert data == dmx
+
+
+def test_parse_respects_length_field():
+    dmx = bytes([10, 20, 30, 40])
+    pkt = _build_artdmx(0, dmx)
+    universe, data = parse_artdmx(pkt)
+    assert len(data) == 4
+    assert data == dmx
+
+
+def test_parse_rejects_non_artnet():
+    assert parse_artdmx(b"NOT-ARTNET-DATA-AT-ALL") is None
+
+
+def test_parse_rejects_wrong_opcode():
+    pkt = bytearray(_build_artdmx(0, bytes([1, 2, 3])))
+    pkt[8:10] = struct.pack("<H", 0x2000)  # ArtPoll, not ArtDMX
+    assert parse_artdmx(bytes(pkt)) is None
+
+
+def test_parse_rejects_short_packet():
+    assert parse_artdmx(b"Art-Net\x00\x00\x50") is None
+
+
+def test_parse_high_universe():
+    pkt = _build_artdmx(300, bytes([1, 2, 3]))
+    universe, _ = parse_artdmx(pkt)
+    assert universe == 300
+
+
+def test_channel_is_one_based():
+    dmx = bytes([11, 22, 33])
+    assert _channel(dmx, 1) == 11
+    assert _channel(dmx, 2) == 22
+    assert _channel(dmx, 3) == 33
+
+
+def test_channel_out_of_range_returns_zero():
+    dmx = bytes([5, 6])
+    assert _channel(dmx, 99) == 0
+    assert _channel(dmx, 0) == 0

--- a/tests/test_dmx_input.py
+++ b/tests/test_dmx_input.py
@@ -214,7 +214,10 @@ def test_mapping_type_changed_in_place_does_not_crash(monkeypatch):
     integration._on_dmx(0, bytes([0, 10, 20, 30]))
     integration._process()
     assert virtual.set_color_override.called
-    assert integration._mapping_state[0] == {"last_color": (10, 20, 30)}
+    assert integration._mapping_state[0] == {
+        "last_color": (10, 20, 30),
+        "_active_type": "color",
+    }
 
     # Now edit the *same* mapping index's type to "fixture" at runtime,
     # without restarting/re-priming — this is exactly what the frontend's
@@ -227,3 +230,58 @@ def test_mapping_type_changed_in_place_does_not_crash(monkeypatch):
     integration._process()  # must not raise / silently no-op
 
     virtual.set_dmx_wash.assert_called_with((255, 0, 0), 1.0)
+
+
+def test_mapping_type_changed_fixture_to_color_releases_wash(monkeypatch):
+    """Regression test for the "frozen frame" bug: switching a mapping from
+    "fixture" (wash) to "color" (live RGB) in place at runtime, while DMX is
+    live, must release the old wash takeover — not just start applying the
+    new color override underneath it.
+
+    Root cause this guards against: ``_release_mapping`` was only ever
+    called by ``_process`` on the stale-stream/deactivation path, using
+    ``mapping.get("type")`` — i.e. the mapping's *current* type. Editing a
+    mapping's type in place never went through that path at all, so nothing
+    ever called ``clear_dmx_wash()`` for the virtual's stale fixture-wash
+    takeover. Since ``Virtual.thread_function``'s render loop gives DMX wash
+    render priority over a color override (wash is checked first), the
+    virtual would keep painting the wash's last (now frozen/stale) RGB
+    value forever, even though a brand new color override was also being
+    applied every cycle underneath it — the LED appears completely frozen,
+    with no exception anywhere (this is not a crash, so nothing appears in
+    the log), even though the color override is "correct" from the DMX
+    Input integration's point of view.
+    """
+    virtual = MagicMock()
+    integration = _make_dmx_input(monkeypatch, virtual)
+
+    fake_time = [1000.0]
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.time.monotonic", lambda: fake_time[0]
+    )
+
+    # Engage the fixture wash first (mapping starts as "fixture", per
+    # _make_dmx_input's default config).
+    integration._on_dmx(0, bytes([0, 0, 0, 0]))
+    integration._process()  # primes
+
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([255, 255, 0, 0]))
+    integration._process()
+    virtual.set_dmx_wash.assert_called_with((255, 0, 0), 1.0)
+    virtual.clear_dmx_wash.assert_not_called()
+
+    # Now edit the *same* mapping index's type to "color" at runtime — e.g.
+    # via the mapping editor UI — without going through any stale/removal
+    # path.
+    integration._data[0]["type"] = "color"
+    integration._data[0]["channels"] = [2, 3, 4]
+
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([0, 10, 20, 30]))
+    integration._process()
+
+    # The stale wash takeover must be released so the new color override
+    # actually becomes visible instead of being silently masked by it.
+    virtual.clear_dmx_wash.assert_called_once()
+    virtual.set_color_override.assert_called_with("#0a141e")

--- a/tests/test_dmx_input.py
+++ b/tests/test_dmx_input.py
@@ -180,6 +180,66 @@ def test_fixture_wash_releases_only_on_stale_stream(monkeypatch):
     virtual.clear_dmx_wash.assert_called_once()
 
 
+def test_mapping_type_changed_in_place_does_not_crash(monkeypatch):
+    """Regression test: editing a mapping's ``type`` in place (same list
+    index) at runtime — e.g. via the mapping editor UI, without restarting
+    the backend — must not leave stale per-index runtime state that crashes
+    the new type's handler.
+
+    Root cause this guards against: each ``_process_*`` handler used to do
+    ``self._mapping_state.setdefault(idx, {<its own default key>: ...})``.
+    ``setdefault`` only inserts when the *index* is entirely absent from the
+    dict — if a different handler already created an entry at that index
+    (from the mapping's previous type), the new handler's key was never
+    added, and later direct indexing like ``state["wash_on"]`` raised a
+    ``KeyError`` on every processing cycle, silently swallowed by
+    ``_update_loop``'s catch-all and logged as a warning — so the new
+    mapping type appeared to simply do nothing.
+
+    ``_prime_mapping`` seeds all three handlers' keys unconditionally, so
+    this bug only manifests once a mapping's universe has already been
+    "seen" (SoundSwitch has already been streaming for a while) *before*
+    the type edit happens — priming is per-universe, not per-mapping, so an
+    existing (previously-seen) universe never re-primes an edited mapping.
+    That's the realistic, common case: you edit a mapping's type while DMX
+    is already live, not at the very first packet after a cold start.
+    """
+    virtual = MagicMock()
+    integration = _make_dmx_input(monkeypatch, virtual)
+
+    fake_time = [1000.0]
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.time.monotonic", lambda: fake_time[0]
+    )
+
+    # Simulate the DMX stream having already been live for a while: universe
+    # 0 is already "seen", so priming will never run again for it.
+    integration._seen_universe.add(0)
+    integration._last_packet_time[0] = fake_time[0]
+
+    # Configure the mapping as "color" and process one packet — since the
+    # universe is already seen, _process_color creates _mapping_state[0]
+    # itself, containing *only* the color handler's key.
+    integration._data[0]["type"] = "color"
+    integration._data[0]["channels"] = [2, 3, 4]
+    integration._on_dmx(0, bytes([0, 10, 20, 30]))
+    integration._process()
+    assert virtual.set_color_override.called
+    assert integration._mapping_state[0] == {"last_color": (10, 20, 30)}
+
+    # Now edit the *same* mapping index's type to "fixture" at runtime,
+    # without restarting/re-priming — this is exactly what the frontend's
+    # mapping editor does when you change a mapping's type via PUT.
+    integration._data[0]["type"] = "fixture"
+    integration._data[0]["channels"] = {"dimmer": 1, "r": 2, "g": 3, "b": 4}
+
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([255, 255, 0, 0]))
+    integration._process()  # must not raise / silently no-op
+
+    virtual.set_dmx_wash.assert_called_with((255, 0, 0), 1.0)
+
+
 def _base_config(stale_timeout=2.0):
     return {
         "name": "test",

--- a/tests/test_dmx_input.py
+++ b/tests/test_dmx_input.py
@@ -1,8 +1,9 @@
 """Tests for the DMX Input (Art-Net) integration parser and mapping logic."""
 
 import struct
+from unittest.mock import MagicMock
 
-from ledfx.integrations.dmx_input import _channel, parse_artdmx
+from ledfx.integrations.dmx_input import DMXInput, _channel, parse_artdmx
 
 
 def _build_artdmx(universe: int, dmx: bytes, sequence: int = 1) -> bytes:
@@ -66,3 +67,103 @@ def test_channel_out_of_range_returns_zero():
     dmx = bytes([5, 6])
     assert _channel(dmx, 99) == 0
     assert _channel(dmx, 0) == 0
+
+
+def _make_dmx_input(monkeypatch, virtual, stale_timeout=2.0):
+    """Build a DMXInput with a fake ledfx/virtual, bypassing all networking.
+
+    Driving `_on_dmx` / `_process` directly (instead of real UDP sockets)
+    keeps this test fast and deterministic, and avoids Windows-specific
+    asyncio Proactor event-loop UDP delivery jitter that made an end-to-end
+    loopback Art-Net harness flaky in manual testing.
+    """
+    ledfx = MagicMock()
+    ledfx.virtuals.get.return_value = virtual
+    config = {
+        "name": "test",
+        "description": "test",
+        "bind_address": "127.0.0.1",
+        "port": 6454,
+        "update_fps": 60,
+        "stale_timeout": stale_timeout,
+        "hold_last_look": False,
+    }
+    integration = DMXInput(ledfx, config, False, [])
+    mapping = {
+        "name": "fixture-under-test",
+        "type": "fixture",
+        "universe": 0,
+        "virtual_id": "virtual-1",
+        "channels": {"dimmer": 1, "r": 2, "g": 3, "b": 4},
+    }
+    integration.add_mapping(mapping)
+    return integration
+
+
+def test_fixture_wash_has_no_threshold_gate(monkeypatch):
+    """Wash engages unconditionally once data arrives, tracks live dimmer/RGB
+    with no on/off threshold, and dimmer=0 renders black instead of
+    reverting to the underlying effect (regression test for the flash bug
+    caused by the old threshold gate)."""
+    virtual = MagicMock()
+    integration = _make_dmx_input(monkeypatch, virtual)
+
+    fake_time = [1000.0]
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.time.monotonic", lambda: fake_time[0]
+    )
+
+    # First packet only primes the baseline; no wash yet.
+    integration._on_dmx(0, bytes([0, 0, 0, 0]))
+    integration._process()
+    assert virtual.set_dmx_wash.call_count == 0
+
+    # Second packet: dimmer=255, red. Wash must engage immediately (no
+    # threshold to cross).
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([255, 255, 0, 0]))
+    integration._process()
+    virtual.set_dmx_wash.assert_called_with((255, 0, 0), 1.0)
+
+    # Third packet: dimmer=1 (a low-but-nonzero value some consoles send for
+    # "off") should NOT be gated to zero/off — no threshold logic at all.
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([1, 255, 0, 0]))
+    integration._process()
+    virtual.set_dmx_wash.assert_called_with((255, 0, 0), 1 / 255.0)
+
+    # Fourth packet: dimmer=0 must render solid black via the dimmer math,
+    # while the wash stays *engaged* (no revert/flash back to the effect).
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([0, 255, 0, 0]))
+    integration._process()
+    virtual.set_dmx_wash.assert_called_with((255, 0, 0), 0.0)
+    virtual.clear_dmx_wash.assert_not_called()
+
+
+def test_fixture_wash_releases_only_on_stale_stream(monkeypatch):
+    """The wash is only released when the DMX stream actually goes stale
+    (no packets for stale_timeout seconds), never due to a low/zero dimmer
+    value."""
+    virtual = MagicMock()
+    integration = _make_dmx_input(monkeypatch, virtual, stale_timeout=2.0)
+
+    fake_time = [1000.0]
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.time.monotonic", lambda: fake_time[0]
+    )
+
+    integration._on_dmx(0, bytes([0, 0, 0, 0]))
+    integration._process()  # primes
+
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([0, 255, 0, 0]))  # dimmer=0, engages
+    integration._process()
+    assert virtual.set_dmx_wash.called
+    virtual.clear_dmx_wash.assert_not_called()
+
+    # Simulate the stream continuing to be silent (SoundSwitch closed/quit)
+    # well past stale_timeout — this is the *only* path that should release.
+    fake_time[0] += 3.0
+    integration._process()
+    virtual.clear_dmx_wash.assert_called_once()

--- a/tests/test_dmx_input.py
+++ b/tests/test_dmx_input.py
@@ -167,3 +167,63 @@ def test_fixture_wash_releases_only_on_stale_stream(monkeypatch):
     fake_time[0] += 3.0
     integration._process()
     virtual.clear_dmx_wash.assert_called_once()
+
+
+def test_mapping_type_changed_in_place_does_not_crash(monkeypatch):
+    """Regression test: editing a mapping's ``type`` in place (same list
+    index) at runtime — e.g. via the mapping editor UI, without restarting
+    the backend — must not leave stale per-index runtime state that crashes
+    the new type's handler.
+
+    Root cause this guards against: each ``_process_*`` handler used to do
+    ``self._mapping_state.setdefault(idx, {<its own default key>: ...})``.
+    ``setdefault`` only inserts when the *index* is entirely absent from the
+    dict — if a different handler already created an entry at that index
+    (from the mapping's previous type), the new handler's key was never
+    added, and later direct indexing like ``state["wash_on"]`` raised a
+    ``KeyError`` on every processing cycle, silently swallowed by
+    ``_update_loop``'s catch-all and logged as a warning — so the new
+    mapping type appeared to simply do nothing.
+
+    ``_prime_mapping`` seeds all three handlers' keys unconditionally, so
+    this bug only manifests once a mapping's universe has already been
+    "seen" (SoundSwitch has already been streaming for a while) *before*
+    the type edit happens — priming is per-universe, not per-mapping, so an
+    existing (previously-seen) universe never re-primes an edited mapping.
+    That's the realistic, common case: you edit a mapping's type while DMX
+    is already live, not at the very first packet after a cold start.
+    """
+    virtual = MagicMock()
+    integration = _make_dmx_input(monkeypatch, virtual)
+
+    fake_time = [1000.0]
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.time.monotonic", lambda: fake_time[0]
+    )
+
+    # Simulate the DMX stream having already been live for a while: universe
+    # 0 is already "seen", so priming will never run again for it.
+    integration._seen_universe.add(0)
+    integration._last_packet_time[0] = fake_time[0]
+
+    # Configure the mapping as "color" and process one packet — since the
+    # universe is already seen, _process_color creates _mapping_state[0]
+    # itself, containing *only* the color handler's key.
+    integration._data[0]["type"] = "color"
+    integration._data[0]["channels"] = [2, 3, 4]
+    integration._on_dmx(0, bytes([0, 10, 20, 30]))
+    integration._process()
+    assert virtual.set_color_override.called
+    assert integration._mapping_state[0] == {"last_color": (10, 20, 30)}
+
+    # Now edit the *same* mapping index's type to "fixture" at runtime,
+    # without restarting/re-priming — this is exactly what the frontend's
+    # mapping editor does when you change a mapping's type via PUT.
+    integration._data[0]["type"] = "fixture"
+    integration._data[0]["channels"] = {"dimmer": 1, "r": 2, "g": 3, "b": 4}
+
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([255, 255, 0, 0]))
+    integration._process()  # must not raise / silently no-op
+
+    virtual.set_dmx_wash.assert_called_with((255, 0, 0), 1.0)

--- a/tests/test_dmx_input.py
+++ b/tests/test_dmx_input.py
@@ -285,3 +285,122 @@ def test_mapping_type_changed_fixture_to_color_releases_wash(monkeypatch):
     # actually becomes visible instead of being silently masked by it.
     virtual.clear_dmx_wash.assert_called_once()
     virtual.set_color_override.assert_called_with("#0a141e")
+
+
+def test_fixture_wash_default_strobe_probability_renders_every_pulse(
+    monkeypatch,
+):
+    """Default ``strobe_probability`` (1.0, or unset) must render every
+    single strobe pulse exactly like today — no regression for anyone who
+    never touches the new setting."""
+    virtual = MagicMock()
+    integration = _make_dmx_input(monkeypatch, virtual)
+
+    fake_time = [1000.0]
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.time.monotonic", lambda: fake_time[0]
+    )
+    # Force every Bernoulli trial to "fail" if it were ever drawn — proves
+    # the strobe_probability==1.0 fast-path skips rolling entirely.
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.random.random", lambda: 0.999
+    )
+
+    integration._on_dmx(0, bytes([0, 0, 0, 0]))
+    integration._process()  # primes
+
+    for _ in range(5):
+        fake_time[0] += 0.02
+        integration._on_dmx(0, bytes([255, 255, 0, 0]))  # pulse on
+        integration._process()
+        virtual.set_dmx_wash.assert_called_with((255, 0, 0), 1.0)
+
+        fake_time[0] += 0.02
+        integration._on_dmx(0, bytes([0, 255, 0, 0]))  # pulse off
+        integration._process()
+        virtual.set_dmx_wash.assert_called_with((255, 0, 0), 0.0)
+
+
+def test_fixture_wash_strobe_probability_suppresses_failed_pulses(
+    monkeypatch,
+):
+    """With strobe_probability < 1.0, a pulse whose single Bernoulli trial
+    "fails" must render fully black (dimmer forced to 0) for that pulse's
+    entire duration, while a pulse that "succeeds" renders normally — and
+    the decision must be drawn once per rising edge, not re-rolled every
+    frame within the same pulse."""
+    virtual = MagicMock()
+    integration = _make_dmx_input(monkeypatch, virtual)
+    integration._data[0]["strobe_probability"] = 0.5
+
+    fake_time = [1000.0]
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.time.monotonic", lambda: fake_time[0]
+    )
+
+    integration._on_dmx(0, bytes([0, 0, 0, 0]))
+    integration._process()  # primes
+
+    # First pulse: rig the trial to "fail" (0.9 >= 0.5).
+    rolls = iter([0.9, 0.1])
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.random.random", lambda: next(rolls)
+    )
+
+    fake_time[0] += 0.02
+    integration._on_dmx(0, bytes([255, 255, 0, 0]))  # rising edge, rolls 0.9
+    integration._process()
+    virtual.set_dmx_wash.assert_called_with((255, 0, 0), 0.0)
+
+    # Still within the same pulse (dimmer still nonzero) — must stay
+    # suppressed without re-rolling, even though the next roll (0.1) would
+    # have succeeded.
+    fake_time[0] += 0.02
+    integration._on_dmx(0, bytes([200, 255, 0, 0]))
+    integration._process()
+    virtual.set_dmx_wash.assert_called_with((255, 0, 0), 0.0)
+
+    # Falling edge — pulse ends.
+    fake_time[0] += 0.02
+    integration._on_dmx(0, bytes([0, 255, 0, 0]))
+    integration._process()
+    virtual.set_dmx_wash.assert_called_with((255, 0, 0), 0.0)
+
+    # Second pulse: rolls 0.1 (succeeds, 0.1 < 0.5) — must render normally.
+    fake_time[0] += 0.02
+    integration._on_dmx(0, bytes([255, 255, 0, 0]))  # rising edge, rolls 0.1
+    integration._process()
+    virtual.set_dmx_wash.assert_called_with((255, 0, 0), 1.0)
+
+
+def test_mapping_type_cache_field_round_trips_untouched(monkeypatch):
+    """An arbitrary ``_type_field_cache`` key (used by the frontend mapping
+    editor to remember each type's last-entered field values across type
+    switches, per-mapping) must survive add_mapping/get_mappings untouched,
+    and must never be interpreted by any of the ``_process_*`` handlers —
+    it is pure frontend-managed UI state that happens to round-trip through
+    the backend's unvalidated mapping dicts."""
+    virtual = MagicMock()
+    integration = _make_dmx_input(monkeypatch, virtual)
+    integration._data[0]["_type_field_cache"] = {
+        "color": {"channels": [5, 6, 7]},
+        "trigger": {"on_threshold": 200, "off_threshold": 150},
+    }
+
+    fake_time = [1000.0]
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.time.monotonic", lambda: fake_time[0]
+    )
+
+    integration._on_dmx(0, bytes([0, 0, 0, 0]))
+    integration._process()  # primes
+    fake_time[0] += 0.02
+    integration._on_dmx(0, bytes([255, 255, 0, 0]))
+    integration._process()  # normal fixture-wash processing, unaffected
+
+    mappings = integration.get_mappings()
+    assert mappings[0]["_type_field_cache"] == {
+        "color": {"channels": [5, 6, 7]},
+        "trigger": {"on_threshold": 200, "off_threshold": 150},
+    }
+    virtual.set_dmx_wash.assert_called_with((255, 0, 0), 1.0)

--- a/tests/test_dmx_input.py
+++ b/tests/test_dmx_input.py
@@ -225,7 +225,10 @@ def test_mapping_type_changed_in_place_does_not_crash(monkeypatch):
     integration._on_dmx(0, bytes([0, 10, 20, 30]))
     integration._process()
     assert virtual.set_color_override.called
-    assert integration._mapping_state[0] == {"last_color": (10, 20, 30)}
+    assert integration._mapping_state[0] == {
+        "last_color": (10, 20, 30),
+        "_active_type": "color",
+    }
 
     # Now edit the *same* mapping index's type to "fixture" at runtime,
     # without restarting/re-priming — this is exactly what the frontend's
@@ -238,6 +241,61 @@ def test_mapping_type_changed_in_place_does_not_crash(monkeypatch):
     integration._process()  # must not raise / silently no-op
 
     virtual.set_dmx_wash.assert_called_with((255, 0, 0), 1.0)
+
+
+def test_mapping_type_changed_fixture_to_color_releases_wash(monkeypatch):
+    """Regression test for the "frozen frame" bug: switching a mapping from
+    "fixture" (wash) to "color" (live RGB) in place at runtime, while DMX is
+    live, must release the old wash takeover — not just start applying the
+    new color override underneath it.
+
+    Root cause this guards against: ``_release_mapping`` was only ever
+    called by ``_process`` on the stale-stream/deactivation path, using
+    ``mapping.get("type")`` — i.e. the mapping's *current* type. Editing a
+    mapping's type in place never went through that path at all, so nothing
+    ever called ``clear_dmx_wash()`` for the virtual's stale fixture-wash
+    takeover. Since ``Virtual.thread_function``'s render loop gives DMX wash
+    render priority over a color override (wash is checked first), the
+    virtual would keep painting the wash's last (now frozen/stale) RGB
+    value forever, even though a brand new color override was also being
+    applied every cycle underneath it — the LED appears completely frozen,
+    with no exception anywhere (this is not a crash, so nothing appears in
+    the log), even though the color override is "correct" from the DMX
+    Input integration's point of view.
+    """
+    virtual = MagicMock()
+    integration = _make_dmx_input(monkeypatch, virtual)
+
+    fake_time = [1000.0]
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.time.monotonic", lambda: fake_time[0]
+    )
+
+    # Engage the fixture wash first (mapping starts as "fixture", per
+    # _make_dmx_input's default config).
+    integration._on_dmx(0, bytes([0, 0, 0, 0]))
+    integration._process()  # primes
+
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([255, 255, 0, 0]))
+    integration._process()
+    virtual.set_dmx_wash.assert_called_with((255, 0, 0), 1.0)
+    virtual.clear_dmx_wash.assert_not_called()
+
+    # Now edit the *same* mapping index's type to "color" at runtime — e.g.
+    # via the mapping editor UI — without going through any stale/removal
+    # path.
+    integration._data[0]["type"] = "color"
+    integration._data[0]["channels"] = [2, 3, 4]
+
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([0, 10, 20, 30]))
+    integration._process()
+
+    # The stale wash takeover must be released so the new color override
+    # actually becomes visible instead of being silently masked by it.
+    virtual.clear_dmx_wash.assert_called_once()
+    virtual.set_color_override.assert_called_with("#0a141e")
 
 
 def _base_config(stale_timeout=2.0):

--- a/tests/test_dmx_input.py
+++ b/tests/test_dmx_input.py
@@ -79,6 +79,17 @@ def _make_dmx_input(monkeypatch, virtual, stale_timeout=2.0):
     """
     ledfx = MagicMock()
     ledfx.virtuals.get.return_value = virtual
+    # MagicMock()'s default attributes are truthy, so an un-configured
+    # `is_dmx_paused()` would look "paused" to `_targets` and silently
+    # filter the virtual out. Default every fake virtual to unpaused.
+    virtual.is_dmx_paused.return_value = False
+    # A real (empty) integrations list so `set_paused`'s `_persist()` can
+    # iterate/find this integration's config entry without special-casing
+    # MagicMock defaults; `save_config` itself is stubbed out below.
+    ledfx.config = {"integrations": []}
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.save_config", lambda **kwargs: None
+    )
     config = {
         "name": "test",
         "description": "test",
@@ -167,3 +178,211 @@ def test_fixture_wash_releases_only_on_stale_stream(monkeypatch):
     fake_time[0] += 3.0
     integration._process()
     virtual.clear_dmx_wash.assert_called_once()
+
+
+def _base_config(stale_timeout=2.0):
+    return {
+        "name": "test",
+        "description": "test",
+        "bind_address": "127.0.0.1",
+        "port": 6454,
+        "update_fps": 60,
+        "stale_timeout": stale_timeout,
+        "hold_last_look": False,
+    }
+
+
+def _make_venue_mapped_dmx_input(
+    monkeypatch, virtuals_by_id, venue_id="venue-1"
+):
+    """Build a DMXInput whose single fixture mapping targets a venue (rather
+    than a single virtual_id), with a mocked VenueManager, so venue/device
+    pause precedence can be exercised without real venue persistence."""
+    ledfx = MagicMock()
+    ledfx.virtuals.get.side_effect = lambda vid: virtuals_by_id.get(vid)
+    ledfx.config = {"integrations": []}
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.save_config", lambda **kwargs: None
+    )
+
+    venue_mgr = MagicMock()
+    venue_mgr.get.return_value = {"virtual_ids": list(virtuals_by_id.keys())}
+    venue_mgr.is_paused.return_value = False
+    ledfx.venues = venue_mgr
+
+    for v in virtuals_by_id.values():
+        v.is_dmx_paused.return_value = False
+
+    integration = DMXInput(ledfx, _base_config(), False, [])
+    mapping = {
+        "name": "venue-fixture",
+        "type": "fixture",
+        "universe": 0,
+        "venue_id": venue_id,
+        "channels": {"dimmer": 1, "r": 2, "g": 3, "b": 4},
+    }
+    integration.add_mapping(mapping)
+    return integration, venue_mgr
+
+
+def test_global_pause_releases_wash_immediately_and_resumes(monkeypatch):
+    """Global pause instantly releases an engaged wash (no waiting for the
+    next stale-stream tick), and stops any further reapplication while
+    paused. Unpausing needs no special action — the next `_process()` with
+    live DMX still flowing simply re-engages."""
+    virtual = MagicMock()
+    integration = _make_dmx_input(monkeypatch, virtual)
+
+    fake_time = [1000.0]
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.time.monotonic", lambda: fake_time[0]
+    )
+
+    integration._on_dmx(0, bytes([0, 0, 0, 0]))
+    integration._process()  # primes
+
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([255, 255, 0, 0]))
+    integration._process()
+    assert virtual.set_dmx_wash.called
+    assert integration.paused is False
+
+    # Pausing releases the wash immediately.
+    integration.set_paused(True)
+    virtual.clear_dmx_wash.assert_called_once()
+    assert integration.paused is True
+
+    # Live DMX keeps flowing (the listener/loop are unaffected by pause),
+    # but nothing gets applied while paused.
+    virtual.set_dmx_wash.reset_mock()
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([128, 100, 100, 100]))
+    integration._process()
+    virtual.set_dmx_wash.assert_not_called()
+
+    # Unpausing needs no special action: the very next tick re-engages.
+    integration.set_paused(False)
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([255, 10, 20, 30]))
+    integration._process()
+    virtual.set_dmx_wash.assert_called_with((10, 20, 30), 1.0)
+
+
+def test_venue_pause_stops_mapped_virtuals_from_receiving_washes(monkeypatch):
+    """A paused venue must stop a venue-targeted mapping from reapplying to
+    any of its member virtuals."""
+    v1, v2 = MagicMock(), MagicMock()
+    integration, venue_mgr = _make_venue_mapped_dmx_input(
+        monkeypatch, {"v1": v1, "v2": v2}
+    )
+
+    fake_time = [1000.0]
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.time.monotonic", lambda: fake_time[0]
+    )
+
+    integration._on_dmx(0, bytes([0, 0, 0, 0]))
+    integration._process()  # primes
+
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([255, 255, 0, 0]))
+    integration._process()
+    assert v1.set_dmx_wash.called
+    assert v2.set_dmx_wash.called
+
+    # Simulate the venue becoming paused (VenueManager.set_paused itself
+    # clears the color-pad override — see test_venues.py — and reports
+    # is_paused()=True from then on).
+    venue_mgr.is_paused.return_value = True
+    v1.set_dmx_wash.reset_mock()
+    v2.set_dmx_wash.reset_mock()
+
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([128, 10, 10, 10]))
+    integration._process()
+    v1.set_dmx_wash.assert_not_called()
+    v2.set_dmx_wash.assert_not_called()
+
+
+def test_device_pause_releases_only_that_virtual(monkeypatch):
+    """Pausing one virtual (of two sharing a venue-targeted mapping) must
+    only stop that one from receiving washes, leaving the other engaged."""
+    v1, v2 = MagicMock(), MagicMock()
+    integration, _venue_mgr = _make_venue_mapped_dmx_input(
+        monkeypatch, {"v1": v1, "v2": v2}
+    )
+
+    fake_time = [1000.0]
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.time.monotonic", lambda: fake_time[0]
+    )
+
+    integration._on_dmx(0, bytes([0, 0, 0, 0]))
+    integration._process()  # primes
+
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([255, 255, 0, 0]))
+    integration._process()
+    assert v1.set_dmx_wash.called
+    assert v2.set_dmx_wash.called
+
+    # Pause v1 at the device level only.
+    v1.is_dmx_paused.return_value = True
+    v1.set_dmx_wash.reset_mock()
+    v2.set_dmx_wash.reset_mock()
+
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([200, 5, 6, 7]))
+    integration._process()
+    v1.set_dmx_wash.assert_not_called()
+    v2.set_dmx_wash.assert_called_with((5, 6, 7), 200 / 255.0)
+
+
+def test_pause_precedence_global_wins_over_unpaused_venue_and_device(
+    monkeypatch,
+):
+    """Global pause must block dispatch even when the venue and device are
+    both unpaused."""
+    v1 = MagicMock()
+    integration, venue_mgr = _make_venue_mapped_dmx_input(
+        monkeypatch, {"v1": v1}
+    )
+    venue_mgr.is_paused.return_value = False  # venue unpaused
+    v1.is_dmx_paused.return_value = False  # device unpaused
+
+    integration.set_paused(True)  # global pause engaged
+
+    fake_time = [1000.0]
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.time.monotonic", lambda: fake_time[0]
+    )
+    integration._on_dmx(0, bytes([0, 0, 0, 0]))
+    integration._process()
+
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([255, 255, 0, 0]))
+    integration._process()
+    v1.set_dmx_wash.assert_not_called()
+
+
+def test_pause_precedence_venue_wins_over_unpaused_device(monkeypatch):
+    """A paused venue must block dispatch to a member virtual even when
+    that virtual's own device-level pause flag is False."""
+    v1 = MagicMock()
+    integration, venue_mgr = _make_venue_mapped_dmx_input(
+        monkeypatch, {"v1": v1}
+    )
+    venue_mgr.is_paused.return_value = True  # venue paused
+    v1.is_dmx_paused.return_value = False  # device unpaused
+
+    fake_time = [1000.0]
+    monkeypatch.setattr(
+        "ledfx.integrations.dmx_input.time.monotonic", lambda: fake_time[0]
+    )
+    integration._on_dmx(0, bytes([0, 0, 0, 0]))
+    integration._process()
+
+    fake_time[0] += 0.05
+    integration._on_dmx(0, bytes([255, 255, 0, 0]))
+    integration._process()
+    v1.set_dmx_wash.assert_not_called()

--- a/tests/test_venues.py
+++ b/tests/test_venues.py
@@ -198,3 +198,39 @@ def test_clear_override_calls_clear_on_all_virtuals(mgr, ledfx):
 def test_clear_override_missing_venue_raises(mgr):
     with pytest.raises(KeyError):
         mgr.clear_override("nope")
+
+
+def test_set_paused_clears_override_and_persists(mgr, ledfx):
+    venue = mgr.create(name="J", rows=1, cols=1)
+    v1 = _add_virtual(ledfx, "v1")
+    mgr.add_virtual(venue["id"], "v1")
+    mgr.activate_override(venue["id"], 0)
+
+    updated = mgr.set_paused(venue["id"], True)
+    assert updated["paused"] is True
+    v1.clear_color_override.assert_called_once()
+    assert mgr.is_paused(venue["id"]) is True
+
+
+def test_set_paused_false_does_not_clear_override(mgr, ledfx):
+    venue = mgr.create(name="K", rows=1, cols=1)
+    v1 = _add_virtual(ledfx, "v1")
+    mgr.add_virtual(venue["id"], "v1")
+    mgr.activate_override(venue["id"], 0)
+    v1.clear_color_override.reset_mock()
+
+    updated = mgr.set_paused(venue["id"], False)
+    assert updated["paused"] is False
+    v1.clear_color_override.assert_not_called()
+    assert mgr.is_paused(venue["id"]) is False
+
+
+def test_set_paused_missing_venue_raises(mgr):
+    with pytest.raises(KeyError):
+        mgr.set_paused("nope", True)
+
+
+def test_is_paused_defaults_false_for_new_venue_and_missing_venue(mgr):
+    venue = mgr.create(name="L")
+    assert mgr.is_paused(venue["id"]) is False
+    assert mgr.is_paused("nope") is False

--- a/tests/test_venues.py
+++ b/tests/test_venues.py
@@ -1,0 +1,200 @@
+"""Tests for the Venues system: CRUD, exclusive virtual membership, and
+color/gradient override activation."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ledfx.venues import VenueManager, _hsl_auto_palette
+
+
+def _make_ledfx():
+    """Build a minimal ledfx stand-in with an in-memory config and a
+    virtuals registry mock."""
+    ledfx = MagicMock()
+    ledfx.config = {}
+    ledfx.virtuals = MagicMock()
+    ledfx._virtuals_by_id = {}
+    ledfx.virtuals.get.side_effect = lambda vid: ledfx._virtuals_by_id.get(vid)
+    return ledfx
+
+
+@pytest.fixture(autouse=True)
+def _no_disk_writes():
+    """VenueManager persists to config.json on every mutation; these are
+    pure logic tests so stub out the disk write."""
+    with patch("ledfx.venues.save_config"):
+        yield
+
+
+def _add_virtual(ledfx, virtual_id):
+    v = MagicMock()
+    ledfx._virtuals_by_id[virtual_id] = v
+    return v
+
+
+@pytest.fixture
+def ledfx():
+    return _make_ledfx()
+
+
+@pytest.fixture
+def mgr(ledfx):
+    return VenueManager(ledfx)
+
+
+def test_hsl_auto_palette_length_and_shape():
+    pads = _hsl_auto_palette(6)
+    assert len(pads) == 6
+    for pad in pads:
+        assert "color" in pad
+        assert pad["color"].startswith("#")
+        assert len(pad["color"]) == 7
+
+
+def test_create_venue_defaults(mgr):
+    venue = mgr.create(name="Living Room")
+    assert venue["name"] == "Living Room"
+    assert venue["virtual_ids"] == []
+    assert venue["color_pads"]["rows"] == 4
+    assert venue["color_pads"]["cols"] == 4
+    assert len(venue["color_pads"]["pads"]) == 16
+
+
+def test_create_venue_dedupes_id(mgr):
+    v1 = mgr.create(name="Patio")
+    v2 = mgr.create(name="Patio")
+    assert v1["id"] != v2["id"]
+
+
+def test_list_and_get_venue(mgr):
+    created = mgr.create(name="Deck", rows=2, cols=2)
+    venue_id = created["id"]
+
+    listed = mgr.list_venues()
+    assert venue_id in listed
+
+    fetched = mgr.get(venue_id)
+    assert fetched["name"] == "Deck"
+    assert mgr.get("does-not-exist") is None
+
+
+def test_update_venue_name_and_grid(mgr):
+    created = mgr.create(name="Garage", rows=2, cols=2)
+    venue_id = created["id"]
+
+    updated = mgr.update(venue_id, {"name": "Garage 2"})
+    assert updated["name"] == "Garage 2"
+
+    resized = mgr.update(venue_id, {"color_pads": {"rows": 3, "cols": 3}})
+    assert resized["color_pads"]["rows"] == 3
+    assert resized["color_pads"]["cols"] == 3
+    assert len(resized["color_pads"]["pads"]) == 9
+
+
+def test_update_missing_venue_raises(mgr):
+    with pytest.raises(KeyError):
+        mgr.update("nope", {"name": "x"})
+
+
+def test_add_virtual_success(mgr, ledfx):
+    venue = mgr.create(name="Studio")
+    _add_virtual(ledfx, "v1")
+
+    updated = mgr.add_virtual(venue["id"], "v1")
+    assert "v1" in updated["virtual_ids"]
+
+
+def test_add_virtual_missing_virtual_raises(mgr):
+    venue = mgr.create(name="Studio2")
+    with pytest.raises(ValueError):
+        mgr.add_virtual(venue["id"], "ghost")
+
+
+def test_add_virtual_exclusive_membership(mgr, ledfx):
+    venue_a = mgr.create(name="A")
+    venue_b = mgr.create(name="B")
+    _add_virtual(ledfx, "v1")
+
+    mgr.add_virtual(venue_a["id"], "v1")
+    with pytest.raises(ValueError):
+        mgr.add_virtual(venue_b["id"], "v1")
+
+
+def test_remove_virtual_clears_override(mgr, ledfx):
+    venue = mgr.create(name="C")
+    v1 = _add_virtual(ledfx, "v1")
+    mgr.add_virtual(venue["id"], "v1")
+
+    mgr.remove_virtual(venue["id"], "v1")
+    v1.clear_color_override.assert_called_once()
+    assert "v1" not in mgr.get(venue["id"])["virtual_ids"]
+
+
+def test_cleanup_virtual_removes_from_owning_venue(mgr, ledfx):
+    venue = mgr.create(name="D")
+    v1 = _add_virtual(ledfx, "v1")
+    mgr.add_virtual(venue["id"], "v1")
+
+    mgr.cleanup_virtual("v1")
+    assert "v1" not in mgr.get(venue["id"])["virtual_ids"]
+    v1.clear_color_override.assert_called_once()
+
+
+def test_delete_venue_clears_overrides_and_removes(mgr, ledfx):
+    venue = mgr.create(name="E")
+    v1 = _add_virtual(ledfx, "v1")
+    mgr.add_virtual(venue["id"], "v1")
+
+    assert mgr.delete(venue["id"]) is True
+    v1.clear_color_override.assert_called_once()
+    assert mgr.get(venue["id"]) is None
+    assert mgr.delete(venue["id"]) is False
+
+
+def test_activate_override_solid_color(mgr, ledfx):
+    venue = mgr.create(name="F", rows=1, cols=1)
+    v1 = _add_virtual(ledfx, "v1")
+    mgr.add_virtual(venue["id"], "v1")
+
+    pad_color = mgr.get(venue["id"])["color_pads"]["pads"][0]["color"]
+    mgr.activate_override(venue["id"], 0)
+    v1.set_color_override.assert_called_once_with(pad_color)
+
+
+def test_activate_override_gradient_pad(mgr, ledfx):
+    venue = mgr.create(name="G", rows=1, cols=1)
+    v1 = _add_virtual(ledfx, "v1")
+    mgr.add_virtual(venue["id"], "v1")
+
+    gradient = "linear-gradient(90deg, #ff0000, #0000ff)"
+    mgr._venues[venue["id"]]["color_pads"]["pads"][0] = {"gradient": gradient}
+
+    mgr.activate_override(venue["id"], 0)
+    v1.set_color_override.assert_called_once_with(gradient)
+
+
+def test_activate_override_invalid_pad_index_raises(mgr, ledfx):
+    venue = mgr.create(name="H", rows=1, cols=1)
+    _add_virtual(ledfx, "v1")
+    mgr.add_virtual(venue["id"], "v1")
+
+    with pytest.raises(IndexError):
+        mgr.activate_override(venue["id"], 99)
+
+
+def test_clear_override_calls_clear_on_all_virtuals(mgr, ledfx):
+    venue = mgr.create(name="I")
+    v1 = _add_virtual(ledfx, "v1")
+    v2 = _add_virtual(ledfx, "v2")
+    mgr.add_virtual(venue["id"], "v1")
+    mgr.add_virtual(venue["id"], "v2")
+
+    mgr.clear_override(venue["id"])
+    v1.clear_color_override.assert_called_once()
+    v2.clear_color_override.assert_called_once()
+
+
+def test_clear_override_missing_venue_raises(mgr):
+    with pytest.raises(KeyError):
+        mgr.clear_override("nope")


### PR DESCRIPTION
Stacks on #1839 (DMX Input integration) and #1838 (Venues). Adds pause/mute controls for the DMX Input takeover at three granularities:

- **Global**: pause the whole DMX Input integration's overrides while keeping the Art-Net UDP listener/ArtPoll alive (SoundSwitch stays connected).
- **Venue**: pause DMX takeover for all virtuals in one venue (also clears any active venue color-pad override).
- **Device**: pause DMX takeover for a single virtual, blocking all mapping types (fixture wash, color tint, venue-trigger) touching it.

Precedence: global > venue > device. Pausing releases any owned override/wash immediately (no waiting for the stale-timeout).

New endpoints:
- `PUT /api/integrations/dmx_input/{id}/pause`
- `PUT /api/venues/{venue_id}/pause`
- `PUT /api/virtuals/{id}/dmx_pause`

`GET /api/virtuals` and `GET /api/venues` now include a computed `dmx_mapped` (and `dmx_paused` for virtuals) so the frontend only renders pause controls where DMX is actually applied.

Tests: `uv run pytest` -> 1015 passed, 13 skipped (9 new tests added covering global/venue/device pause + precedence). black/flake8 clean.

Companion frontend PR (UI for these controls) is being opened separately against fersg87/LedFx-Frontend-v2, stacked the same way.
