### PR TITLE
Fix: Support Nanoleaf devices that return length, not layout

### DIFF
--- a/ledfx/devices/nanoleaf.py
+++ b/ledfx/devices/nanoleaf.py
@@ -211,16 +211,30 @@ class NanoleafDevice(NetworkedDevice):
         ).json()
 
         _LOGGER.debug("nanoleaf config response: %s", nanoleaf_config)
-        _LOGGER.info("parsing panel layout...")
 
-        panels = [
-            {"x": i["x"], "y": i["y"], "panelId": i["panelId"]}
-            for i in sorted(
-                nanoleaf_config["panelLayout"]["layout"]["positionData"],
-                key=lambda panel: (panel["x"], panel["y"]),
+        if "panelLayout" in nanoleaf_config:
+            _LOGGER.info("parsing panel layout...")
+            panels = [
+                {"x": i["x"], "y": i["y"], "panelId": i["panelId"]}
+                for i in sorted(
+                    nanoleaf_config["panelLayout"]["layout"]["positionData"],
+                    key=lambda panel: (panel["x"], panel["y"]),
+                )
+                if i["panelId"] != 0
+            ]
+        else:
+            # Nanoleaf Matter WiFi Essentials devices (Holiday String Lights,
+            # Essentials Lightstrips, Rope Lights, Floor Lamp, WiFi A19, etc.)
+            # do not expose panelLayout. Fall back to the /length endpoint
+            # to determine pixel count, and address LEDs by simple index.
+            _LOGGER.info(
+                "no panelLayout found, falling back to /length endpoint..."
             )
-            if i["panelId"] != 0
-        ]
+            length_response = requests.get(
+                self.url(self.config["auth_token"]) + "/length"
+            ).json()
+            num_leds = length_response["numLEDs"]
+            panels = [{"x": i, "y": 0, "panelId": i} for i in range(num_leds)]
 
         config = {
             "name": self.config["name"],

--- a/ledfx/devices/nanoleaf.py
+++ b/ledfx/devices/nanoleaf.py
@@ -230,9 +230,15 @@ class NanoleafDevice(NetworkedDevice):
             _LOGGER.info(
                 "no panelLayout found, falling back to /length endpoint..."
             )
-            length_response = requests.get(
-                self.url(self.config["auth_token"]) + "/length"
-            ).json()
+            try:
+                length_response = requests.get(
+                    self.url(self.config["auth_token"]) + "/length",
+                    timeout=2.0,
+                ).json()
+            except (ConnectTimeout, ReadTimeout) as e:
+                raise ValueError(
+                    f"{self.name} could not fetch Nanoleaf LED length: {e}"
+                ) from e
             num_leds = length_response["numLEDs"]
             panels = [{"x": i, "y": 0, "panelId": i} for i in range(num_leds)]
 


### PR DESCRIPTION
Fixes #1850

Falls back to the `/length` endpoint when `panelLayout` is absent from
the device info response, which is the case for Nanoleaf Matter WiFi
Essentials devices (Holiday String Lights, Essentials Lightstrips,
Rope Lights, Floor Lamp, WiFi A19, etc). LEDs are then addressed by
simple index (0..N-1), per Nanoleaf's own Essentials OpenAPI docs.

Existing Shapes/Light Panels/Canvas behavior (panelLayout-based) is
unchanged.

Tested against a Holiday String Lights unit (NL71K2, firmware 4.0.12).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nanoleaf device initialization now times out after two seconds when retrieving panel information.
  * Connection and read timeouts now produce a clear error identifying the affected device.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->