### PR TITLE
Fix issue with melt_and_sparkle suddenly changing.

### DIFF
--- a/ledfx/effects/melt_and_sparkle.py
+++ b/ledfx/effects/melt_and_sparkle.py
@@ -168,7 +168,7 @@ class MeltSparkle(AudioReactiveEffect, HSVEffect):
         self.array_sin(self.v)
         np.add(self.v, (1.0 - t1), out=self.v)
         self.v = triangle(self.v)
-        np.add(self.v, bass_factor * self._direction, out=self.v)
+        np.add(self.v, bass_factor, out=self.v)
         self.v = triangle(self.v)
 
         # The power operation effectively adjusts the amount of black between


### PR DESCRIPTION
Direction should not have been applied to the bass offset. Fixes sudden large changes in the output array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the Melt and Sparkle effect’s brightness response to bass input.
  - Bass-driven brightness now behaves consistently regardless of the effect’s direction setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->