### PR TITLE
Feat: Add melbank flag

### DIFF
--- a/docs/apis/api.md
+++ b/docs/apis/api.md
@@ -218,6 +218,12 @@ Returns the LedFx schema with the matching *schema_type* as JSON
 -   *effects*: Returns all the valid schemas for an LedFx effect
 -   *integrations*: Returns all the integrations registered with LedFx
 
+Effect schema entries include `uses_melbank_range`, a boolean capability flag
+for frontends. When `true`, the effect consumes melbank data through the
+virtual frequency range, so `frequency_min` and `frequency_max` controls are
+meaningful for that effect. When `false`, frontends can hide those virtual
+frequency controls for the selected effect.
+
 ## /api/devices
 
 Query and manage devices connected to LedFx

--- a/docs/developer/melbanks.md
+++ b/docs/developer/melbanks.md
@@ -149,6 +149,11 @@ melbank_data = self.melbank(filtered=False, size=self.pixel_count)
 # size: Interpolate to match pixel count
 ```
 
+Effects that call `self.melbank()` or `self.melbank_thirds()` should set
+`USES_MELBANK_RANGE = True` on the effect class. The `/api/schema` response
+exposes this as `uses_melbank_range` so frontends know whether virtual
+`frequency_min` and `frequency_max` controls apply to the selected effect.
+
 ### Automatic Melbank Selection
 
 Effects don't manually select melbanks. The system automatically:

--- a/ledfx/api/schema.py
+++ b/ledfx/api/schema.py
@@ -79,6 +79,7 @@ class SchemaEndpoint(RestEndpoint):
                         "id": effect_type,
                         "name": effect.NAME,
                         "category": effect.CATEGORY,
+                        "uses_melbank_range": effect.USES_MELBANK_RANGE,
                     }
 
                     if effect.HIDDEN_KEYS:

--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -283,6 +283,7 @@ class Effect(BaseRegistry):
     ADVANCED_KEYS = ["diag"]
     # over ride in effect children to allow edit and show others
     PERMITTED_KEYS = None
+    USES_MELBANK_RANGE = False
     _config = None
     _active = False
     _virtual = None

--- a/ledfx/effects/bands.py
+++ b/ledfx/effects/bands.py
@@ -8,6 +8,7 @@ from ledfx.effects.gradient import GradientEffect
 class BandsAudioEffect(AudioReactiveEffect, GradientEffect):
     NAME = "Bands"
     CATEGORY = "2D"
+    USES_MELBANK_RANGE = True
 
     CONFIG_SCHEMA = vol.Schema(
         {

--- a/ledfx/effects/bands_matrix.py
+++ b/ledfx/effects/bands_matrix.py
@@ -8,6 +8,7 @@ from ledfx.effects.gradient import GradientEffect
 class BandsMatrixAudioEffect(AudioReactiveEffect, GradientEffect):
     NAME = "Bands Matrix"
     CATEGORY = "2D"
+    USES_MELBANK_RANGE = True
 
     CONFIG_SCHEMA = vol.Schema(
         {

--- a/ledfx/effects/blocks.py
+++ b/ledfx/effects/blocks.py
@@ -8,6 +8,7 @@ from ledfx.effects.gradient import GradientEffect
 class BlocksAudioEffect(AudioReactiveEffect, GradientEffect):
     NAME = "Blocks"
     CATEGORY = "2D"
+    USES_MELBANK_RANGE = True
 
     CONFIG_SCHEMA = vol.Schema(
         {

--- a/ledfx/effects/energy.py
+++ b/ledfx/effects/energy.py
@@ -8,6 +8,7 @@ from ledfx.effects.audio import AudioReactiveEffect
 class EnergyAudioEffect(AudioReactiveEffect):
     NAME = "Energy"
     CATEGORY = "Classic"
+    USES_MELBANK_RANGE = True
 
     CONFIG_SCHEMA = vol.Schema(
         {

--- a/ledfx/effects/equalizer.py
+++ b/ledfx/effects/equalizer.py
@@ -8,6 +8,7 @@ from ledfx.effects.gradient import GradientEffect
 class EQAudioEffect(AudioReactiveEffect, GradientEffect):
     NAME = "Equalizer"
     CATEGORY = "2D"
+    USES_MELBANK_RANGE = True
 
     CONFIG_SCHEMA = vol.Schema(
         {

--- a/ledfx/effects/equalizer2d.py
+++ b/ledfx/effects/equalizer2d.py
@@ -19,6 +19,7 @@ def interpolate_point(p1, p2, t):
 class Equalizer2d(Twod, GradientEffect):
     NAME = "Equalizer2d"
     CATEGORY = "Matrix"
+    USES_MELBANK_RANGE = True
     HIDDEN_KEYS = Twod.HIDDEN_KEYS + []
     ADVANCED_KEYS = Twod.ADVANCED_KEYS + [
         "peak_percent",

--- a/ledfx/effects/melt_and_sparkle.py
+++ b/ledfx/effects/melt_and_sparkle.py
@@ -13,6 +13,7 @@ from ledfx.effects.math import triangle
 class MeltSparkle(AudioReactiveEffect, HSVEffect):
     NAME = "Melt and Sparkle"
     CATEGORY = "Atmospheric"
+    USES_MELBANK_RANGE = True
 
     CONFIG_SCHEMA = vol.Schema(
         {

--- a/ledfx/effects/pitchSpectrum.py
+++ b/ledfx/effects/pitchSpectrum.py
@@ -9,6 +9,7 @@ from ledfx.effects.gradient import GradientEffect
 class PitchSpectrumAudioEffect(AudioReactiveEffect, GradientEffect):
     NAME = "Pitch Spectrum"
     CATEGORY = "Classic"
+    USES_MELBANK_RANGE = True
 
     CONFIG_SCHEMA = vol.Schema(
         {

--- a/ledfx/effects/power.py
+++ b/ledfx/effects/power.py
@@ -9,6 +9,7 @@ from ledfx.effects.gradient import GradientEffect
 class PowerAudioEffect(AudioReactiveEffect, GradientEffect):
     NAME = "Power"
     CATEGORY = "Classic"
+    USES_MELBANK_RANGE = True
 
     CONFIG_SCHEMA = vol.Schema(
         {

--- a/ledfx/effects/rain.py
+++ b/ledfx/effects/rain.py
@@ -11,6 +11,7 @@ from ledfx.effects.droplets import DROPLET_NAMES, load_droplet
 class RainAudioEffect(AudioReactiveEffect):
     NAME = "Rain"
     CATEGORY = "Classic"
+    USES_MELBANK_RANGE = True
 
     CONFIG_SCHEMA = vol.Schema(
         {

--- a/ledfx/effects/scan_multi.py
+++ b/ledfx/effects/scan_multi.py
@@ -40,6 +40,7 @@ class Scan:
 class ScanMultiAudioEffect(AudioReactiveEffect, GradientEffect):
     NAME = "Scan Multi"
     CATEGORY = "Classic"
+    USES_MELBANK_RANGE = True
     HIDDEN_KEYS = ["gradient_roll"]
     ADVANCED_KEYS = AudioReactiveEffect.ADVANCED_KEYS + [
         "input_source",

--- a/ledfx/effects/scroll.py
+++ b/ledfx/effects/scroll.py
@@ -8,6 +8,7 @@ from ledfx.effects.audio import AudioReactiveEffect
 class ScrollAudioEffect(AudioReactiveEffect):
     NAME = "Scroll"
     CATEGORY = "Classic"
+    USES_MELBANK_RANGE = True
 
     CONFIG_SCHEMA = vol.Schema(
         {

--- a/ledfx/effects/scroll_plus.py
+++ b/ledfx/effects/scroll_plus.py
@@ -8,6 +8,7 @@ from ledfx.effects.audio import AudioReactiveEffect
 class ScrollAudioEffect(AudioReactiveEffect):
     NAME = "Scroll+"
     CATEGORY = "Classic"
+    USES_MELBANK_RANGE = True
 
     CONFIG_SCHEMA = vol.Schema(
         {

--- a/ledfx/effects/spectrum.py
+++ b/ledfx/effects/spectrum.py
@@ -7,6 +7,7 @@ from ledfx.effects.audio import AudioReactiveEffect
 class SpectrumAudioEffect(AudioReactiveEffect):
     NAME = "Spectrum"
     CATEGORY = "Classic"
+    USES_MELBANK_RANGE = True
 
     CONFIG_SCHEMA = vol.Schema(
         {

--- a/ledfx/effects/water.py
+++ b/ledfx/effects/water.py
@@ -23,6 +23,7 @@ class Water(AudioReactiveEffect, HSVEffect):
 
     NAME = "Water"
     CATEGORY = "Atmospheric"
+    USES_MELBANK_RANGE = True
 
     CONFIG_SCHEMA = vol.Schema(
         {

--- a/ledfx/effects/waterfall2d.py
+++ b/ledfx/effects/waterfall2d.py
@@ -19,6 +19,7 @@ class Waterfall(Twod, GradientEffect):
 
     NAME = "Waterfall"
     CATEGORY = "Matrix"
+    USES_MELBANK_RANGE = True
     HIDDEN_KEYS = Twod.HIDDEN_KEYS + [
         "background_mode",
     ]

--- a/ledfx/effects/wavelength.py
+++ b/ledfx/effects/wavelength.py
@@ -8,6 +8,7 @@ from ledfx.effects.gradient import GradientEffect
 class WavelengthAudioEffect(AudioReactiveEffect, GradientEffect):
     NAME = "Wavelength"
     CATEGORY = "Classic"
+    USES_MELBANK_RANGE = True
 
     # There is no additional configuration here, but override the blur
     # default to be 3.0 so blurring is enabled.


### PR DESCRIPTION
see

https://ledfx--1851.org.readthedocs.build/en/1851/apis/api.html#api-schema-schema-type
https://ledfx--1851.org.readthedocs.build/en/1851/developer/melbanks.html#how-effects-access-melbanks

## Summary

Adds an effect schema capability flag, `uses_melbank_range`, so frontends can determine whether the virtual `frequency_min` / `frequency_max` controls are meaningful for the selected effect.

This must be a static declaration as its too late in run time calls to melbank functions to automagical the flag passed to the UI in the schema.

## Changes

- Added `USES_MELBANK_RANGE = False` as the default on the base `Effect` class.
- Exposed `uses_melbank_range` in `/api/schema` effect entries.
- Marked effects that call `self.melbank()` or `self.melbank_thirds()` with `USES_MELBANK_RANGE = True`.
- Documented the frontend-facing schema field in `docs/apis/api.md`.
- Documented effect-author guidance in `docs/developer/melbanks.md`.

## Frontend Usage

Frontends can inspect the effect schema response:

```json
{
  "effects": {
    "bands": {
      "uses_melbank_range": true
    }
  }
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added effect capability information to the schema API, indicating whether virtual frequency-range controls apply.
  * Enabled virtual frequency-range controls for supported audio-reactive effects.
  * Frontends can now hide irrelevant frequency controls for effects that do not use them.

* **Documentation**
  * Documented the new capability and configuration requirements for melbank-based effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->